### PR TITLE
Add .NET auto instrumentation

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
@@ -155,6 +155,13 @@ Get the current recommended auto instrumentation python image
 {{- end -}}
 
 {{/*
+Get the current recommended auto instrumentation .net image
+*/}}
+{{- define "auto-instrumentation-dotnet.image" -}}
+{{- printf "%s/%s:%s" .Values.manager.autoInstrumentationImage.dotnet.repositoryDomain .Values.manager.autoInstrumentationImage.dotnet.repository .Values.manager.autoInstrumentationImage.dotnet.tag -}}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "amazon-cloudwatch-observability.labels" -}}

--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -29,6 +29,7 @@ spec:
         - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}
         - "--auto-instrumentation-java-image={{ template "auto-instrumentation-java.image" . }}"
         - "--auto-instrumentation-python-image={{ template "auto-instrumentation-python.image" . }}"
+        - "--auto-instrumentation-dotnet-image={{ template "auto-instrumentation-dotnet.image" . }}"
         - "--feature-gates=operator.autoinstrumentation.multi-instrumentation,operator.autoinstrumentation.multi-instrumentation.skip-container-validation"
         command:
         - /manager

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -417,7 +417,7 @@ manager:
     dotnet:
       repositoryDomain: public.ecr.aws/aws-observability
       repository: adot-autoinstrumentation-dotnet
-      tag: v0.1.0
+      tag: v1.1.0
   autoAnnotateAutoInstrumentation:
     java:
       namespaces: [ ]

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -8,9 +8,6 @@ replicaCount: 1
 ##
 nameOverride: ""
 
-## Reference one or more secrets to be used when pulling images from authenticated repositories.
-imagePullSecrets: [ ]
-
 ## Provide the ClusterName (this is a required parameter)
 clusterName:
 
@@ -410,6 +407,10 @@ manager:
       repositoryDomain: public.ecr.aws/aws-observability
       repository: adot-autoinstrumentation-python
       tag: v0.2.0
+    dotnet:
+      repositoryDomain: public.ecr.aws/aws-observability
+      repository: adot-autoinstrumentation-dotnet
+      tag: v0.0.0
   autoAnnotateAutoInstrumentation:
     java:
       namespaces: [ ]
@@ -417,6 +418,11 @@ manager:
       daemonsets: [ ]
       statefulsets: [ ]
     python:
+      namespaces: [ ]
+      deployments: [ ]
+      daemonsets: [ ]
+      statefulsets: [ ]
+    dotnet:
       namespaces: [ ]
       deployments: [ ]
       daemonsets: [ ]

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -398,7 +398,7 @@ manager:
   name:
   image:
     repository: cloudwatch-agent-operator
-    tag: 1.4.1
+    tag: 1.5.0
     repositoryDomainMap:
       public: public.ecr.aws/cloudwatch-agent
       cn-north-1: 934860584483.dkr.ecr.cn-north-1.amazonaws.com.cn


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Add the .NET auto instrumentation sdk to the cloudwatch agent operator as a command argument [PR](https://github.com/aws/amazon-cloudwatch-agent-operator/pull/193)

Uses `public.ecr.aws/aws-observability/adot-autoinstrumentation-dotnet:v1.1.0`

Also removes unused `imagePullSecrets` parameter in values.yaml

Helm integration tests pass after building the latest commit on the operator: https://github.com/aws-observability/helm-charts/actions/runs/9963070189


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

