### PR TITLE
[WIP] Fixing checkout action of GHA

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           ref: "${{ github.event.inputs.commit_sha }}"
 
       - name: Configure Git


### PR DESCRIPTION
See https://github.com/helm/chart-releaser-action/issues/13 and https://github.com/helm/chart-releaser-action/issues/36

*Description of changes:*
Helm chart releaser action was unable to release the helm chart because it could not detect any changes in git history, this is because [git rev-list --max-parents=0 --first-parent HEAD](https://github.com/helm/chart-releaser-action/blob/master/cr.sh#L176) is expecting the full git history for the branch. So anyone using the checkout action will have this issue.
Also the releaser action has example here https://github.com/helm/charts-repo-actions-demo/blob/main/.github/workflows/release.yaml

1. Added full-depth: 0 to pull in entire git history
```
(24-04-26 21:03:52) <0> [~]  
dev-dsk-mitsalvi-2b-dd18fa62 % helm search repo aws-observability
NAME                                             	CHART VERSION	APP VERSION	DESCRIPTION                                     
aws-observability/amazon-cloudwatch-observability	1.5.4        	1.0.0      	A Helm chart for Amazon CloudWatch Observability
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

