### PR TITLE
fix indentations for resources blocks and bump up memory limit for DCGM

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml
@@ -45,7 +45,7 @@ spec:
   config: {{ include "cloudwatch-agent.modify-config" (merge (dict "Config" .Values.agent.defaultConfig) . ) }}
   {{- end }}
   {{- with .Values.agent.resources }}
-  resources: {{- toYaml . | nindent 2}}
+  resources: {{- toYaml . | nindent 4}}
   {{- end }}
   volumeMounts:
   - mountPath: /rootfs

--- a/charts/amazon-cloudwatch-observability/templates/linux/dcgm-exporter-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/dcgm-exporter-daemonset.yaml
@@ -24,7 +24,7 @@ spec:
                 values:
                   - fargate
   {{- with .Values.dcgmExporter.resources }}
-  resources: {{- toYaml . | nindent 2}}
+  resources: {{- toYaml . | nindent 4}}
   {{- end }}
   env:
   - name: "DCGM_EXPORTER_KUBERNETES"

--- a/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
@@ -48,7 +48,7 @@ spec:
         - name: CI_VERSION
           value: "k8s/1.3.17"
         {{- with .Values.containerLogs.fluentBit.resources }}
-        resources: {{- toYaml . | nindent 6}}
+        resources: {{- toYaml . | nindent 10}}
         {{- end }}
         volumeMounts:
         # Please don't change below read-only permissions

--- a/charts/amazon-cloudwatch-observability/templates/linux/neuron-monitor-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/neuron-monitor-daemonset.yaml
@@ -26,7 +26,7 @@ spec:
                 values:
                   - fargate
   {{- with .Values.neuronMonitor.resources }}
-  resources: {{- toYaml . | nindent 2}}
+  resources: {{- toYaml . | nindent 4}}
   {{- end }}
   env:
   - name: NODE_NAME

--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -37,7 +37,7 @@ spec:
         - containerPort: {{ .Values.manager.ports.containerPort }}
           name: webhook-server
           protocol: TCP
-        resources: {{ toYaml .Values.manager.resources | nindent 12 }}
+        resources: {{ toYaml .Values.manager.resources | nindent 10 }}
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert

--- a/charts/amazon-cloudwatch-observability/templates/windows/cloudwatch-agent-windows-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/windows/cloudwatch-agent-windows-daemonset.yaml
@@ -20,7 +20,7 @@ spec:
     kubernetes.io/os: windows
   config: {{ .Values.agent.windowsDefaultConfig | toJson | quote }}
   {{- with .Values.agent.resources }}
-  resources: {{- toYaml . | nindent 2}}
+  resources: {{- toYaml . | nindent 4}}
   {{- end }}
   env:
   - name: K8S_NODE_NAME

--- a/charts/amazon-cloudwatch-observability/templates/windows/fluent-bit-windows-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/windows/fluent-bit-windows-daemonset.yaml
@@ -54,7 +54,7 @@ spec:
         - name: CI_VERSION
           value: "k8s/1.3.17"
         {{- with .Values.containerLogs.fluentBit.resources }}
-        resources: {{- toYaml . | nindent 6}}
+        resources: {{- toYaml . | nindent 10}}
         {{- end }}
         volumeMounts:
           - name: fluent-bit-config

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -586,7 +586,7 @@ dcgmExporter:
       memory: 128Mi
     limits:
       cpu: 500m
-      memory: 250Mi
+      memory: 500Mi
   configmap: dcgm-exporter-config-map
   arguments: ["--web-config-file=/etc/dcgm-exporter/web-config.yaml" ]
   service:


### PR DESCRIPTION
*Issue #, if available:*
- Wrong indentation values are used for resources blocks causing `unknown fields` errors
```
helm install --wait --create-namespace --namespace amazon-cloudwatch amazon-cloudwatch ./charts/amazon-cloudwatch-observability --set clusterName=test-cluster --set region=us-west-2
W0719 10:36:54.976442   16872 warnings.go:70] unknown field "spec.template.spec.limits"
W0719 10:36:54.976470   16872 warnings.go:70] unknown field "spec.template.spec.requests"
W0719 10:36:54.977537   16872 warnings.go:70] unknown field "spec.template.spec.limits"
W0719 10:36:54.977553   16872 warnings.go:70] unknown field "spec.template.spec.requests"
W0719 10:36:55.237276   16872 warnings.go:70] unknown field "spec.limits"
W0719 10:36:55.237315   16872 warnings.go:70] unknown field "spec.requests"
W0719 10:36:55.239300   16872 warnings.go:70] unknown field "spec.limits"
W0719 10:36:55.239323   16872 warnings.go:70] unknown field "spec.requests"
W0719 10:36:55.433433   16872 warnings.go:70] unknown field "spec.limits"
W0719 10:36:55.433460   16872 warnings.go:70] unknown field "spec.requests"
W0719 10:36:55.610348   16872 warnings.go:70] unknown field "spec.limits"
W0719 10:36:55.610372   16872 warnings.go:70] unknown field "spec.requests"
```

- Crashing DCGM pods with OOM (ExitCode 137) with the default memory limit of 250Mi

*Description of changes:*
- Fix indentation values used with `nindent` 
- Increase the default memory limit to 500Mi for DCGM Exporter container

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

