### PR TITLE
EKS Addon Fargate Bug Fix

### DIFF
--- a/charts/amazon-cloudwatch-observability/README.md
+++ b/charts/amazon-cloudwatch-observability/README.md
@@ -2,7 +2,22 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 ## Introduction
-This AWS Observability Helm Chart provides easy mechanisms to setup the [Amazon CloudWatch Agent Operator](https://github.com/aws/amazon-cloudwatch-agent-operator) to manage the [CloudWatch Agent](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Install-CloudWatch-Agent.html) on Kubernetes clusters.
+The Amazon CloudWatch Observability Helm Chart provides easy mechanisms to setup the [Amazon CloudWatch Agent Operator](https://github.com/aws/amazon-cloudwatch-agent-operator) to manage the [CloudWatch Agent](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Install-CloudWatch-Agent.html) on Kubernetes clusters.
+
+## Getting Started
+Full instructions can be found in the [AWS documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/install-CloudWatch-Observability-EKS-addon.html)
+
+### Installation
+1. You must have Helm installed to use this chart. For more information about installing Helm, see the [Helm documentation](https://helm.sh/docs/).
+2. After you have installed Helm, enter the following commands. Replace my-cluster-name with the name of your cluster, and replace my-cluster-region with the Region that the cluster runs in.
+
+```bash
+helm repo add aws-observability https://aws-observability.github.io/helm-charts
+helm repo update aws-observability
+helm install --wait --create-namespace --namespace amazon-cloudwatch amazon-cloudwatch aws-observability/amazon-cloudwatch-observability --set clusterName=my-cluster-name --set region=my-cluster-region
+```
+
+By default, the helm chart will enable [Container Insights](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights.html) enhanced observability with container logging, and [CloudWatch Application Signals](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Application-Monitoring-Sections.html). This helps you to collect infrastructure metrics, application performance telemetry, and container logs from the Amazon EKS cluster.
 
 ## Windows Support
 CloudWatch DaemonSet on Windows is officially supported only for containerd runtime.

--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml
@@ -52,74 +52,74 @@ spec:
       memory: "512Mi"
       cpu: "500m"
   volumeMounts:
-    - mountPath: /rootfs
-      name: rootfs
-      readOnly: true
-    - mountPath: /var/run/docker.sock
-      name: dockersock
-      readOnly: true
-    - mountPath: /run/containerd/containerd.sock
-      name: containerdsock
-    - mountPath: /var/lib/docker
-      name: varlibdocker
-      readOnly: true
-    - mountPath: /sys
-      name: sys
-      readOnly: true
-    - mountPath: /dev/disk
-      name: devdisk
-      readOnly: true
-    - mountPath: /etc/amazon-cloudwatch-observability-agent-cert
-      name: agenttls
-      readOnly: true
-    - mountPath: /var/lib/kubelet/pod-resources
-      name: kubelet-podresources
+  - mountPath: /rootfs
+    name: rootfs
+    readOnly: true
+  - mountPath: /var/run/docker.sock
+    name: dockersock
+    readOnly: true
+  - mountPath: /run/containerd/containerd.sock
+    name: containerdsock
+  - mountPath: /var/lib/docker
+    name: varlibdocker
+    readOnly: true
+  - mountPath: /sys
+    name: sys
+    readOnly: true
+  - mountPath: /dev/disk
+    name: devdisk
+    readOnly: true
+  - mountPath: /etc/amazon-cloudwatch-observability-agent-cert
+    name: agenttls
+    readOnly: true
+  - mountPath: /var/lib/kubelet/pod-resources
+    name: kubelet-podresources
   volumes:
-    - name: kubelet-podresources
-      hostPath:
-        path: /var/lib/kubelet/pod-resources
-        type: Directory
-    - name: rootfs
-      hostPath:
-        path: /
-    - hostPath:
-        path: /var/run/docker.sock
-      name: dockersock
-    - hostPath:
-        path: /var/lib/docker
-      name: varlibdocker
-    - hostPath:
-        path: /run/containerd/containerd.sock
-      name: containerdsock
-    - hostPath:
-        path: /sys
-      name: sys
-    - hostPath:
-        path: /dev/disk/
-      name: devdisk
-    - name: agenttls
-      secret:
-        secretName: amazon-cloudwatch-observability-agent-cert
-        items:
-          - key: ca.crt
-            path: tls-ca.crt
+  - name: kubelet-podresources
+    hostPath:
+      path: /var/lib/kubelet/pod-resources
+      type: Directory
+  - name: rootfs
+    hostPath:
+      path: /
+  - hostPath:
+      path: /var/run/docker.sock
+    name: dockersock
+  - hostPath:
+      path: /var/lib/docker
+    name: varlibdocker
+  - hostPath:
+      path: /run/containerd/containerd.sock
+    name: containerdsock
+  - hostPath:
+      path: /sys
+    name: sys
+  - hostPath:
+      path: /dev/disk/
+    name: devdisk
+  - name: agenttls
+    secret:
+      secretName: amazon-cloudwatch-observability-agent-cert
+      items:
+        - key: ca.crt
+          path: tls-ca.crt
   env:
-    - name: K8S_NODE_NAME
-      valueFrom:
-        fieldRef:
-          fieldPath: spec.nodeName
-    - name: HOST_IP
-      valueFrom:
-        fieldRef:
-          fieldPath: status.hostIP
-    - name: HOST_NAME
-      valueFrom:
-        fieldRef:
-          fieldPath: spec.nodeName
-    - name: K8S_NAMESPACE
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.namespace
+  - name: K8S_NODE_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: spec.nodeName
+  - name: HOST_IP
+    valueFrom:
+      fieldRef:
+        fieldPath: status.hostIP
+  - name: HOST_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: spec.nodeName
+  - name: K8S_NAMESPACE
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace
   {{- with .Values.tolerations }}
   tolerations: {{- toYaml . | nindent 2}}
   {{- end }}

--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml
@@ -30,6 +30,15 @@ spec:
   nodeSelector:
     kubernetes.io/os: linux
   serviceAccount: {{ template "cloudwatch-agent.serviceAccountName" . }}
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: {{ .Values.fargateLabelKey }}
+                operator: NotIn
+                values:
+                  - fargate
   {{- if .Values.agent.config }}
   config: {{ include "cloudwatch-agent.modify-config" (merge (dict "Config" .Values.agent.config) . ) }}
   {{- else }}
@@ -43,74 +52,74 @@ spec:
       memory: "512Mi"
       cpu: "500m"
   volumeMounts:
-  - mountPath: /rootfs
-    name: rootfs
-    readOnly: true
-  - mountPath: /var/run/docker.sock
-    name: dockersock
-    readOnly: true
-  - mountPath: /run/containerd/containerd.sock
-    name: containerdsock
-  - mountPath: /var/lib/docker
-    name: varlibdocker
-    readOnly: true
-  - mountPath: /sys
-    name: sys
-    readOnly: true
-  - mountPath: /dev/disk
-    name: devdisk
-    readOnly: true
-  - mountPath: /etc/amazon-cloudwatch-observability-agent-cert
-    name: agenttls
-    readOnly: true
-  - mountPath: /var/lib/kubelet/pod-resources
-    name: kubelet-podresources
+    - mountPath: /rootfs
+      name: rootfs
+      readOnly: true
+    - mountPath: /var/run/docker.sock
+      name: dockersock
+      readOnly: true
+    - mountPath: /run/containerd/containerd.sock
+      name: containerdsock
+    - mountPath: /var/lib/docker
+      name: varlibdocker
+      readOnly: true
+    - mountPath: /sys
+      name: sys
+      readOnly: true
+    - mountPath: /dev/disk
+      name: devdisk
+      readOnly: true
+    - mountPath: /etc/amazon-cloudwatch-observability-agent-cert
+      name: agenttls
+      readOnly: true
+    - mountPath: /var/lib/kubelet/pod-resources
+      name: kubelet-podresources
   volumes:
-  - name: kubelet-podresources
-    hostPath:
-      path: /var/lib/kubelet/pod-resources
-      type: Directory
-  - name: rootfs
-    hostPath:
-      path: /
-  - hostPath:
-      path: /var/run/docker.sock
-    name: dockersock
-  - hostPath:
-      path: /var/lib/docker
-    name: varlibdocker
-  - hostPath:
-      path: /run/containerd/containerd.sock
-    name: containerdsock
-  - hostPath:
-      path: /sys
-    name: sys
-  - hostPath:
-      path: /dev/disk/
-    name: devdisk
-  - name: agenttls
-    secret:
-      secretName: amazon-cloudwatch-observability-agent-cert
-      items:
-        - key: ca.crt
-          path: tls-ca.crt
+    - name: kubelet-podresources
+      hostPath:
+        path: /var/lib/kubelet/pod-resources
+        type: Directory
+    - name: rootfs
+      hostPath:
+        path: /
+    - hostPath:
+        path: /var/run/docker.sock
+      name: dockersock
+    - hostPath:
+        path: /var/lib/docker
+      name: varlibdocker
+    - hostPath:
+        path: /run/containerd/containerd.sock
+      name: containerdsock
+    - hostPath:
+        path: /sys
+      name: sys
+    - hostPath:
+        path: /dev/disk/
+      name: devdisk
+    - name: agenttls
+      secret:
+        secretName: amazon-cloudwatch-observability-agent-cert
+        items:
+          - key: ca.crt
+            path: tls-ca.crt
   env:
-  - name: K8S_NODE_NAME
-    valueFrom:
-      fieldRef:
-        fieldPath: spec.nodeName
-  - name: HOST_IP
-    valueFrom:
-      fieldRef:
-        fieldPath: status.hostIP
-  - name: HOST_NAME
-    valueFrom:
-      fieldRef:
-        fieldPath: spec.nodeName
-  - name: K8S_NAMESPACE
-    valueFrom:
-      fieldRef:
-        fieldPath: metadata.namespace
+    - name: K8S_NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.hostIP
+    - name: HOST_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    - name: K8S_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
   {{- with .Values.tolerations }}
   tolerations: {{- toYaml . | nindent 2}}
   {{- end }}

--- a/charts/amazon-cloudwatch-observability/templates/linux/dcgm-exporter-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/dcgm-exporter-daemonset.yaml
@@ -15,10 +15,14 @@ spec:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
-        - matchExpressions:
-          - key: {{ .Values.nodeLabelKey }}
-            operator: In
-            values: {{ .Values.gpuInstances | toYaml | nindent 16 }}
+          - matchExpressions:
+              - key: {{ .Values.nodeLabelKey }}
+                operator: In
+                values: {{ .Values.gpuInstances | toYaml | nindent 16 }}
+              - key: {{ .Values.fargateLabelKey }}
+                operator: NotIn
+                values:
+                  - fargate
   resources:
     requests:
       cpu: 250m
@@ -27,36 +31,36 @@ spec:
       cpu: 500m
       memory: 250Mi
   env:
-  - name: "DCGM_EXPORTER_KUBERNETES"
-    value: "true"
-  - name: "DCGM_EXPORTER_LISTEN"
-    value: "{{ .Values.dcgmExporter.service.address }}"
-  - name: NODE_NAME
-    valueFrom:
-      fieldRef:
-        fieldPath: spec.nodeName
+    - name: "DCGM_EXPORTER_KUBERNETES"
+      value: "true"
+    - name: "DCGM_EXPORTER_LISTEN"
+      value: "{{ .Values.dcgmExporter.service.address }}"
+    - name: NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
   ports:
-  - name: "metrics"
-    port: {{ .Values.dcgmExporter.service.port }}
+    - name: "metrics"
+      port: {{ .Values.dcgmExporter.service.port }}
   volumeMounts:
-  - name: "pod-gpu-resources"
-    readOnly: true
-    mountPath: "/var/lib/kubelet/pod-resources"
-  - mountPath: /etc/amazon-cloudwatch-observability-dcgm-cert
-    name: dcgmtls
-    readOnly: true
+    - name: "pod-gpu-resources"
+      readOnly: true
+      mountPath: "/var/lib/kubelet/pod-resources"
+    - mountPath: /etc/amazon-cloudwatch-observability-dcgm-cert
+      name: dcgmtls
+      readOnly: true
   volumes:
-  - name: dcgmtls
-    secret:
-      secretName: amazon-cloudwatch-observability-agent-cert
-      items:
-        - key: tls.crt
-          path: server.crt
-        - key:  tls.key
-          path: server.key
-  - name: "pod-gpu-resources"
-    hostPath:
-      path: /var/lib/kubelet/pod-resources
+    - name: dcgmtls
+      secret:
+        secretName: amazon-cloudwatch-observability-agent-cert
+        items:
+          - key: tls.crt
+            path: server.crt
+          - key:  tls.key
+            path: server.key
+    - name: "pod-gpu-resources"
+      hostPath:
+        path: /var/lib/kubelet/pod-resources
   metricsConfig: |
     DCGM_FI_DEV_GPU_UTIL,      gauge, GPU utilization (in %).
     DCGM_FI_DEV_MEM_COPY_UTIL, gauge, Memory utilization (in %).

--- a/charts/amazon-cloudwatch-observability/templates/linux/dcgm-exporter-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/dcgm-exporter-daemonset.yaml
@@ -31,36 +31,36 @@ spec:
       cpu: 500m
       memory: 250Mi
   env:
-    - name: "DCGM_EXPORTER_KUBERNETES"
-      value: "true"
-    - name: "DCGM_EXPORTER_LISTEN"
-      value: "{{ .Values.dcgmExporter.service.address }}"
-    - name: NODE_NAME
-      valueFrom:
-        fieldRef:
-          fieldPath: spec.nodeName
+  - name: "DCGM_EXPORTER_KUBERNETES"
+    value: "true"
+  - name: "DCGM_EXPORTER_LISTEN"
+    value: "{{ .Values.dcgmExporter.service.address }}"
+  - name: NODE_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: spec.nodeName
   ports:
-    - name: "metrics"
-      port: {{ .Values.dcgmExporter.service.port }}
+  - name: "metrics"
+    port: {{ .Values.dcgmExporter.service.port }}
   volumeMounts:
-    - name: "pod-gpu-resources"
-      readOnly: true
-      mountPath: "/var/lib/kubelet/pod-resources"
-    - mountPath: /etc/amazon-cloudwatch-observability-dcgm-cert
-      name: dcgmtls
-      readOnly: true
+  - name: "pod-gpu-resources"
+    readOnly: true
+    mountPath: "/var/lib/kubelet/pod-resources"
+  - mountPath: /etc/amazon-cloudwatch-observability-dcgm-cert
+    name: dcgmtls
+    readOnly: true
   volumes:
-    - name: dcgmtls
-      secret:
-        secretName: amazon-cloudwatch-observability-agent-cert
-        items:
-          - key: tls.crt
-            path: server.crt
-          - key:  tls.key
-            path: server.key
-    - name: "pod-gpu-resources"
-      hostPath:
-        path: /var/lib/kubelet/pod-resources
+  - name: dcgmtls
+    secret:
+      secretName: amazon-cloudwatch-observability-agent-cert
+      items:
+        - key: tls.crt
+          path: server.crt
+        - key:  tls.key
+          path: server.key
+  - name: "pod-gpu-resources"
+    hostPath:
+      path: /var/lib/kubelet/pod-resources
   metricsConfig: |
     DCGM_FI_DEV_GPU_UTIL,      gauge, GPU utilization (in %).
     DCGM_FI_DEV_MEM_COPY_UTIL, gauge, Memory utilization (in %).

--- a/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
@@ -24,77 +24,86 @@ spec:
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
-      - name: fluent-bit
-        image: {{ template "fluent-bit.image" . }}
-        imagePullPolicy: Always
-        env:
-        - name: AWS_REGION
-          value: {{ .Values.region }}
-        - name: CLUSTER_NAME
-          value: {{ .Values.clusterName | quote }}
-        - name: READ_FROM_HEAD
-          value: "Off"
-        - name: READ_FROM_TAIL
-          value: "On"
-        - name: HOST_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        - name: HOSTNAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: CI_VERSION
-          value: "k8s/1.3.17"
-        resources:
-          limits:
-            cpu: 500m
-            memory: 250Mi
-          requests:
-            cpu: 50m
-            memory: 25Mi
-        volumeMounts:
-        # Please don't change below read-only permissions
-        - name: fluentbitstate
-          mountPath: /var/fluent-bit/state
-        - name: varlog
-          mountPath: /var/log
-          readOnly: true
-        - name: varlibdockercontainers
-          mountPath: /var/lib/docker/containers
-          readOnly: true
-        - name: fluent-bit-config
-          mountPath: /fluent-bit/etc/
-        - name: runlogjournal
-          mountPath: /run/log/journal
-          readOnly: true
-        - name: dmesg
-          mountPath: /var/log/dmesg
-          readOnly: true
+        - name: fluent-bit
+          image: {{ template "fluent-bit.image" . }}
+          imagePullPolicy: Always
+          env:
+            - name: AWS_REGION
+              value: {{ .Values.region }}
+            - name: CLUSTER_NAME
+              value: {{ .Values.clusterName | quote }}
+            - name: READ_FROM_HEAD
+              value: "Off"
+            - name: READ_FROM_TAIL
+              value: "On"
+            - name: HOST_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: CI_VERSION
+              value: "k8s/1.3.17"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 250Mi
+            requests:
+              cpu: 50m
+              memory: 25Mi
+          volumeMounts:
+            # Please don't change below read-only permissions
+            - name: fluentbitstate
+              mountPath: /var/fluent-bit/state
+            - name: varlog
+              mountPath: /var/log
+              readOnly: true
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+            - name: fluent-bit-config
+              mountPath: /fluent-bit/etc/
+            - name: runlogjournal
+              mountPath: /run/log/journal
+              readOnly: true
+            - name: dmesg
+              mountPath: /var/log/dmesg
+              readOnly: true
       terminationGracePeriodSeconds: 10
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       volumes:
-      - name: fluentbitstate
-        hostPath:
-          path: /var/fluent-bit/state
-      - name: varlog
-        hostPath:
-          path: /var/log
-      - name: varlibdockercontainers
-        hostPath:
-          path: /var/lib/docker/containers
-      - name: fluent-bit-config
-        configMap:
-          name: fluent-bit-config
-      - name: runlogjournal
-        hostPath:
-          path: /run/log/journal
-      - name: dmesg
-        hostPath:
-          path: /var/log/dmesg
+        - name: fluentbitstate
+          hostPath:
+            path: /var/fluent-bit/state
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+        - name: fluent-bit-config
+          configMap:
+            name: fluent-bit-config
+        - name: runlogjournal
+          hostPath:
+            path: /run/log/journal
+        - name: dmesg
+          hostPath:
+            path: /var/log/dmesg
       serviceAccountName: {{ template "cloudwatch-agent.serviceAccountName" . }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: {{ .Values.fargateLabelKey }}
+                    operator: NotIn
+                    values:
+                      - fargate
       nodeSelector:
         kubernetes.io/os: linux
       {{- with .Values.tolerations }}

--- a/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
@@ -24,76 +24,76 @@ spec:
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
-        - name: fluent-bit
-          image: {{ template "fluent-bit.image" . }}
-          imagePullPolicy: Always
-          env:
-            - name: AWS_REGION
-              value: {{ .Values.region }}
-            - name: CLUSTER_NAME
-              value: {{ .Values.clusterName | quote }}
-            - name: READ_FROM_HEAD
-              value: "Off"
-            - name: READ_FROM_TAIL
-              value: "On"
-            - name: HOST_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: HOSTNAME
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.name
-            - name: CI_VERSION
-              value: "k8s/1.3.17"
-          resources:
-            limits:
-              cpu: 500m
-              memory: 250Mi
-            requests:
-              cpu: 50m
-              memory: 25Mi
-          volumeMounts:
-            # Please don't change below read-only permissions
-            - name: fluentbitstate
-              mountPath: /var/fluent-bit/state
-            - name: varlog
-              mountPath: /var/log
-              readOnly: true
-            - name: varlibdockercontainers
-              mountPath: /var/lib/docker/containers
-              readOnly: true
-            - name: fluent-bit-config
-              mountPath: /fluent-bit/etc/
-            - name: runlogjournal
-              mountPath: /run/log/journal
-              readOnly: true
-            - name: dmesg
-              mountPath: /var/log/dmesg
-              readOnly: true
+      - name: fluent-bit
+        image: {{ template "fluent-bit.image" . }}
+        imagePullPolicy: Always
+        env:
+        - name: AWS_REGION
+          value: {{ .Values.region }}
+        - name: CLUSTER_NAME
+          value: {{ .Values.clusterName | quote }}
+        - name: READ_FROM_HEAD
+          value: "Off"
+        - name: READ_FROM_TAIL
+          value: "On"
+        - name: HOST_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: HOSTNAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: CI_VERSION
+          value: "k8s/1.3.17"
+        resources:
+          limits:
+            cpu: 500m
+            memory: 250Mi
+          requests:
+            cpu: 50m
+            memory: 25Mi
+        volumeMounts:
+        # Please don't change below read-only permissions
+        - name: fluentbitstate
+          mountPath: /var/fluent-bit/state
+        - name: varlog
+          mountPath: /var/log
+          readOnly: true
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+        - name: fluent-bit-config
+          mountPath: /fluent-bit/etc/
+        - name: runlogjournal
+          mountPath: /run/log/journal
+          readOnly: true
+        - name: dmesg
+          mountPath: /var/log/dmesg
+          readOnly: true
       terminationGracePeriodSeconds: 10
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       volumes:
-        - name: fluentbitstate
-          hostPath:
-            path: /var/fluent-bit/state
-        - name: varlog
-          hostPath:
-            path: /var/log
-        - name: varlibdockercontainers
-          hostPath:
-            path: /var/lib/docker/containers
-        - name: fluent-bit-config
-          configMap:
-            name: fluent-bit-config
-        - name: runlogjournal
-          hostPath:
-            path: /run/log/journal
-        - name: dmesg
-          hostPath:
-            path: /var/log/dmesg
+      - name: fluentbitstate
+        hostPath:
+          path: /var/fluent-bit/state
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+      - name: fluent-bit-config
+        configMap:
+          name: fluent-bit-config
+      - name: runlogjournal
+        hostPath:
+          path: /run/log/journal
+      - name: dmesg
+        hostPath:
+          path: /var/log/dmesg
       serviceAccountName: {{ template "cloudwatch-agent.serviceAccountName" . }}
       affinity:
         nodeAffinity:

--- a/charts/amazon-cloudwatch-observability/templates/linux/neuron-monitor-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/neuron-monitor-daemonset.yaml
@@ -33,17 +33,17 @@ spec:
       cpu: 256m
       memory: 128Mi
   env:
-    - name: NODE_NAME
-      valueFrom:
-        fieldRef:
-          fieldPath: spec.nodeName
-    - name: PATH
-      value: /usr/local/bin:/usr/bin:/bin:/opt/aws/neuron/bin
-    - name: GOMEMLIMIT
-      value: 160MiB
+  - name: NODE_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: spec.nodeName
+  - name: PATH
+    value: /usr/local/bin:/usr/bin:/bin:/opt/aws/neuron/bin
+  - name: GOMEMLIMIT
+    value: 160MiB
   ports:
-    - name: "metrics"
-      port: {{ .Values.neuronMonitor.service.port }}
+  - name: "metrics"
+    port: {{ .Values.neuronMonitor.service.port }}
   command:
     - "/opt/bin/entrypoint.sh"
   args:
@@ -53,18 +53,18 @@ spec:
   securityContext:
     privileged: true
   volumeMounts:
-    - mountPath: /etc/amazon-cloudwatch-observability-neuron-cert/
-      name: neurontls
-      readOnly: true
+  - mountPath: /etc/amazon-cloudwatch-observability-neuron-cert/
+    name: neurontls
+    readOnly: true
   volumes:
-    - name: neurontls
-      secret:
-        secretName: amazon-cloudwatch-observability-agent-cert
-        items:
-          - key: tls.crt
-            path: server.crt
-          - key: tls.key
-            path: server.key
+  - name: neurontls
+    secret:
+      secretName: amazon-cloudwatch-observability-agent-cert
+      items:
+        - key: tls.crt
+          path: server.crt
+        - key: tls.key
+          path: server.key
   monitorConfig: |
     {
       "period": "5s",

--- a/charts/amazon-cloudwatch-observability/templates/linux/neuron-monitor-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/neuron-monitor-daemonset.yaml
@@ -14,13 +14,17 @@ spec:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
           - matchExpressions:
-            - key: kubernetes.io/os
-              operator: In
-              values:
-                - linux
-            - key: {{ .Values.nodeLabelKey }}
-              operator: In
-              values: {{ .Values.neuronInstances | toYaml | nindent 20 }}
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                  - linux
+              - key: {{ .Values.nodeLabelKey }}
+                operator: In
+                values: {{ .Values.neuronInstances | toYaml | nindent 20 }}
+              - key: {{ .Values.fargateLabelKey }}
+                operator: NotIn
+                values:
+                  - fargate
   resources:
     limits:
       cpu: 500m
@@ -29,19 +33,17 @@ spec:
       cpu: 256m
       memory: 128Mi
   env:
-  - name: NODE_NAME
-    valueFrom:
-      fieldRef:
-        fieldPath: spec.nodeName
-  - name: PATH
-    value: /usr/local/bin:/usr/bin:/bin:/opt/aws/neuron/bin
-  - name: GOMEMLIMIT
-    value: 160MiB
+    - name: NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    - name: PATH
+      value: /usr/local/bin:/usr/bin:/bin:/opt/aws/neuron/bin
   ports:
-  - name: "metrics"
-    port: {{ .Values.neuronMonitor.service.port }}
+    - name: "metrics"
+      port: {{ .Values.neuronMonitor.service.port }}
   command:
-  - "/opt/bin/entrypoint.sh"
+    - "/opt/bin/entrypoint.sh"
   args:
     port: "{{ .Values.neuronMonitor.service.port }}"
     cert-file: "/etc/amazon-cloudwatch-observability-neuron-cert/server.crt"
@@ -49,18 +51,18 @@ spec:
   securityContext:
     privileged: true
   volumeMounts:
-  - mountPath: /etc/amazon-cloudwatch-observability-neuron-cert/
-    name: neurontls
-    readOnly: true
+    - mountPath: /etc/amazon-cloudwatch-observability-neuron-cert/
+      name: neurontls
+      readOnly: true
   volumes:
-  - name: neurontls
-    secret:
-      secretName: amazon-cloudwatch-observability-agent-cert
-      items:
-        - key: tls.crt
-          path: server.crt
-        - key: tls.key
-          path: server.key
+    - name: neurontls
+      secret:
+        secretName: amazon-cloudwatch-observability-agent-cert
+        items:
+          - key: tls.crt
+            path: server.crt
+          - key: tls.key
+            path: server.key
   monitorConfig: |
     {
       "period": "5s",

--- a/charts/amazon-cloudwatch-observability/templates/linux/neuron-monitor-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/neuron-monitor-daemonset.yaml
@@ -35,6 +35,8 @@ spec:
         fieldPath: spec.nodeName
   - name: PATH
     value: /usr/local/bin:/usr/bin:/bin:/opt/aws/neuron/bin
+  - name: GOMEMLIMIT
+    value: 160MiB
   ports:
   - name: "metrics"
     port: {{ .Values.neuronMonitor.service.port }}

--- a/charts/amazon-cloudwatch-observability/templates/linux/neuron-monitor-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/neuron-monitor-daemonset.yaml
@@ -39,6 +39,8 @@ spec:
           fieldPath: spec.nodeName
     - name: PATH
       value: /usr/local/bin:/usr/bin:/bin:/opt/aws/neuron/bin
+    - name: GOMEMLIMIT
+      value: 160MiB
   ports:
     - name: "metrics"
       port: {{ .Values.neuronMonitor.service.port }}

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -18,6 +18,8 @@ clusterName:
 region:
 
 nodeLabelKey: node.kubernetes.io/instance-type
+fargateLabelKey: eks.amazonaws.com/compute-type
+
 ## NVIDIA GPU instance types
 gpuInstances: [ p2.xlarge, p2.8xlarge, p2.16xlarge, p3.2xlarge, p3.8xlarge, p3.16xlarge, p3dn.24xlarge, p4d.24xlarge, p4de.24xlarge, p5.48xlarge, g3s.xlarge, g3.4xlarge, g3.8xlarge, g3.16xlarge, g4dn.xlarge, g4dn.2xlarge, g4dn.4xlarge, g4dn.8xlarge, g4dn.16xlarge, g4dn.12xlarge, g4dn.metal, g4ad.xlarge, g4ad.2xlarge, g4ad.4xlarge, g4ad.8xlarge, g4ad.16xlarge, g5.xlarge, g5.2xlarge, g5.4xlarge, g5.8xlarge, g5.16xlarge, g5.12xlarge, g5.24xlarge, g5.48xlarge, g5g.xlarge, g5g.2xlarge, g5g.4xlarge, g5g.8xlarge, g5g.16xlarge, g5g.metal, ml.p5.48xlarge, ml.p4d.24xlarge, ml.p4de.24xlarge, ml.p3.2xlarge, ml.p3.8xlarge, ml.p3.16xlarge, ml.p3dn.24xlarge, ml.p2.xlarge, ml.p2.8xlarge, ml.p2.16xlarge, ml.g3s.xlarge, ml.g3.4xlarge, ml.g3.8xlarge, ml.g3.16xlarge, ml.g4dn.xlarge, ml.g4dn.2xlarge, ml.g4dn.4xlarge, ml.g4dn.8xlarge, ml.g4dn.16xlarge, ml.g4dn.12xlarge, ml.g4dn.metal, ml.g4ad.xlarge, ml.g4ad.2xlarge, ml.g4ad.4xlarge, ml.g4ad.8xlarge, ml.g4ad.16xlarge, ml.g5.xlarge, ml.g5.2xlarge, ml.g5.4xlarge, ml.g5.8xlarge, ml.g5.16xlarge, ml.g5.12xlarge, ml.g5.24xlarge, ml.g5.48xlarge, ml.g5g.xlarge, ml.g5g.2xlarge, ml.g5g.4xlarge, ml.g5g.8xlarge, ml.g5g.16xlarge, ml.g5g.metal]
 
@@ -26,7 +28,8 @@ neuronInstances: [ trn1.2xlarge, trn1.32xlarge, trn1n.32xlarge, inf1.xlarge, inf
 
 ## Provide default tolerations
 tolerations:
-- operator: Exists
+  - operator: Exists
+
 
 containerLogs:
   enabled: true
@@ -60,14 +63,14 @@ containerLogs:
           Regex               ^(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
           Time_Key            time
           Time_Format         %b %d %H:%M:%S
-  
+        
         [PARSER]
           Name                container_firstline
           Format              regex
           Regex               (?<log>(?<="log":")\S(?!\.).*?)(?<!\\)".*(?<stream>(?<="stream":").*?)".*(?<time>\d{4}-\d{1,2}-\d{1,2}T\d{2}:\d{2}:\d{2}\.\w*).*(?=})
           Time_Key            time
           Time_Format         %Y-%m-%dT%H:%M:%S.%LZ
-    
+        
         [PARSER]
           Name                cwagent_firstline
           Format              regex
@@ -89,7 +92,7 @@ containerLogs:
             Rotate_Wait         30
             storage.type        filesystem
             Read_from_Head      ${READ_FROM_HEAD}
-      
+          
           [INPUT]
             Name                tail
             Tag                 application.*
@@ -100,7 +103,7 @@ containerLogs:
             Skip_Long_Lines     On
             Refresh_Interval    10
             Read_from_Head      ${READ_FROM_HEAD}
-      
+          
           [INPUT]
             Name                tail
             Tag                 application.*
@@ -111,7 +114,7 @@ containerLogs:
             Skip_Long_Lines     On
             Refresh_Interval    10
             Read_from_Head      ${READ_FROM_HEAD}
-      
+          
           [FILTER]
             Name                kubernetes
             Match               application.*
@@ -126,7 +129,7 @@ containerLogs:
             Use_Kubelet         On
             Kubelet_Port        10250
             Buffer_Size         0
-      
+          
           [OUTPUT]
             Name                cloudwatch_logs
             Match               application.*
@@ -145,7 +148,7 @@ containerLogs:
             DB                  /var/fluent-bit/state/systemd.db
             Path                /var/log/journal
             Read_From_Tail      ${READ_FROM_TAIL}
-      
+          
           [INPUT]
             Name                tail
             Tag                 dataplane.tail.*
@@ -158,7 +161,7 @@ containerLogs:
             Rotate_Wait         30
             storage.type        filesystem
             Read_from_Head      ${READ_FROM_HEAD}
-      
+          
           [FILTER]
             Name                modify
             Match               dataplane.systemd.*
@@ -166,12 +169,12 @@ containerLogs:
             Rename              _SYSTEMD_UNIT               systemd_unit
             Rename              MESSAGE                     message
             Remove_regex        ^((?!hostname|systemd_unit|message).)*$
-      
+          
           [FILTER]
             Name                aws
             Match               dataplane.*
             imds_version        v2
-      
+          
           [OUTPUT]
             Name                cloudwatch_logs
             Match               dataplane.*
@@ -235,7 +238,7 @@ containerLogs:
           Daemon                      off
           net.dns.resolver            LEGACY
           Parsers_File                parsers.conf
-          
+        
           @INCLUDE application-log.conf
           @INCLUDE dataplane-log.conf
           @INCLUDE host-log.conf
@@ -273,7 +276,7 @@ containerLogs:
             Rotate_Wait         30
             Refresh_Interval    10
             Read_from_Head      ${READ_FROM_HEAD}
-    
+          
           [INPUT]
             Name                tail
             Tag                 application.*
@@ -285,7 +288,7 @@ containerLogs:
             Rotate_Wait         30
             Refresh_Interval    10
             Read_from_Head      ${READ_FROM_HEAD}
-      
+          
           [INPUT]
             Name                tail
             Tag                 application.*
@@ -297,7 +300,7 @@ containerLogs:
             Rotate_Wait         30
             Refresh_Interval    10
             Read_from_Head      ${READ_FROM_HEAD}
-      
+          
           [OUTPUT]
             Name                cloudwatch_logs
             Match               application.*
@@ -318,7 +321,7 @@ containerLogs:
             Rotate_Wait         30
             Refresh_Interval    10
             Read_from_Head      ${READ_FROM_HEAD}
-    
+          
           [INPUT]
             Name                tail
             Tag                 dataplane.tail.C.ProgramData.Amazon.EKS.logs.vpc-bridge
@@ -337,7 +340,7 @@ containerLogs:
             Channels            EKS
             DB                  C:\\var\\fluent-bit\\state\\flb_eks_winlog.db
             Interval_Sec        60
-    
+          
           [FILTER]
             Name                aws
             Match               dataplane.*
@@ -347,7 +350,7 @@ containerLogs:
             Name                aws
             Match               winlog.*
             imds_version        v2
-      
+          
           [OUTPUT]
             Name                cloudwatch_logs
             Match               dataplane.*
@@ -371,12 +374,12 @@ containerLogs:
             Channels            System
             DB                  C:\\var\\fluent-bit\\state\\flb_system_winlog.db
             Interval_Sec        60
-      
+          
           [FILTER]
             Name                aws
             Match               winlog.*
             imds_version        v2
-      
+          
           [OUTPUT]
             Name                cloudwatch_logs
             Match               winlog.*

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -21,15 +21,14 @@ nodeLabelKey: node.kubernetes.io/instance-type
 fargateLabelKey: eks.amazonaws.com/compute-type
 
 ## NVIDIA GPU instance types
-gpuInstances: [ p2.xlarge, p2.8xlarge, p2.16xlarge, p3.2xlarge, p3.8xlarge, p3.16xlarge, p3dn.24xlarge, p4d.24xlarge, p4de.24xlarge, p5.48xlarge, g3s.xlarge, g3.4xlarge, g3.8xlarge, g3.16xlarge, g4dn.xlarge, g4dn.2xlarge, g4dn.4xlarge, g4dn.8xlarge, g4dn.16xlarge, g4dn.12xlarge, g4dn.metal, g4ad.xlarge, g4ad.2xlarge, g4ad.4xlarge, g4ad.8xlarge, g4ad.16xlarge, g5.xlarge, g5.2xlarge, g5.4xlarge, g5.8xlarge, g5.16xlarge, g5.12xlarge, g5.24xlarge, g5.48xlarge, g5g.xlarge, g5g.2xlarge, g5g.4xlarge, g5g.8xlarge, g5g.16xlarge, g5g.metal, ml.p5.48xlarge, ml.p4d.24xlarge, ml.p4de.24xlarge, ml.p3.2xlarge, ml.p3.8xlarge, ml.p3.16xlarge, ml.p3dn.24xlarge, ml.p2.xlarge, ml.p2.8xlarge, ml.p2.16xlarge, ml.g3s.xlarge, ml.g3.4xlarge, ml.g3.8xlarge, ml.g3.16xlarge, ml.g4dn.xlarge, ml.g4dn.2xlarge, ml.g4dn.4xlarge, ml.g4dn.8xlarge, ml.g4dn.16xlarge, ml.g4dn.12xlarge, ml.g4dn.metal, ml.g4ad.xlarge, ml.g4ad.2xlarge, ml.g4ad.4xlarge, ml.g4ad.8xlarge, ml.g4ad.16xlarge, ml.g5.xlarge, ml.g5.2xlarge, ml.g5.4xlarge, ml.g5.8xlarge, ml.g5.16xlarge, ml.g5.12xlarge, ml.g5.24xlarge, ml.g5.48xlarge, ml.g5g.xlarge, ml.g5g.2xlarge, ml.g5g.4xlarge, ml.g5g.8xlarge, ml.g5g.16xlarge, ml.g5g.metal]
+gpuInstances: [ p2.xlarge, p2.8xlarge, p2.16xlarge, p3.2xlarge, p3.8xlarge, p3.16xlarge, p3dn.24xlarge, p4d.24xlarge, p4de.24xlarge, p5.48xlarge, g3s.xlarge, g3.4xlarge, g3.8xlarge, g3.16xlarge, g4dn.xlarge, g4dn.2xlarge, g4dn.4xlarge, g4dn.8xlarge, g4dn.16xlarge, g4dn.12xlarge, g4dn.metal, g4ad.xlarge, g4ad.2xlarge, g4ad.4xlarge, g4ad.8xlarge, g4ad.16xlarge, g5.xlarge, g5.2xlarge, g5.4xlarge, g5.8xlarge, g5.16xlarge, g5.12xlarge, g5.24xlarge, g5.48xlarge, g5g.xlarge, g5g.2xlarge, g5g.4xlarge, g5g.8xlarge, g5g.16xlarge, g5g.metal, ml.p5.48xlarge, ml.p4d.24xlarge, ml.p4de.24xlarge, ml.p3.2xlarge, ml.p3.8xlarge, ml.p3.16xlarge, ml.p3dn.24xlarge, ml.p2.xlarge, ml.p2.8xlarge, ml.p2.16xlarge, ml.g3s.xlarge, ml.g3.4xlarge, ml.g3.8xlarge, ml.g3.16xlarge, ml.g4dn.xlarge, ml.g4dn.2xlarge, ml.g4dn.4xlarge, ml.g4dn.8xlarge, ml.g4dn.16xlarge, ml.g4dn.12xlarge, ml.g4dn.metal, ml.g4ad.xlarge, ml.g4ad.2xlarge, ml.g4ad.4xlarge, ml.g4ad.8xlarge, ml.g4ad.16xlarge, ml.g5.xlarge, ml.g5.2xlarge, ml.g5.4xlarge, ml.g5.8xlarge, ml.g5.16xlarge, ml.g5.12xlarge, ml.g5.24xlarge, ml.g5.48xlarge, ml.g5g.xlarge, ml.g5g.2xlarge, ml.g5g.4xlarge, ml.g5g.8xlarge, ml.g5g.16xlarge, ml.g5g.metal ]
 
 ## Tranium/Infrentia instance types
-neuronInstances: [ trn1.2xlarge, trn1.32xlarge, trn1n.32xlarge, inf1.xlarge, inf1.2xlarge, inf1.6xlarge, inf1.24xlarge, inf2.xlarge, inf2.8xlarge, inf2.24xlarge, inf2.48xlarge, ml.trn1.2xlarge, ml.trn1.32xlarge, ml.trn1n.32xlarge, ml.inf1.xlarge, ml.inf1.2xlarge, ml.inf1.6xlarge, ml.inf1.24xlarge, ml.inf2.xlarge, ml.inf2.8xlarge, ml.inf2.24xlarge, ml.inf2.48xlarge]
+neuronInstances: [ trn1.2xlarge, trn1.32xlarge, trn1n.32xlarge, inf1.xlarge, inf1.2xlarge, inf1.6xlarge, inf1.24xlarge, inf2.xlarge, inf2.8xlarge, inf2.24xlarge, inf2.48xlarge, ml.trn1.2xlarge, ml.trn1.32xlarge, ml.trn1n.32xlarge, ml.inf1.xlarge, ml.inf1.2xlarge, ml.inf1.6xlarge, ml.inf1.24xlarge, ml.inf2.xlarge, ml.inf2.8xlarge, ml.inf2.24xlarge, ml.inf2.48xlarge ]
 
 ## Provide default tolerations
 tolerations:
   - operator: Exists
-
 
 containerLogs:
   enabled: true
@@ -517,7 +516,7 @@ agent:
   ## TLS Certificate Option 2: Use certManager to generate self-signed certificate.
   ## certManager must be enabled. If enabled, it takes precedence over option 1.
   certManager:
-    enabled:  false
+    enabled: false
     ## Provide the issuer kind and name to do the cert auth job.
     ## By default, OpenTelemetry Operator will use self-signer issuer.
     issuerRef: { }
@@ -568,7 +567,7 @@ dcgmExporter:
       us-gov-east-1: 743662458514.dkr.ecr.us-gov-east-1.amazonaws.com
       us-gov-west-1: 743662458514.dkr.ecr.us-gov-west-1.amazonaws.com
   configmap: dcgm-exporter-config-map
-  arguments: ["--web-config-file=/etc/dcgm-exporter/web-config.yaml"]
+  arguments: [ "--web-config-file=/etc/dcgm-exporter/web-config.yaml" ]
   service:
     enable: true
     type: ClusterIP
@@ -595,6 +594,6 @@ neuronMonitor:
     runAsNonRoot: false
     runAsUser: 0
     capabilities:
-      add: ["SYS_ADMIN"]
+      add: [ "SYS_ADMIN" ]
   serviceAccount:
     name: # override exporter service account name

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -21,14 +21,14 @@ nodeLabelKey: node.kubernetes.io/instance-type
 fargateLabelKey: eks.amazonaws.com/compute-type
 
 ## NVIDIA GPU instance types
-gpuInstances: [ p2.xlarge, p2.8xlarge, p2.16xlarge, p3.2xlarge, p3.8xlarge, p3.16xlarge, p3dn.24xlarge, p4d.24xlarge, p4de.24xlarge, p5.48xlarge, g3s.xlarge, g3.4xlarge, g3.8xlarge, g3.16xlarge, g4dn.xlarge, g4dn.2xlarge, g4dn.4xlarge, g4dn.8xlarge, g4dn.16xlarge, g4dn.12xlarge, g4dn.metal, g4ad.xlarge, g4ad.2xlarge, g4ad.4xlarge, g4ad.8xlarge, g4ad.16xlarge, g5.xlarge, g5.2xlarge, g5.4xlarge, g5.8xlarge, g5.16xlarge, g5.12xlarge, g5.24xlarge, g5.48xlarge, g5g.xlarge, g5g.2xlarge, g5g.4xlarge, g5g.8xlarge, g5g.16xlarge, g5g.metal, ml.p5.48xlarge, ml.p4d.24xlarge, ml.p4de.24xlarge, ml.p3.2xlarge, ml.p3.8xlarge, ml.p3.16xlarge, ml.p3dn.24xlarge, ml.p2.xlarge, ml.p2.8xlarge, ml.p2.16xlarge, ml.g3s.xlarge, ml.g3.4xlarge, ml.g3.8xlarge, ml.g3.16xlarge, ml.g4dn.xlarge, ml.g4dn.2xlarge, ml.g4dn.4xlarge, ml.g4dn.8xlarge, ml.g4dn.16xlarge, ml.g4dn.12xlarge, ml.g4dn.metal, ml.g4ad.xlarge, ml.g4ad.2xlarge, ml.g4ad.4xlarge, ml.g4ad.8xlarge, ml.g4ad.16xlarge, ml.g5.xlarge, ml.g5.2xlarge, ml.g5.4xlarge, ml.g5.8xlarge, ml.g5.16xlarge, ml.g5.12xlarge, ml.g5.24xlarge, ml.g5.48xlarge, ml.g5g.xlarge, ml.g5g.2xlarge, ml.g5g.4xlarge, ml.g5g.8xlarge, ml.g5g.16xlarge, ml.g5g.metal ]
+gpuInstances: [ p2.xlarge, p2.8xlarge, p2.16xlarge, p3.2xlarge, p3.8xlarge, p3.16xlarge, p3dn.24xlarge, p4d.24xlarge, p4de.24xlarge, p5.48xlarge, g3s.xlarge, g3.4xlarge, g3.8xlarge, g3.16xlarge, g4dn.xlarge, g4dn.2xlarge, g4dn.4xlarge, g4dn.8xlarge, g4dn.16xlarge, g4dn.12xlarge, g4dn.metal, g4ad.xlarge, g4ad.2xlarge, g4ad.4xlarge, g4ad.8xlarge, g4ad.16xlarge, g5.xlarge, g5.2xlarge, g5.4xlarge, g5.8xlarge, g5.16xlarge, g5.12xlarge, g5.24xlarge, g5.48xlarge, g5g.xlarge, g5g.2xlarge, g5g.4xlarge, g5g.8xlarge, g5g.16xlarge, g5g.metal, ml.p5.48xlarge, ml.p4d.24xlarge, ml.p4de.24xlarge, ml.p3.2xlarge, ml.p3.8xlarge, ml.p3.16xlarge, ml.p3dn.24xlarge, ml.p2.xlarge, ml.p2.8xlarge, ml.p2.16xlarge, ml.g3s.xlarge, ml.g3.4xlarge, ml.g3.8xlarge, ml.g3.16xlarge, ml.g4dn.xlarge, ml.g4dn.2xlarge, ml.g4dn.4xlarge, ml.g4dn.8xlarge, ml.g4dn.16xlarge, ml.g4dn.12xlarge, ml.g4dn.metal, ml.g4ad.xlarge, ml.g4ad.2xlarge, ml.g4ad.4xlarge, ml.g4ad.8xlarge, ml.g4ad.16xlarge, ml.g5.xlarge, ml.g5.2xlarge, ml.g5.4xlarge, ml.g5.8xlarge, ml.g5.16xlarge, ml.g5.12xlarge, ml.g5.24xlarge, ml.g5.48xlarge, ml.g5g.xlarge, ml.g5g.2xlarge, ml.g5g.4xlarge, ml.g5g.8xlarge, ml.g5g.16xlarge, ml.g5g.metal]
 
 ## Tranium/Infrentia instance types
-neuronInstances: [ trn1.2xlarge, trn1.32xlarge, trn1n.32xlarge, inf1.xlarge, inf1.2xlarge, inf1.6xlarge, inf1.24xlarge, inf2.xlarge, inf2.8xlarge, inf2.24xlarge, inf2.48xlarge, ml.trn1.2xlarge, ml.trn1.32xlarge, ml.trn1n.32xlarge, ml.inf1.xlarge, ml.inf1.2xlarge, ml.inf1.6xlarge, ml.inf1.24xlarge, ml.inf2.xlarge, ml.inf2.8xlarge, ml.inf2.24xlarge, ml.inf2.48xlarge ]
+neuronInstances: [ trn1.2xlarge, trn1.32xlarge, trn1n.32xlarge, inf1.xlarge, inf1.2xlarge, inf1.6xlarge, inf1.24xlarge, inf2.xlarge, inf2.8xlarge, inf2.24xlarge, inf2.48xlarge, ml.trn1.2xlarge, ml.trn1.32xlarge, ml.trn1n.32xlarge, ml.inf1.xlarge, ml.inf1.2xlarge, ml.inf1.6xlarge, ml.inf1.24xlarge, ml.inf2.xlarge, ml.inf2.8xlarge, ml.inf2.24xlarge, ml.inf2.48xlarge]
 
 ## Provide default tolerations
 tolerations:
-  - operator: Exists
+- operator: Exists
 
 containerLogs:
   enabled: true
@@ -567,7 +567,7 @@ dcgmExporter:
       us-gov-east-1: 743662458514.dkr.ecr.us-gov-east-1.amazonaws.com
       us-gov-west-1: 743662458514.dkr.ecr.us-gov-west-1.amazonaws.com
   configmap: dcgm-exporter-config-map
-  arguments: [ "--web-config-file=/etc/dcgm-exporter/web-config.yaml" ]
+  arguments: ["--web-config-file=/etc/dcgm-exporter/web-config.yaml" ]
   service:
     enable: true
     type: ClusterIP
@@ -594,6 +594,6 @@ neuronMonitor:
     runAsNonRoot: false
     runAsUser: 0
     capabilities:
-      add: [ "SYS_ADMIN" ]
+      add: ["SYS_ADMIN"]
   serviceAccount:
     name: # override exporter service account name


### PR DESCRIPTION
*Issue #, if available:*
This pr fixes this issue: https://github.com/aws/amazon-cloudwatch-agent-operator/issues/183

The pr https://github.com/aws-observability/helm-charts/pull/41 added the default tolerations for all pod workloads installed by the EKS add-on, the CWA daemonset and fluent-bit daemonset now tolerate all taints ensuring they run on every single node on the cluster.

For clusters setup with a combination of managed node groups and fargate profiles, this causes pods to be brought up even on the fargate nodes even though there exists a taint on these nodes - which causes the daemonsets to never complete deployment and the add-on goes into a failed state.


This pr fixes this using node affinity and making sure that the any pod with key eks.amazonaws.com/compute-type and with the value: fargate, is not scheduled.

Why can't daemonset work on fargate nodes?

DaemonSets do not work on Fargate nodes because Fargate nodes are serverless. DaemonSets are designed to run a copy of a pod on every node in a Kubernetes cluster, but Fargate nodes do not have a fixed or consistent set of nodes like traditional EC2-based Kubernetes clusters. Since you cannot control or ensure the placement of pods on specific Fargate nodes, the fundamental requirement of DaemonSets to run on every node cannot be met.

*Description of changes:*

Tested changes by running:
`helm template amazon-cloudwatch-observability ./amazon-cloudwatch-observability  --include-crds --namespace amazon-cloudwatch --set clusterName=cloudwatchagent-operator-toleration-fargate --set region=us-east-1 | kubectl apply --namespace amazon-cloudwatch -f -`

Just adding this to the daemonsets to avoid getting scheduled on fargate nodes:

```
        affinity:
          nodeAffinity:
            requiredDuringSchedulingIgnoredDuringExecution:
              nodeSelectorTerms:
              - matchExpressions:
                - key: eks.amazonaws.com/compute-type
                  operator: NotIn
                  values:
                  - fargate
```

Fargate nodes have this taint: amazonaws.com/compute-type=fargate:NoSchedule, so the above affinity will block off any daemonset pods that are being scheduled on fargate nodes.



## Before and after bug fix 

### Before bug fix - pods are pending which results in eks addon failure

<img width="1728" alt="Screenshot 2024-07-01 at 4 27 59 PM" src="https://github.com/aws-observability/helm-charts/assets/50599809/998274d7-b758-4230-94b9-b5069465e457">


### After bug fix - all pods are running and eks addon status is active

<img width="1728" alt="Screenshot 2024-07-02 at 10 54 14 AM" src="https://github.com/aws-observability/helm-charts/assets/50599809/0080fc66-67ab-4b6b-a2a4-c8b17e861545">






### Picture of what was added to Cloudwatch-agent, dcgm exporter, fluent bit, and neuron monitor daemonset
<img width="1920" alt="Screenshot 2024-07-02 at 12 14 34 PM (2)" src="https://github.com/aws-observability/helm-charts/assets/50599809/7759e87f-a6d6-43c6-abe7-91d1c328d8c1">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

