### PR TITLE
Running helm integration tests on PR build

### DIFF
--- a/.github/workflows/amazon-cloudwatch-observability-helm-integration-test.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-helm-integration-test.yaml
@@ -5,9 +5,12 @@ name: Run Integration Test for Amazon CloudWatch Observability Helm Chart
 on:
   push:
     branches:
-      - helm-tests*
+      - main
+  pull_request:
+    types: [ opened, reopened, synchronize, ready_for_review ]
+    branches:
+      - main
   workflow_dispatch:
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true

--- a/integration-tests/amazon-cloudwatch-observability/terraform/helm/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/helm/main.tf
@@ -120,6 +120,10 @@ resource "helm_release" "this" {
     name  = "region"
     value = "${var.region}"
   }
+  set {
+    name  = "clusterName"
+    value = "${aws_eks_cluster.this.name}"
+  }
 }
 
 resource "null_resource" "validator" {

--- a/integration-tests/amazon-cloudwatch-observability/validator/validateResources_test.go
+++ b/integration-tests/amazon-cloudwatch-observability/validator/validateResources_test.go
@@ -63,7 +63,7 @@ func TestOperatorOnEKs(t *testing.T) {
 	//Validating the number of pods and status
 	pods, err := ListPods(nameSpace, clientSet)
 	assert.NoError(t, err)
-	assert.Len(t, pods.Items, 5)
+	assert.Len(t, pods.Items, 3)
 	for _, pod := range pods.Items {
 		fmt.Println("pod name: " + pod.Name + " namespace:" + pod.Namespace)
 		assert.Contains(t, []v1.PodPhase{v1.PodRunning, v1.PodPending}, pod.Status.Phase)
@@ -127,7 +127,7 @@ func TestOperatorOnEKs(t *testing.T) {
 		// - fluent-bit-windows
 		// - dcgm-exporter (this can be removed in the future)
 		// - neuron-monitor
-		if match, _ := regexp.MatchString(agentName+"|fluent-bit|dcgm-exporter", daemonSet.Name); !match {
+		if match, _ := regexp.MatchString(agentName+"|fluent-bit|dcgm-exporter|neuron-monitor", daemonSet.Name); !match {
 			assert.Fail(t, "DaemonSet is not created correctly")
 		}
 	}

--- a/integration-tests/amazon-cloudwatch-observability/validator/validateResources_test.go
+++ b/integration-tests/amazon-cloudwatch-observability/validator/validateResources_test.go
@@ -23,14 +23,17 @@ import (
 )
 
 const (
-	nameSpace        = "amazon-cloudwatch"
-	addOnName        = "amazon-cloudwatch-observability"
-	agentName        = "cloudwatch-agent"
-	operatorName     = addOnName + "-controller-manager"
-	fluentBitName    = "fluent-bit"
-	dcgmExporterName = "dcgm-exporter"
-	podNameRegex     = "(" + agentName + "|" + operatorName + "|" + fluentBitName + ")-*"
-	serviceNameRegex = agentName + "(-headless|-monitoring)?|" + addOnName + "-webhook-service|" + dcgmExporterName + "-service"
+	nameSpace            = "amazon-cloudwatch"
+	addOnName            = "amazon-cloudwatch-observability"
+	agentName            = "cloudwatch-agent"
+	agentNameWindows     = "cloudwatch-agent-windows"
+	operatorName         = addOnName + "-controller-manager"
+	fluentBitName        = "fluent-bit"
+	fluentBitNameWindows = "fluent-bit-windows"
+	dcgmExporterName     = "dcgm-exporter"
+	neuronMonitor        = "neuron-monitor"
+	podNameRegex         = "(" + agentName + "|" + agentNameWindows + "|" + operatorName + "|" + fluentBitName + "|" + fluentBitNameWindows + ")-*"
+	serviceNameRegex     = agentName + "(-headless|-monitoring)?|" + agentNameWindows + "(-headless|-monitoring)?|" + addOnName + "-webhook-service|" + dcgmExporterName + "-service|" + neuronMonitor + "-service"
 )
 
 func TestOperatorOnEKs(t *testing.T) {
@@ -60,14 +63,16 @@ func TestOperatorOnEKs(t *testing.T) {
 	//Validating the number of pods and status
 	pods, err := ListPods(nameSpace, clientSet)
 	assert.NoError(t, err)
-	assert.Len(t, pods.Items, 3)
+	assert.Len(t, pods.Items, 5)
 	for _, pod := range pods.Items {
 		fmt.Println("pod name: " + pod.Name + " namespace:" + pod.Namespace)
 		assert.Contains(t, []v1.PodPhase{v1.PodRunning, v1.PodPending}, pod.Status.Phase)
 		// matches
 		// - cloudwatch-agent-*
+		// - cloudwatch-agent-windows-*
 		// - amazon-cloudwatch-observability-controller-manager-*
 		// - fluent-bit-*
+		// - fluent-bit-windows-*
 		if match, _ := regexp.MatchString(podNameRegex, pod.Name); !match {
 			assert.Fail(t, "Cluster Pods are not created correctly")
 		}
@@ -76,7 +81,7 @@ func TestOperatorOnEKs(t *testing.T) {
 	//Validating the services
 	services, err := ListServices(nameSpace, clientSet)
 	assert.NoError(t, err)
-	assert.Len(t, services.Items, 5)
+	assert.Len(t, services.Items, 9)
 	for _, service := range services.Items {
 		fmt.Println("service name: " + service.Name + " namespace:" + service.Namespace)
 		// matches
@@ -84,7 +89,11 @@ func TestOperatorOnEKs(t *testing.T) {
 		// - cloudwatch-agent
 		// - cloudwatch-agent-headless
 		// - cloudwatch-agent-monitoring
+		// - cloudwatch-agent-windows
+		// - cloudwatch-agent-windows-headless
+		// - cloudwatch-agent-windows-monitoring
 		// - dcgm-exporter-service
+		// - neuron-monitor-service
 		if match, _ := regexp.MatchString(serviceNameRegex, service.Name); !match {
 			assert.Fail(t, "Cluster Service is not created correctly")
 		}
@@ -108,13 +117,16 @@ func TestOperatorOnEKs(t *testing.T) {
 	//Validating the Daemon Sets
 	daemonSets, err := ListDaemonSets(nameSpace, clientSet)
 	assert.NoError(t, err)
-	assert.Len(t, daemonSets.Items, 3)
+	assert.Len(t, daemonSets.Items, 6)
 	for _, daemonSet := range daemonSets.Items {
 		fmt.Println("daemonSet name: " + daemonSet.Name + " namespace:" + daemonSet.Namespace)
 		// matches
 		// - cloudwatch-agent
+		// - cloudwatch-agent-windows
 		// - fluent-bit
+		// - fluent-bit-windows
 		// - dcgm-exporter (this can be removed in the future)
+		// - neuron-monitor
 		if match, _ := regexp.MatchString(agentName+"|fluent-bit|dcgm-exporter", daemonSet.Name); !match {
 			assert.Fail(t, "DaemonSet is not created correctly")
 		}
@@ -130,9 +142,11 @@ func TestOperatorOnEKs(t *testing.T) {
 	// - amazon-cloudwatch-observability-controller-manager
 	// - cloudwatch-agent
 	// - dcgm-exporter-service-acct
+	// - neuron-monitor-service-acct
 	assert.True(t, validateServiceAccount(serviceAccounts, addOnName+"-controller-manager"))
 	assert.True(t, validateServiceAccount(serviceAccounts, agentName))
 	assert.True(t, validateServiceAccount(serviceAccounts, dcgmExporterName+"-service-acct"))
+	assert.True(t, validateServiceAccount(serviceAccounts, neuronMonitor+"-service-acct"))
 
 	//Validating ClusterRoles
 	clusterRoles, err := ListClusterRoles(clientSet)
@@ -148,7 +162,9 @@ func TestOperatorOnEKs(t *testing.T) {
 	assert.NoError(t, err)
 	// searches
 	// - dcgm-exporter-role
+	// - neuron-monitor-role
 	assert.True(t, validateRoles(roles, dcgmExporterName+"-role"))
+	assert.True(t, validateRoles(roles, neuronMonitor+"-role"))
 
 	//Validating ClusterRoleBinding
 	clusterRoleBindings, err := ListClusterRoleBindings(clientSet)
@@ -164,7 +180,9 @@ func TestOperatorOnEKs(t *testing.T) {
 	assert.NoError(t, err)
 	// searches
 	// - dcgm-exporter-role-binding
+	// - neuron-monitor-role-binding
 	assert.True(t, validateRoleBindings(roleBindings, dcgmExporterName+"-role-binding"))
+	assert.True(t, validateRoleBindings(roleBindings, neuronMonitor+"-role-binding"))
 
 	//Validating MutatingWebhookConfiguration
 	mutatingWebhookConfigurations, err := ListMutatingWebhookConfigurations(clientSet)


### PR DESCRIPTION
*Description of changes:*
1. Modifying the current helm chart integration test for amazon-cloudwatch-observability to run on PR build


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

