### PR TITLE
Update Operator (1.0.4->1.1.0) and AutoInstrumentationJava (1.31.1->1.32.1) for amazon-cloudwatch-observability v1.4.0

### DIFF
--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -40,7 +40,7 @@ manager:
   name:
   image:
     repository: cloudwatch-agent-operator
-    tag: 1.0.4
+    tag: 1.1.0
     repositoryDomainMap:
       public: public.ecr.aws/cloudwatch-agent
       cn-north-1: 934860584483.dkr.ecr.cn-north-1.amazonaws.com.cn
@@ -51,7 +51,7 @@ manager:
     java:
       repositoryDomain: public.ecr.aws/aws-observability
       repository: adot-autoinstrumentation-java
-      tag: v1.31.1
+      tag: v1.32.1
     python:
       repositoryDomain: public.ecr.aws/aws-observability
       repository: adot-autoinstrumentation-python


### PR DESCRIPTION
*Description of changes:* Update Operator (1.0.4->1.1.0) and AutoInstrumentationJava (1.31.1->1.32.1) for amazon-cloudwatch-observability v1.4.0


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

