### PR TITLE
Adding support for nodejs instrumentation

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
@@ -155,6 +155,13 @@ Get the current recommended auto instrumentation python image
 {{- end -}}
 
 {{/*
+Get the current recommended auto instrumentation nodejs image
+*/}}
+{{- define "auto-instrumentation-nodejs.image" -}}
+{{- printf "%s/%s:%s" .Values.manager.autoInstrumentationImage.nodejs.repositoryDomain .Values.manager.autoInstrumentationImage.nodejs.repository .Values.manager.autoInstrumentationImage.nodejs.tag -}}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "amazon-cloudwatch-observability.labels" -}}

--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -29,6 +29,7 @@ spec:
         - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}
         - "--auto-instrumentation-java-image={{ template "auto-instrumentation-java.image" . }}"
         - "--auto-instrumentation-python-image={{ template "auto-instrumentation-python.image" . }}"
+        - "--auto-instrumentation-nodejs-image={{ template "auto-instrumentation-nodejs.image" . }}"
         - "--feature-gates=operator.autoinstrumentation.multi-instrumentation,operator.autoinstrumentation.multi-instrumentation.skip-container-validation"
         command:
         - /manager

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -408,6 +408,10 @@ manager:
       repositoryDomain: public.ecr.aws/aws-observability
       repository: adot-autoinstrumentation-python
       tag: v0.2.0
+    nodejs:
+      repositoryDomain: ghcr.io/open-telemetry/opentelemetry-operator
+      repository: autoinstrumentation-nodejs
+      tag: 0.51.0
   autoAnnotateAutoInstrumentation:
     java:
       namespaces: [ ]
@@ -415,6 +419,11 @@ manager:
       daemonsets: [ ]
       statefulsets: [ ]
     python:
+      namespaces: [ ]
+      deployments: [ ]
+      daemonsets: [ ]
+      statefulsets: [ ]
+    nodejs:
       namespaces: [ ]
       deployments: [ ]
       daemonsets: [ ]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Add nodejs annotation to support the instrumentation in operator
2. Update helpers file to pick correct image for nodejs instrumentation SDK
3. Add instrumentation flag to operator

Tested as part of https://github.com/aws/amazon-cloudwatch-agent-operator/pull/191


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

