### PR TITLE
Migrate Windows helm-chart tests.

### DIFF
--- a/.github/workflows/amazon-cloudwatch-observability-helm-integration-test.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-helm-integration-test.yaml
@@ -79,3 +79,115 @@ jobs:
           command: |
             cd integration-tests/amazon-cloudwatch-observability/terraform/helm
             terraform destroy --auto-approve
+
+  HelmChartsIntegrationTestWindows-2022:
+    name: HelmChartsIntegrationTestWindows-2022
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Generate testing id
+        run: echo TESTING_ID="${{ github.run_id }}-${{ github.run_number }}" >> $GITHUB_ENV
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+
+      #  local directory to store the kubernetes config
+      - name: Create kubeconfig directory
+        run: mkdir -p ${{ github.workspace }}/../../../.kube
+
+      - name: Set KUBECONFIG environment variable
+        run: echo KUBECONFIG="${{ github.workspace }}/../../../.kube/config" >> $GITHUB_ENV
+
+      - name: Verify Terraform version
+        run: terraform --version
+
+      - name: Terraform apply
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 1
+          timeout_minutes: 60 # EKS takes about 20 minutes to spin up a cluster and service on the cluster
+          retry_wait_seconds: 5
+          command: |
+            cd integration-tests/amazon-cloudwatch-observability/terraform/helm-windows
+            terraform init
+            if terraform apply -auto-approve \
+                -var="windows_os_version=WINDOWS_CORE_2022_x86_64" -var="kube_dir=${{ github.workspace }}/../../../.kube"; then
+              terraform destroy -auto-approve
+            else
+              terraform destroy -auto-approve && exit 1
+            fi
+
+      - name: Terraform destroy
+        if: ${{ cancelled() || failure() }}
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 8
+          retry_wait_seconds: 5
+          command: |
+            cd integration-tests/amazon-cloudwatch-observability/terraform/helm-windows
+            terraform destroy --auto-approve
+
+  HelmChartsIntegrationTestWindows-2019:
+    name: HelmChartsIntegrationTestWindows-2019
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Generate testing id
+        run: echo TESTING_ID="${{ github.run_id }}-${{ github.run_number }}" >> $GITHUB_ENV
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+
+      #  local directory to store the kubernetes config
+      - name: Create kubeconfig directory
+        run: mkdir -p ${{ github.workspace }}/../../../.kube
+
+      - name: Set KUBECONFIG environment variable
+        run: echo KUBECONFIG="${{ github.workspace }}/../../../.kube/config" >> $GITHUB_ENV
+
+      - name: Verify Terraform version
+        run: terraform --version
+
+      - name: Terraform apply
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 1
+          timeout_minutes: 60 # EKS takes about 20 minutes to spin up a cluster and service on the cluster
+          retry_wait_seconds: 5
+          command: |
+            cd integration-tests/amazon-cloudwatch-observability/terraform/helm-windows
+            terraform init
+            if terraform apply -auto-approve \
+                -var="windows_os_version=WINDOWS_CORE_2019_x86_64" -var="kube_dir=${{ github.workspace }}/../../../.kube"; then
+              terraform destroy -auto-approve
+            else
+              terraform destroy -auto-approve && exit 1
+            fi
+
+      - name: Terraform destroy
+        if: ${{ cancelled() || failure() }}
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 8
+          retry_wait_seconds: 5
+          command: |
+            cd integration-tests/amazon-cloudwatch-observability/terraform/helm-windows
+            terraform destroy --auto-approve

