### PR TITLE
Allow configurable resource requests and limits through command arguments.

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
       - image: {{ template "cloudwatch-agent-operator.image" . }}
         args:
-        - {{ printf "--auto-instrumentation-config=%s" (dict "java" (.Values.manager.autoInstrumentationImage.java.resources) "python" (.Values.manager.autoInstrumentationImage.python.resources) | toJson) | quote }}
+        - {{ printf "--auto-instrumentation-config=%s" (dict "java" (.Values.manager.autoInstrumentationImage.java.resources) "python" (.Values.manager.autoInstrumentationImage.python.resources) "dotnet" (.Values.manager.autoInstrumentationImage.dotnet.resources) | toJson) | quote }}
         - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}
         - "--auto-instrumentation-java-image={{ template "auto-instrumentation-java.image" . }}"
         - "--auto-instrumentation-python-image={{ template "auto-instrumentation-python.image" . }}"

--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -55,3 +55,4 @@ spec:
       {{- with .Values.tolerations }}
       tolerations: {{- toYaml . | nindent 6}}
       {{- end }}
+

--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         {{- include "amazon-cloudwatch-observability.podLabels" . | nindent 8 }}
     spec:
       containers:
-      - image: public.ecr.aws/o5o6y1v9/cloudwatch-agent-operator:latest
+      - image: {{ template "cloudwatch-agent-operator.image" . }}
         args:
         - {{ printf "--auto-instrumentation-config=%s" (dict "java" (.Values.manager.autoInstrumentationImage.java.resources) "python" (.Values.manager.autoInstrumentationImage.python.resources) | toJson) | quote }}
         - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}

--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
       - image: {{ template "cloudwatch-agent-operator.image" . }}
         args:
-        - {{ printf "--auto-instrumentation-config=%s" (.Values.initContainers.resources.limits | toJson) | quote }}
+        - {{ printf "--auto-instrumentation-config=%s" (.Values.manager.autoInstrumentationResources.limits | toJson) | quote }}
         - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}
         - "--auto-instrumentation-java-image={{ template "auto-instrumentation-java.image" . }}"
         - "--auto-instrumentation-python-image={{ template "auto-instrumentation-python.image" . }}"

--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -26,7 +26,6 @@ spec:
       containers:
       - image: {{ template "cloudwatch-agent-operator.image" . }}
         args:
-        - {{ printf "--auto-instrumentation-config=%s" (.Values.manager.autoInstrumentationResources.limits | toJson) | quote }}
         - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}
         - "--auto-instrumentation-java-image={{ template "auto-instrumentation-java.image" . }}"
         - "--auto-instrumentation-python-image={{ template "auto-instrumentation-python.image" . }}"

--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         {{- include "amazon-cloudwatch-observability.podLabels" . | nindent 8 }}
     spec:
       containers:
-      - image: {{ template "cloudwatch-agent-operator.image" . }}
+      - image: public.ecr.aws/o5o6y1v9/cloudwatch-agent-operator:latest
         args:
         - {{ printf "--auto-instrumentation-config=%s" (dict "java" (.Values.manager.autoInstrumentationImage.java.resources) "python" (.Values.manager.autoInstrumentationImage.python.resources) | toJson) | quote }}
         - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}

--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
       - image: {{ template "cloudwatch-agent-operator.image" . }}
         args:
-        - {{ printf "--auto-instrumentation-config=%s" (.Values.manager.autoInstrumentationResources.limits | toJson) | quote }}
+        - {{ printf "--auto-instrumentation-config=%s" (dict "java" (.Values.manager.autoInstrumentationImage.java.resources.limits) "python" (.Values.manager.autoInstrumentationImage.python.resources.limits) | toJson) | quote }}
         - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}
         - "--auto-instrumentation-java-image={{ template "auto-instrumentation-java.image" . }}"
         - "--auto-instrumentation-python-image={{ template "auto-instrumentation-python.image" . }}"

--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -26,6 +26,7 @@ spec:
       containers:
       - image: {{ template "cloudwatch-agent-operator.image" . }}
         args:
+        - {{ printf "--auto-instrumentation-config=%s" (.Values.initContainers.resources.limits | toJson) | quote }}
         - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}
         - "--auto-instrumentation-java-image={{ template "auto-instrumentation-java.image" . }}"
         - "--auto-instrumentation-python-image={{ template "auto-instrumentation-python.image" . }}"

--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -26,6 +26,7 @@ spec:
       containers:
       - image: {{ template "cloudwatch-agent-operator.image" . }}
         args:
+        - {{ printf "--auto-instrumentation-config=%s" (.Values.manager.autoInstrumentationResources.limits | toJson) | quote }}
         - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}
         - "--auto-instrumentation-java-image={{ template "auto-instrumentation-java.image" . }}"
         - "--auto-instrumentation-python-image={{ template "auto-instrumentation-python.image" . }}"

