### PR TITLE
[DO NOT MERGE] update dcgm image to the latest and fix dcgm pod crashing with OOM

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/linux/dcgm-exporter-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/dcgm-exporter-daemonset.yaml
@@ -29,7 +29,7 @@ spec:
       memory: 128Mi
     limits:
       cpu: 500m
-      memory: 250Mi
+      memory: 500Mi
   env:
   - name: "DCGM_EXPORTER_KUBERNETES"
     value: "true"

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -559,7 +559,7 @@ dcgmExporter:
   name:
   image:
     repository: dcgm-exporter
-    tag: 3.3.3-3.3.1-ubuntu22.04
+    tag: 3.3.6-3.4.2-ubuntu22.04
     repositoryDomainMap:
       public: nvcr.io/nvidia/k8s
       cn-north-1: 934860584483.dkr.ecr.cn-north-1.amazonaws.com.cn


### PR DESCRIPTION
*Description of changes:*
- Update the DCGM Exporter image to the latest version `3.3.6-3.4.2-ubuntu22.04`
- Increase the memory limit to 500MB for DCGM Exporter daemonset to fix OOM crashing issue (ExitCode 137)

Observing the memory consumption by DCGM pods with a mixed combination of nodes of different sizes (g4dn.12xl, g5.12xl, p3-16xl, p3-8xl and p3-2xl), memory utilizations seem to stabilize around ~230MB with the latest DCGM exporter image. 
```
kubectl top pods -n amazon-cloudwatch --sort-by memory | grep dcgm | head -10
dcgm-exporter-bhpnz                                               1m           230Mi
dcgm-exporter-gw7gc                                               1m           229Mi
dcgm-exporter-jfgzx                                               1m           229Mi
dcgm-exporter-vmv2x                                               1m           229Mi
dcgm-exporter-x792q                                               1m           228Mi
dcgm-exporter-5pfcn                                               1m           228Mi
dcgm-exporter-d6kv7                                               1m           228Mi
dcgm-exporter-7s28r                                               2m           228Mi
dcgm-exporter-6vn76                                               2m           228Mi
dcgm-exporter-b269q                                               4m           228Mi
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