--- a/integration-tests/amazon-cloudwatch-observability/terraform/helm-windows/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/helm-windows/main.tf
@@ -1,0 +1,235 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+module "common" {
+  source = "../common"
+}
+
+module "basic_components" {
+  source = "../basic_components"
+}
+
+locals {
+  aws_eks  = "aws eks --region ${var.region}"
+  cluster_name = var.cluster_name != "" ? var.cluster_name : "cwagent-operator-helm-integ"
+}
+
+data "aws_eks_cluster_auth" "this" {
+  name = aws_eks_cluster.this.name
+}
+
+data "aws_caller_identity" "account_id" {}
+
+data "aws_eks_cluster" "eks_windows_cluster_ca" {
+  name = aws_eks_cluster.this.name
+}
+
+output "account_id" {
+  value = data.aws_caller_identity.account_id.account_id
+}
+
+resource "aws_eks_cluster" "this" {
+  name     = "${local.cluster_name}-${module.common.testing_id}"
+  role_arn = module.basic_components.role_arn
+  version  = var.k8s_version
+  vpc_config {
+    subnet_ids         = module.basic_components.public_subnet_ids
+    security_group_ids = [module.basic_components.security_group]
+  }
+}
+
+## EKS Cluster Addon
+
+resource "aws_eks_addon" "eks_windows_addon" {
+  cluster_name = aws_eks_cluster.this.name
+  addon_name   = "vpc-cni"
+}
+
+## Enable VPC CNI Windows Support
+
+resource "kubernetes_config_map_v1_data" "amazon_vpc_cni_windows" {
+  depends_on = [
+    aws_eks_cluster.this,
+    aws_eks_addon.eks_windows_addon
+  ]
+  metadata {
+    name      = "amazon-vpc-cni"
+    namespace = "kube-system"
+  }
+
+  force = true
+
+  data = {
+    enable-windows-ipam : "true"
+  }
+}
+
+## AWS CONFIGMAP
+
+resource "kubernetes_config_map" "configmap" {
+  data = {
+    "mapRoles" = <<EOT
+- groups:
+  - system:bootstrappers
+  - system:nodes
+  rolearn: arn:aws:iam::${data.aws_caller_identity.account_id.account_id}:role/${local.cluster_name}-Worker-Role-${module.common.testing_id}
+  username: system:node:{{EC2PrivateDNSName}}
+- groups:
+  - eks:kube-proxy-windows
+  - system:bootstrappers
+  - system:nodes
+  rolearn: arn:aws:iam::${data.aws_caller_identity.account_id.account_id}:role/${local.cluster_name}-Worker-Role-${module.common.testing_id}
+  username: system:node:{{EC2PrivateDNSName}}
+EOT
+  }
+
+  metadata {
+    name      = "aws-auth"
+    namespace = "kube-system"
+  }
+}
+
+# EKS Node Groups
+resource "aws_eks_node_group" "this" {
+  cluster_name    = aws_eks_cluster.this.name
+  node_group_name = "${local.cluster_name}-node"
+  node_role_arn   = aws_iam_role.node_role.arn
+  subnet_ids      = module.basic_components.public_subnet_ids
+
+  scaling_config {
+    desired_size = 1
+    max_size     = 1
+    min_size     = 1
+  }
+
+  ami_type       = "AL2_x86_64"
+  capacity_type  = "ON_DEMAND"
+  disk_size      = 20
+  instance_types = ["t3a.medium"]
+
+  depends_on = [
+    aws_iam_role_policy_attachment.node_CloudWatchAgentServerPolicy,
+    aws_iam_role_policy_attachment.node_AmazonEC2ContainerRegistryReadOnly,
+    aws_iam_role_policy_attachment.node_AmazonEKS_CNI_Policy,
+    aws_iam_role_policy_attachment.node_AmazonEKSWorkerNodePolicy
+  ]
+}
+
+# EKS Windows Node Groups
+resource "aws_eks_node_group" "node_group_windows" {
+  cluster_name    = aws_eks_cluster.this.name
+  node_group_name = "${local.cluster_name}-windows-node"
+  node_role_arn   = aws_iam_role.node_role.arn
+  subnet_ids      = module.basic_components.public_subnet_ids
+
+  scaling_config {
+    desired_size = 1
+    max_size     = 1
+    min_size     = 1
+  }
+
+  ami_type       = var.windows_os_version
+  capacity_type  = "ON_DEMAND"
+  disk_size      = 50
+  instance_types = ["t3.large"]
+
+  depends_on = [
+    aws_iam_role_policy_attachment.node_CloudWatchAgentServerPolicy,
+    aws_iam_role_policy_attachment.node_AmazonEC2ContainerRegistryReadOnly,
+    aws_iam_role_policy_attachment.node_AmazonEKS_CNI_Policy,
+    aws_iam_role_policy_attachment.node_AmazonEKSWorkerNodePolicy
+  ]
+}
+
+# EKS Node IAM Role
+resource "aws_iam_role" "node_role" {
+  name = "${local.cluster_name}-Worker-Role-${module.common.testing_id}"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "node_AmazonEKSWorkerNodePolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.node_role.name
+}
+
+resource "aws_iam_role_policy_attachment" "node_AmazonEKS_CNI_Policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.node_role.name
+}
+
+resource "aws_iam_role_policy_attachment" "node_AmazonEC2ContainerRegistryReadOnly" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.node_role.name
+}
+
+resource "aws_iam_role_policy_attachment" "node_CloudWatchAgentServerPolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+  role       = aws_iam_role.node_role.name
+}
+
+resource "null_resource" "kubectl" {
+  depends_on = [
+    aws_eks_cluster.this,
+    aws_eks_node_group.this,
+    aws_eks_node_group.node_group_windows
+  ]
+  provisioner "local-exec" {
+    command = <<-EOT
+      ${local.aws_eks} update-kubeconfig --name ${aws_eks_cluster.this.name}
+      ${local.aws_eks} list-clusters --output text
+      ${local.aws_eks} describe-cluster --name ${aws_eks_cluster.this.name} --output text
+    EOT
+  }
+}
+
+resource "helm_release" "this" {
+  depends_on = [
+    null_resource.kubectl
+  ]
+  name = "amazon-cloudwatch-observability"
+  namespace = "amazon-cloudwatch"
+  create_namespace = true
+  chart      = "${var.helm_dir}"
+  set {
+    name  = "region"
+    value = "${var.region}"
+  }
+}
+
+resource "null_resource" "deployment_wait" {
+  depends_on = [
+    helm_release.this,
+  ]
+  provisioner "local-exec" {
+    command = <<-EOT
+      curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+      chmod +x kubectl
+      ./kubectl rollout status daemonset fluent-bit-windows -n amazon-cloudwatch --timeout 600s
+      ./kubectl rollout status daemonset cloudwatch-agent-windows -n amazon-cloudwatch --timeout 600s
+    EOT
+  }
+}
+
+resource "null_resource" "validator" {
+  depends_on = [
+    helm_release.this,
+    null_resource.deployment_wait
+  ]
+  provisioner "local-exec" {
+    command = "go test ${var.test_dir} -v --tags=windowslinux"
+  }
+}