--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -55,4 +55,3 @@ spec:
       {{- with .Values.tolerations }}
       tolerations: {{- toYaml . | nindent 6}}
       {{- end }}
-

--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
       - image: {{ template "cloudwatch-agent-operator.image" . }}
         args:
-        - {{ printf "--auto-instrumentation-config=%s" (dict "java" (.Values.manager.autoInstrumentationImage.java.resources) "python" (.Values.manager.autoInstrumentationImage.python.resources) "dotnet" (.Values.manager.autoInstrumentationImage.dotnet.resources) | toJson) | quote }}
+        - {{ printf "--auto-instrumentation-config=%s" (dict "java" (.Values.manager.autoInstrumentationImage.java.resources) "python" (.Values.manager.autoInstrumentationImage.python.resources) | toJson) | quote }}
         - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}
         - "--auto-instrumentation-java-image={{ template "auto-instrumentation-java.image" . }}"
         - "--auto-instrumentation-python-image={{ template "auto-instrumentation-python.image" . }}"

--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
       - image: {{ template "cloudwatch-agent-operator.image" . }}
         args:
-        - {{ printf "--auto-instrumentation-config=%s" (dict "java" (.Values.manager.autoInstrumentationImage.java.resources.limits) "python" (.Values.manager.autoInstrumentationImage.python.resources.limits) | toJson) | quote }}
+        - {{ printf "--auto-instrumentation-config=%s" (dict "java" (.Values.manager.autoInstrumentationImage.java.resources) "python" (.Values.manager.autoInstrumentationImage.python.resources) | toJson) | quote }}
         - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}
         - "--auto-instrumentation-java-image={{ template "auto-instrumentation-java.image" . }}"
         - "--auto-instrumentation-python-image={{ template "auto-instrumentation-python.image" . }}"

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -415,22 +415,22 @@ manager:
       tag: v1.32.3
       resources:
         requests:
-          memory: "50m"
-          cpu: "64Mi"
+          memory: "64Mi"
+          cpu: "50m"
         limits:
-          memory: "500m"
-          cpu: "64Mi"
+          memory: "64Mi"
+          cpu: "500m"
     python:
       repositoryDomain: public.ecr.aws/aws-observability
       repository: adot-autoinstrumentation-python
       tag: v0.3.0
       resources:
         requests:
-          memory: "50m"
-          cpu: "32Mi"
+          memory: "32Mi"
+          cpu: "50m"
         limits:
-          memory: "500m"
-          cpu: "32Mi"
+          memory: "32Mi"
+          cpu: "500m"
   autoAnnotateAutoInstrumentation:
     java:
       namespaces: [ ]

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -446,6 +446,13 @@ manager:
   service:
     name:
 
+## Default resource limits for init containers.
+initContainers:
+  resources:
+    limits:
+      cpu: 100m
+      memory: 64Mi
+
 ## Admission webhooks make sure only requests with correctly formatted rules will get into the Operator.
 admissionWebhooks:
   create: true

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -398,7 +398,7 @@ manager:
   name:
   image:
     repository: cloudwatch-agent-operator
-    tag: 1.5.0
+    tag: 1.6.0
     repositoryDomainMap:
       public: public.ecr.aws/cloudwatch-agent
       cn-north-1: 934860584483.dkr.ecr.cn-north-1.amazonaws.com.cn

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -408,10 +408,6 @@ manager:
       cn-northwest-1: 934860584483.dkr.ecr.cn-northwest-1.amazonaws.com.cn
       us-gov-east-1: 743662458514.dkr.ecr.us-gov-east-1.amazonaws.com
       us-gov-west-1: 743662458514.dkr.ecr.us-gov-west-1.amazonaws.com
-  autoInstrumentationResources:
-    limits:
-      cpu: ""
-      memory: ""
   autoInstrumentationImage:
     java:
       repositoryDomain: public.ecr.aws/aws-observability

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -408,6 +408,10 @@ manager:
       cn-northwest-1: 934860584483.dkr.ecr.cn-northwest-1.amazonaws.com.cn
       us-gov-east-1: 743662458514.dkr.ecr.us-gov-east-1.amazonaws.com
       us-gov-west-1: 743662458514.dkr.ecr.us-gov-west-1.amazonaws.com
+  autoInstrumentationResources:
+    limits:
+      cpu: ""
+      memory: ""
   autoInstrumentationImage:
     java:
       repositoryDomain: public.ecr.aws/aws-observability

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -410,8 +410,12 @@ manager:
       us-gov-west-1: 743662458514.dkr.ecr.us-gov-west-1.amazonaws.com
   autoInstrumentationResources:
     limits:
