### PR TITLE
Testing GHA with commit SHA

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,15 +2,21 @@ name: Release Helm Charts
 
 on:
   workflow_dispatch:
+    inputs:
+      commit_sha:
+        required: true
+        type: string
+        default: ""
+        description: "Release commit SHA"
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          ref: "${{ github.event.inputs.commit_sha }}"
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
*Description of changes:*
1. Adding commit SHA as an input for the helm chart release GHA
Test run - https://github.com/aws-observability/helm-charts/actions/runs/8270051584/job/22626717309


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

