### PR TITLE
Supporting Dotnet instrumentation for amazon-cloudwatch-observability helm char

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
@@ -155,6 +155,13 @@ Get the current recommended auto instrumentation python image
 {{- end -}}
 
 {{/*
+Get the current recommended auto instrumentation dotnet image
+*/}}
+{{- define "auto-instrumentation-dotnet.image" -}}
+{{- printf "%s/%s:%s" .Values.manager.autoInstrumentationImage.dotnet.repositoryDomain .Values.manager.autoInstrumentationImage.dotnet.repository .Values.manager.autoInstrumentationImage.dotnet.tag -}}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "amazon-cloudwatch-observability.labels" -}}

--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -29,6 +29,7 @@ spec:
         - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}
         - "--auto-instrumentation-java-image={{ template "auto-instrumentation-java.image" . }}"
         - "--auto-instrumentation-python-image={{ template "auto-instrumentation-python.image" . }}"
+        - "--auto-instrumentation-dotnet-image={{ template "auto-instrumentation-dotnet.image" . }}"
         - "--feature-gates=operator.autoinstrumentation.multi-instrumentation,operator.autoinstrumentation.multi-instrumentation.skip-container-validation"
         command:
         - /manager

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -46,7 +46,7 @@ manager:
     repository: cloudwatch-agent-operator
     tag: 1.3.1
     repositoryDomainMap:
-      public: 576881538829.dkr.ecr.us-east-1.amazonaws.com
+      public: public.ecr.aws/cloudwatch-agent
       cn-north-1: 934860584483.dkr.ecr.cn-north-1.amazonaws.com.cn
       cn-northwest-1: 934860584483.dkr.ecr.cn-northwest-1.amazonaws.com.cn
       us-gov-east-1: 743662458514.dkr.ecr.us-gov-east-1.amazonaws.com

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -43,8 +43,8 @@ containerLogs:
 manager:
   name:
   image:
-    repository: amazon-cloudwatch-agent-operator
-    tag: 1.3.2
+    repository: cloudwatch-agent-operator
+    tag: 1.3.1
     repositoryDomainMap:
       public: 576881538829.dkr.ecr.us-east-1.amazonaws.com
       cn-north-1: 934860584483.dkr.ecr.cn-north-1.amazonaws.com.cn

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -43,10 +43,10 @@ containerLogs:
 manager:
   name:
   image:
-    repository: cloudwatch-agent-operator
-    tag: 1.3.1
+    repository: amazon-cloudwatch-agent-operator
+    tag: 1.3.2
     repositoryDomainMap:
-      public: public.ecr.aws/cloudwatch-agent
+      public: 576881538829.dkr.ecr.us-east-1.amazonaws.com
       cn-north-1: 934860584483.dkr.ecr.cn-north-1.amazonaws.com.cn
       cn-northwest-1: 934860584483.dkr.ecr.cn-northwest-1.amazonaws.com.cn
       us-gov-east-1: 743662458514.dkr.ecr.us-gov-east-1.amazonaws.com
@@ -60,6 +60,10 @@ manager:
       repositoryDomain: public.ecr.aws/aws-observability
       repository: adot-autoinstrumentation-python
       tag: v0.1.1
+    dotnet:
+      repositoryDomain: ghcr.io/open-telemetry/opentelemetry-operator
+      repository: autoinstrumentation-dotnet
+      tag: 1.6.0
   autoAnnotateAutoInstrumentation:
     java:
       namespaces: [ ]
@@ -67,6 +71,11 @@ manager:
       daemonsets: [ ]
       statefulsets: [ ]
     python:
+      namespaces: [ ]
+      deployments: [ ]
+      daemonsets: [ ]
+      statefulsets: [ ]
+    dotnet:
       namespaces: [ ]
       deployments: [ ]
       daemonsets: [ ]


### PR DESCRIPTION
*Description of changes:*
1. Add dotnet annotation to operator
2. Update helpers file to pick correct image for DotNet instrumentation SDK
3. Add instrumentation flag to operator

Tested as part of https://github.com/aws/amazon-cloudwatch-agent-operator/pull/168


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