-      cpu: ""
-      memory: ""
+      java:
+        cpu: ""
+        memory: ""
+      python:
+        cpu: ""
+        memory: ""
   autoInstrumentationImage:
     java:
       repositoryDomain: public.ecr.aws/aws-observability

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -408,23 +408,23 @@ manager:
       cn-northwest-1: 934860584483.dkr.ecr.cn-northwest-1.amazonaws.com.cn
       us-gov-east-1: 743662458514.dkr.ecr.us-gov-east-1.amazonaws.com
       us-gov-west-1: 743662458514.dkr.ecr.us-gov-west-1.amazonaws.com
-  autoInstrumentationResources:
-    limits:
-      java:
-        cpu: ""
-        memory: ""
-      python:
-        cpu: ""
-        memory: ""
   autoInstrumentationImage:
     java:
       repositoryDomain: public.ecr.aws/aws-observability
       repository: adot-autoinstrumentation-java
       tag: v1.32.3
+      resources:
+        limits:
+          memory: "500m"
+          cpu: "64Mi"
     python:
       repositoryDomain: public.ecr.aws/aws-observability
       repository: adot-autoinstrumentation-python
       tag: v0.3.0
+      resources:
+        limits:
+          memory: "500m"
+          cpu: "32Mi"
   autoAnnotateAutoInstrumentation:
     java:
       namespaces: [ ]

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -414,6 +414,9 @@ manager:
       repository: adot-autoinstrumentation-java
       tag: v1.32.3
       resources:
+        requests:
+          memory: "50m"
+          cpu: "64Mi"
         limits:
           memory: "500m"
           cpu: "64Mi"
@@ -422,6 +425,9 @@ manager:
       repository: adot-autoinstrumentation-python
       tag: v0.3.0
       resources:
+        requests:
+          memory: "50m"
+          cpu: "32Mi"
         limits:
           memory: "500m"
           cpu: "32Mi"

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -401,6 +401,10 @@ manager:
       cn-northwest-1: 934860584483.dkr.ecr.cn-northwest-1.amazonaws.com.cn
       us-gov-east-1: 743662458514.dkr.ecr.us-gov-east-1.amazonaws.com
       us-gov-west-1: 743662458514.dkr.ecr.us-gov-west-1.amazonaws.com
+  autoInstrumentationResources:
+    limits:
+      cpu: ""
+      memory: ""
   autoInstrumentationImage:
     java:
       repositoryDomain: public.ecr.aws/aws-observability
@@ -445,13 +449,6 @@ manager:
 
   service:
     name:
-
-## Default resource limits for init containers.
-initContainers:
-  resources:
-    limits:
-      cpu: 100m
-      memory: 64Mi
 
 ## Admission webhooks make sure only requests with correctly formatted rules will get into the Operator.
 admissionWebhooks:

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -414,22 +414,22 @@ manager:
       repository: adot-autoinstrumentation-java
       tag: v1.32.3
       resources:
-        requests:
-          cpu: "50m"
-          memory: "64Mi"
         limits:
           cpu: "500m"
+          memory: "64Mi"
+        requests:
+          cpu: "50m"
           memory: "64Mi"
     python:
       repositoryDomain: public.ecr.aws/aws-observability
       repository: adot-autoinstrumentation-python
       tag: v0.3.0
       resources:
-        requests:
-          cpu: "50m"
-          memory: "32Mi"
         limits:
           cpu: "500m"
+          memory: "32Mi"
+        requests:
+          cpu: "50m"
           memory: "32Mi"
   autoAnnotateAutoInstrumentation:
     java:

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -415,22 +415,22 @@ manager:
       tag: v1.32.3
       resources:
         requests:
-          memory: "64Mi"
           cpu: "50m"
-        limits:
           memory: "64Mi"
+        limits:
           cpu: "500m"
+          memory: "64Mi"
     python:
       repositoryDomain: public.ecr.aws/aws-observability
       repository: adot-autoinstrumentation-python
       tag: v0.3.0
       resources:
         requests:
-          memory: "32Mi"
           cpu: "50m"
-        limits:
           memory: "32Mi"
+        limits:
           cpu: "500m"
+          memory: "32Mi"
   autoAnnotateAutoInstrumentation:
     java:
       namespaces: [ ]


### PR DESCRIPTION
*Description of changes:*
Allow configurable resource limits through command arguments so operator can take these values and use them for init containers.

*Testing:*
See https://github.com/aws/amazon-cloudwatch-agent-operator/pull/196.

1. With these local helm chart changes, I ran `helm upgrade --install amazon-cloudwatch-observability helm-charts/charts/amazon-cloudwatch-observability --values helm-charts/charts/amazon-cloudwatch-observability/values.yaml --set clusterName=cloudwatchagent-operator --set region=us-west-2`.
2. Then, ran `kubectl get pods`.
3. Then, ran `kubectl describe pod amazon-cloudwatch-observability-controller-manager-####`.

As we can see, it has the new operator image and command arguments.
<img width="666" alt="Screenshot 2024-08-09 at 3 53 26 PM" src="https://github.com/user-attachments/assets/327b8703-175c-455d-8cd9-a4b7ea77d532">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