--- a/integration-tests/amazon-cloudwatch-observability/terraform/helm-windows/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/helm-windows/main.tf
@@ -234,6 +234,6 @@ resource "null_resource" "validator" {
     null_resource.deployment_wait
   ]
   provisioner "local-exec" {
-    command = "go test ${var.test_dir} -v --tags=windowslinux"
+    command = "go test ${var.test_dir} -v"
   }
 }

--- a/integration-tests/amazon-cloudwatch-observability/terraform/helm-windows/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/helm-windows/main.tf
@@ -234,6 +234,6 @@ resource "null_resource" "validator" {
     null_resource.deployment_wait
   ]
   provisioner "local-exec" {
-    command = "go test ${var.test_dir} -v"
+    command = "go test ${var.test_dir} -v --tags=windowslinux"
   }
 }

--- a/integration-tests/amazon-cloudwatch-observability/terraform/helm-windows/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/helm-windows/main.tf
@@ -222,8 +222,8 @@ resource "null_resource" "deployment_wait" {
     command = <<-EOT
       curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
       chmod +x kubectl
-      ./kubectl rollout status daemonset fluent-bit-windows -n amazon-cloudwatch --timeout 600s
-      ./kubectl rollout status daemonset cloudwatch-agent-windows -n amazon-cloudwatch --timeout 600s
+      ./kubectl rollout status daemonset fluent-bit-windows -n amazon-cloudwatch --timeout 1200s
+      ./kubectl rollout status daemonset cloudwatch-agent-windows -n amazon-cloudwatch --timeout 1200s
     EOT
   }
 }

