### PR TITLE
feat(helm:daemonsets): parametrize resources configuration using values

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml
@@ -44,13 +44,9 @@ spec:
   {{- else }}
   config: {{ include "cloudwatch-agent.modify-config" (merge (dict "Config" .Values.agent.defaultConfig) . ) }}
   {{- end }}
-  resources:
-    requests:
-      memory: "128Mi"
-      cpu: "250m"
-    limits:
-      memory: "512Mi"
-      cpu: "500m"
+  {{- with .Values.agent.resources }}
+  resources: {{- toYaml . | nindent 2}}
+  {{- end }}
   volumeMounts:
   - mountPath: /rootfs
     name: rootfs

--- a/charts/amazon-cloudwatch-observability/templates/linux/dcgm-exporter-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/dcgm-exporter-daemonset.yaml
@@ -23,13 +23,9 @@ spec:
                 operator: NotIn
                 values:
                   - fargate
-  resources:
-    requests:
-      cpu: 250m
-      memory: 128Mi
-    limits:
-      cpu: 500m
-      memory: 250Mi
+  {{- with .Values.dcgmExporter.resources }}
+  resources: {{- toYaml . | nindent 2}}
+  {{- end }}
   env:
   - name: "DCGM_EXPORTER_KUBERNETES"
     value: "true"

--- a/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
@@ -47,13 +47,9 @@ spec:
               fieldPath: metadata.name
         - name: CI_VERSION
           value: "k8s/1.3.17"
-        resources:
-          limits:
-            cpu: 500m
-            memory: 250Mi
-          requests:
-            cpu: 50m
-            memory: 25Mi
+        {{- with .Values.containerLogs.fluentBit.resources }}
+        resources: {{- toYaml . | nindent 6}}
+        {{- end }}
         volumeMounts:
         # Please don't change below read-only permissions
         - name: fluentbitstate

--- a/charts/amazon-cloudwatch-observability/templates/linux/neuron-monitor-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/neuron-monitor-daemonset.yaml
@@ -25,13 +25,9 @@ spec:
                 operator: NotIn
                 values:
                   - fargate
-  resources:
-    limits:
-      cpu: 500m
-      memory: 256Mi
-    requests:
-      cpu: 256m
-      memory: 128Mi
+  {{- with .Values.neuronMonitor.resources }}
+  resources: {{- toYaml . | nindent 2}}
+  {{- end }}
   env:
   - name: NODE_NAME
     valueFrom:

--- a/charts/amazon-cloudwatch-observability/templates/windows/cloudwatch-agent-windows-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/windows/cloudwatch-agent-windows-daemonset.yaml
@@ -19,13 +19,9 @@ spec:
   nodeSelector:
     kubernetes.io/os: windows
   config: {{ .Values.agent.windowsDefaultConfig | toJson | quote }}
-  resources:
-    requests:
-      memory: "128Mi"
-      cpu: "250m"
-    limits:
-      memory: "512Mi"
-      cpu: "500m"
+  {{- with .Values.agent.resources }}
+  resources: {{- toYaml . | nindent 2}}
+  {{- end }}
   env:
   - name: K8S_NODE_NAME
     valueFrom:

--- a/charts/amazon-cloudwatch-observability/templates/windows/fluent-bit-windows-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/windows/fluent-bit-windows-daemonset.yaml
@@ -53,13 +53,9 @@ spec:
               fieldPath: metadata.name
         - name: CI_VERSION
           value: "k8s/1.3.17"
-        resources:
-          limits:
-            cpu: 500m
-            memory: 600Mi
-          requests:
-            cpu: 300m
-            memory: 300Mi
+        {{- with .Values.containerLogs.fluentBit.resources }}
+        resources: {{- toYaml . | nindent 6}}
+        {{- end }}
         volumeMounts:
           - name: fluent-bit-config
             mountPath: fluent-bit\configuration\

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -43,6 +43,13 @@ containerLogs:
         cn-northwest-1: 128054284489.dkr.ecr.cn-northwest-1.amazonaws.com.cn
         us-gov-east-1: 161423150738.dkr.ecr.us-gov-east-1.amazonaws.com
         us-gov-west-1: 161423150738.dkr.ecr.us-gov-west-1.amazonaws.com
+    resources:
+      limits:
+        cpu: 500m
+        memory: 250Mi
+      requests:
+        cpu: 50m
+        memory: 25Mi
     config:
       service: |
         [SERVICE]
@@ -506,6 +513,13 @@ agent:
       us-gov-east-1: 743662458514.dkr.ecr.us-gov-east-1.amazonaws.com
       us-gov-west-1: 743662458514.dkr.ecr.us-gov-west-1.amazonaws.com
   enabled: true
+  resources:
+    requests:
+      memory: "128Mi"
+      cpu: "250m"
+    limits:
+      memory: "512Mi"
+      cpu: "500m"
   ## TLS Certificate Option 1: Use Helm to automatically generate self-signed certificate.
   ## autoGenerateCert must be enabled. This is the default option.
   ## If true, Helm will automatically create a self-signed cert and secret for you.
@@ -566,6 +580,13 @@ dcgmExporter:
       cn-northwest-1: 934860584483.dkr.ecr.cn-northwest-1.amazonaws.com.cn
       us-gov-east-1: 743662458514.dkr.ecr.us-gov-east-1.amazonaws.com
       us-gov-west-1: 743662458514.dkr.ecr.us-gov-west-1.amazonaws.com
+  resources:
+    requests:
+      cpu: 250m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 250Mi
   configmap: dcgm-exporter-config-map
   arguments: ["--web-config-file=/etc/dcgm-exporter/web-config.yaml" ]
   service:
@@ -584,6 +605,13 @@ neuronMonitor:
     tag: 1.0.1
     repositoryDomainMap:
       public: public.ecr.aws/neuron
+  resources:
+    limits:
+      cpu: 500m
+      memory: 256Mi
+    requests:
+      cpu: 256m
+      memory: 128Mi
   configmap: neuron-monitor-config-map
   service:
     enable: true


### PR DESCRIPTION
resolves:
#62 
#61 

Introduced resources fields to `values.yaml` and replaced hardcoded daemonsets resources. Hardcoded resources prevented users from capacity customization.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

