### PR TITLE
Fixing helm template function call for instrumentation images in oper…

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -27,8 +27,8 @@ spec:
       - image: {{ template "cloudwatch-agent-operator.image" . }}
         args:
         - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}
-        - "--auto-instrumentation-java-image={{ template "auto-instrumentation-java.image" }}"
-        - "--auto-instrumentation-python-image={{ template "auto-instrumentation-python.image" }}"
+        - "--auto-instrumentation-java-image={{ template "auto-instrumentation-java.image" . }}"
+        - "--auto-instrumentation-python-image={{ template "auto-instrumentation-python.image" . }}"
         - "--feature-gates=operator.autoinstrumentation.multi-instrumentation,operator.autoinstrumentation.multi-instrumentation.skip-container-validation"
         command:
         - /manager


### PR DESCRIPTION
…ator deployment

*Description of changes:*
1. Operator was unable to parse the ADOT instrumentation images for both python and java because of incorrect call to helm function

*Testing*
Ran Helm templating command to check the output
```
helm template amazon-cloudwatch-observability ./charts/amazon-cloudwatch-observability/ --include-crds --namespace amazon-cloudwatch --set region=us-east-1 > output.yaml
```

Attaching snippet
```
      - image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent-operator:1.1.0
        args:
        - "--auto-annotation-config={\"java\":{\"daemonsets\":[],\"deployments\":[],\"namespaces\":[],\"statefulsets\":[]},\"python\":{\"daemonsets\":[],\"deployments\":[],\"namespaces\":[],\"statefulsets\":[]}}"
        - "--auto-instrumentation-java-image=public.ecr.aws/aws-observability/adot-autoinstrumentation-java:v1.32.1"
        - "--auto-instrumentation-python-image=public.ecr.aws/aws-observability/adot-autoinstrumentation-python:v0.0.1"
        - "--feature-gates=operator.autoinstrumentation.multi-instrumentation,operator.autoinstrumentation.multi-instrumentation.skip-container-validation"
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