--- a/integration-tests/amazon-cloudwatch-observability/terraform/helm-windows/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/helm-windows/main.tf
@@ -11,7 +11,7 @@ module "basic_components" {
 
 locals {
   aws_eks  = "aws eks --region ${var.region}"
-  cluster_name = var.cluster_name != "" ? var.cluster_name : "cwagent-operator-helm-integ"
+  cluster_name = var.cluster_name != "" ? var.cluster_name : "cwagent-helm-chart-integ"
 }
 
 data "aws_eks_cluster_auth" "this" {

--- a/integration-tests/amazon-cloudwatch-observability/terraform/helm-windows/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/helm-windows/main.tf
@@ -208,6 +208,10 @@ resource "helm_release" "this" {
     name  = "region"
     value = "${var.region}"
   }
+  set {
+    name  = "clusterName"
+    value = "${aws_eks_cluster.this.name}"
+  }
 }
 
 resource "null_resource" "deployment_wait" {

--- a/integration-tests/amazon-cloudwatch-observability/terraform/helm-windows/providers.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/helm-windows/providers.tf
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+provider "aws" {
+  region = var.region
+}
+
+provider "helm" {
+  kubernetes {
+    config_path = "${var.kube_dir}/config"
+  }
+}
+
+provider "kubernetes" {
+  host                   = aws_eks_cluster.this.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.eks_windows_cluster_ca.certificate_authority[0].data)
+  token                  = data.aws_eks_cluster_auth.this.token
+}

--- a/integration-tests/amazon-cloudwatch-observability/terraform/helm-windows/variables.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/helm-windows/variables.tf
@@ -1,0 +1,38 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+variable "region" {
+  type    = string
+  default = "us-west-2"
+}
+
+variable "k8s_version" {
+  type    = string
+  default = "1.25"
+}
+
+# eks addon and helm tests are similar
+variable "test_dir" {
+  type    = string
+  default = "../../eks"
+}
+
+variable "helm_dir" {
+  type    = string
+  default = "../../../helm"
+}
+
+variable "kube_dir" {
+  type    = string
+  default = "~/.kube"
+}
+
+variable "cluster_name" {
+  type    = string
+  default = "cwagent-operator-helm-integ"
+}
+
+variable "windows_os_version" {
+  type    = string
+  default = "WINDOWS_CORE_2022_x86_64"
+}

--- a/integration-tests/amazon-cloudwatch-observability/terraform/helm-windows/variables.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/helm-windows/variables.tf
@@ -8,18 +8,18 @@ variable "region" {
 
 variable "k8s_version" {
   type    = string
-  default = "1.25"
+  default = "1.29"
 }
 
 # eks addon and helm tests are similar
 variable "test_dir" {
   type    = string
-  default = "../../eks"
+  default = "../../validator"
 }
 
 variable "helm_dir" {
   type    = string
-  default = "../../../helm"
+  default = "../../../../charts/amazon-cloudwatch-observability"
 }
 
 variable "kube_dir" {
@@ -29,7 +29,7 @@ variable "kube_dir" {
 
 variable "cluster_name" {
   type    = string
-  default = "cwagent-operator-helm-integ"
+  default = "cwagent-helm-chart-integ"
 }
 
 variable "windows_os_version" {

--- a/integration-tests/amazon-cloudwatch-observability/terraform/helm/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/helm/main.tf
@@ -131,6 +131,6 @@ resource "null_resource" "validator" {
     helm_release.this
   ]
   provisioner "local-exec" {
-    command = "go test ${var.test_dir} -v"
+    command = "go test ${var.test_dir} -v --tags=linuxonly"
   }
 }

--- a/integration-tests/amazon-cloudwatch-observability/validator/resourceCount_linuxonly_test.go
+++ b/integration-tests/amazon-cloudwatch-observability/validator/resourceCount_linuxonly_test.go
@@ -7,14 +7,6 @@
 package validator
 
 const (
-	// Services count for CW agent on Linux and Windows
-	serviceCountLinux   = 6
-	serviceCountWindows = 3
-
-	// DaemonSet count for CW agent on Linux and Windows
-	daemonsetCountLinux   = 4
-	daemonsetCountWindows = 2
-
 	// Pods count for CW agent on Linux and Windows
 	podCountLinux   = 3
 	podCountWindows = 0

--- a/integration-tests/amazon-cloudwatch-observability/validator/resourceCount_linuxonly_test.go
+++ b/integration-tests/amazon-cloudwatch-observability/validator/resourceCount_linuxonly_test.go
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linuxonly
+// +build linuxonly
+
+package validator
+
+const (
+	// Services count for CW agent on Linux and Windows
+	serviceCountLinux   = 6
+	serviceCountWindows = 3
+
+	// DaemonSet count for CW agent on Linux and Windows
+	daemonsetCountLinux   = 4
+	daemonsetCountWindows = 2
+
+	// Pods count for CW agent on Linux and Windows
+	podCountLinux   = 3
+	podCountWindows = 0
+)

--- a/integration-tests/amazon-cloudwatch-observability/validator/resourceCount_windowslinux_test.go
+++ b/integration-tests/amazon-cloudwatch-observability/validator/resourceCount_windowslinux_test.go
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windowslinux
+// +build windowslinux
+
+package validator
+
+const (
+	// Services count for CW agent on Linux and Windows
+	serviceCountLinux   = 6
+	serviceCountWindows = 3
+
+	// DaemonSet count for CW agent on Linux and Windows
+	daemonsetCountLinux   = 4
+	daemonsetCountWindows = 2
+
+	// Pods count for CW agent on Linux and Windows
+	podCountLinux   = 3
+	podCountWindows = 2
+)

--- a/integration-tests/amazon-cloudwatch-observability/validator/resourceCount_windowslinux_test.go
+++ b/integration-tests/amazon-cloudwatch-observability/validator/resourceCount_windowslinux_test.go
@@ -7,14 +7,6 @@
 package validator
 
 const (
-	// Services count for CW agent on Linux and Windows
-	serviceCountLinux   = 6
-	serviceCountWindows = 3
-
-	// DaemonSet count for CW agent on Linux and Windows
-	daemonsetCountLinux   = 4
-	daemonsetCountWindows = 2
-
 	// Pods count for CW agent on Linux and Windows
 	podCountLinux   = 3
 	podCountWindows = 2

--- a/integration-tests/amazon-cloudwatch-observability/validator/validateResources_test.go
+++ b/integration-tests/amazon-cloudwatch-observability/validator/validateResources_test.go
@@ -70,7 +70,7 @@ func TestOperatorOnEKs(t *testing.T) {
 	//Validating the number of pods and status
 	pods, err := ListPods(nameSpace, clientSet)
 	assert.NoError(t, err)
-	assert.Len(t, pods.Items, 3)
+	assert.Len(t, pods.Items, podCount)
 	for _, pod := range pods.Items {
 		fmt.Println("pod name: " + pod.Name + " namespace:" + pod.Namespace)
 		assert.Contains(t, []v1.PodPhase{v1.PodRunning, v1.PodPending}, pod.Status.Phase)

--- a/integration-tests/amazon-cloudwatch-observability/validator/validateResources_test.go
+++ b/integration-tests/amazon-cloudwatch-observability/validator/validateResources_test.go
@@ -63,7 +63,7 @@ func TestOperatorOnEKs(t *testing.T) {
 	//Validating the number of pods and status
 	pods, err := ListPods(nameSpace, clientSet)
 	assert.NoError(t, err)
-	assert.Len(t, pods.Items, 3)
+	assert.Len(t, pods.Items, 5)
 	for _, pod := range pods.Items {
 		fmt.Println("pod name: " + pod.Name + " namespace:" + pod.Namespace)
 		assert.Contains(t, []v1.PodPhase{v1.PodRunning, v1.PodPending}, pod.Status.Phase)

--- a/integration-tests/amazon-cloudwatch-observability/validator/validateResources_test.go
+++ b/integration-tests/amazon-cloudwatch-observability/validator/validateResources_test.go
@@ -1,6 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build linuxonly || windowslinux
+// +build linuxonly windowslinux
+
 package validator
 
 import (
@@ -36,6 +39,10 @@ const (
 	serviceNameRegex     = agentName + "(-headless|-monitoring)?|" + agentNameWindows + "(-headless|-monitoring)?|" + addOnName + "-webhook-service|" + dcgmExporterName + "-service|" + neuronMonitor + "-service"
 )
 
+const (
+	podCount = podCountLinux + podCountWindows
+)
+
 func TestOperatorOnEKs(t *testing.T) {
 	userHomeDir, err := os.UserHomeDir()
 	if err != nil {
@@ -63,7 +70,7 @@ func TestOperatorOnEKs(t *testing.T) {
 	//Validating the number of pods and status
 	pods, err := ListPods(nameSpace, clientSet)
 	assert.NoError(t, err)
-	assert.Len(t, pods.Items, 5)
+	assert.Len(t, pods.Items, 3)
 	for _, pod := range pods.Items {
 		fmt.Println("pod name: " + pod.Name + " namespace:" + pod.Namespace)
 		assert.Contains(t, []v1.PodPhase{v1.PodRunning, v1.PodPending}, pod.Status.Phase)


### PR DESCRIPTION
Migrated windows from https://github.com/aws/amazon-cloudwatch-agent-operator/blob/main/.github/workflows/helm-integ-test.yml into https://github.com/aws-observability/helm-charts/blob/main/.github/workflows/amazon-cloudwatch-observability-helm-integration-test.yaml and refactored the directory location for helm.

See https://github.com/aws-observability/helm-charts/pull/27 for previous status on PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

