### PR TITLE
Fix CI on Windows with containerd 1.7

### DIFF
--- a/charts/amazon-cloudwatch-observability/README.md
+++ b/charts/amazon-cloudwatch-observability/README.md
@@ -4,6 +4,9 @@
 ## Introduction
 This AWS Observability Helm Chart provides easy mechanisms to setup the [Amazon CloudWatch Agent Operator](https://github.com/aws/amazon-cloudwatch-agent-operator) to manage the [CloudWatch Agent](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Install-CloudWatch-Agent.html) on Kubernetes clusters.
 
+## Windows Support
+CloudWatch DaemonSet on Windows is officially supported only for containerd runtime.
+
 ## Security
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.

--- a/charts/amazon-cloudwatch-observability/crds/cloudwatch.aws.amazon.com_amazoncloudwatchagents.yaml
+++ b/charts/amazon-cloudwatch-observability/crds/cloudwatch.aws.amazon.com_amazoncloudwatchagents.yaml
@@ -7460,6 +7460,11 @@ spec:
                     type: object
                   type: array
                   x-kubernetes-list-type: atomic
+                workingDir:
+                  description: WorkingDir represents Container's working directory.
+                    If not specified, the container runtime's default will be used,
+                    which might be configured in the container image. Cannot be updated.
+                  type: string
               type: object
             status:
               description: AmazonCloudWatchAgentStatus defines the observed state of

--- a/charts/amazon-cloudwatch-observability/templates/windows/cloudwatch-agent-windows-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/windows/cloudwatch-agent-windows-daemonset.yaml
@@ -13,6 +13,7 @@ spec:
       runAsUserName: "NT AUTHORITY\\System"
   hostNetwork: true
   image: {{ template "cloudwatch-agent.image" . }}
+  workingDir: "%CONTAINER_SANDBOX_MOUNT_POINT%\\Program Files\\Amazon\\AmazonCloudWatchAgent"
   mode: daemonset
   serviceAccount: {{ template "cloudwatch-agent.serviceAccountName" . }}
   nodeSelector:


### PR DESCRIPTION
*Issue #, if available:*
Behaviour of WorkDir changed with containerd 1.7. This caused Windows CI DS to fail. This fix is backward compatible with both containerd 1.6 and 1.7. EKS Windows only supports containerd runtime.

*Description of changes:*
Add workingDir field in podSpec of container in CloudWatch Agent Windows DaemonSet

*Testing*
https://github.com/aws-observability/helm-charts/actions/runs/8816835391

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

