### PR TITLE
Do not create fluent bit resources if containerLogs is disabled

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-configmap.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.containerLogs.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -18,7 +19,6 @@ data:
         storage.checksum          off
         storage.backlog.mem_limit 5M
 
-{{- if .Values.containerLogs.enabled }}
     @INCLUDE application-log.conf
     @INCLUDE dataplane-log.conf
     @INCLUDE host-log.conf

--- a/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.containerLogs.enabled }}
 {{- $clusterName := .Values.clusterName | required ".Values.clusterName is required." -}}
 {{- $region := .Values.region | required ".Values.region is required." -}}
 apiVersion: apps/v1
@@ -48,13 +49,8 @@ spec:
           value: "k8s/1.3.17"
         resources:
           limits:
-          {{- if .Values.containerLogs.enabled }}
             cpu: 500m
             memory: 250Mi
-          {{ else }}
-            cpu: 50m
-            memory: 25Mi
-          {{ end }}
           requests:
             cpu: 50m
             memory: 25Mi
@@ -101,3 +97,4 @@ spec:
       serviceAccountName: {{ template "cloudwatch-agent.serviceAccountName" . }}
       nodeSelector:
         kubernetes.io/os: linux
+{{- end }}

--- a/charts/amazon-cloudwatch-observability/templates/windows/fluent-bit-windows-configmap.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/windows/fluent-bit-windows-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.containerLogs.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -14,7 +15,6 @@ data:
         net.dns.resolver            LEGACY
         Parsers_File                parsers.conf
 
-{{- if .Values.containerLogs.enabled }}
     @INCLUDE application-log.conf
     @INCLUDE dataplane-log.conf
     @INCLUDE host-log.conf

--- a/charts/amazon-cloudwatch-observability/templates/windows/fluent-bit-windows-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/windows/fluent-bit-windows-daemonset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.containerLogs.enabled }}
 {{- $clusterName := .Values.clusterName | required ".Values.clusterName is required." -}}
 {{- $region := .Values.region | required ".Values.region is required." -}}
 apiVersion: apps/v1
@@ -54,13 +55,8 @@ spec:
           value: "k8s/1.3.17"
         resources:
           limits:
-          {{- if .Values.containerLogs.enabled }}
             cpu: 500m
             memory: 600Mi
-          {{ else }}
-            cpu: 300m
-            memory: 300Mi
-          {{ end }}
           requests:
             cpu: 300m
             memory: 300Mi
@@ -74,3 +70,4 @@ spec:
       terminationGracePeriodSeconds: 10
       dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: {{ template "cloudwatch-agent.serviceAccountName" . }}
+{{- end }}


### PR DESCRIPTION
*Description of changes:* When `containerLogs` is disabled, the current behavior is to still create the fluent bit resources, but set it up in a way to not actually do any work and use minimal compute resources.
Instead, we are now updating the behavior to not create the fluent bit resources altogether if `containerLogs` is disabled.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

