### PR TITLE
feat(fluent-bit): set system-node-critical as a default priorityClass

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml
@@ -30,6 +30,7 @@ spec:
   nodeSelector:
     kubernetes.io/os: linux
   serviceAccount: {{ template "cloudwatch-agent.serviceAccountName" . }}
+  priorityClassName: {{ .Values.agent.priorityClassName }}
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
@@ -71,6 +71,7 @@ spec:
       terminationGracePeriodSeconds: 10
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
+      priorityClassName: {{ .Values.containerLogs.fluentBit.priorityClassName }}
       volumes:
       - name: fluentbitstate
         hostPath:

--- a/charts/amazon-cloudwatch-observability/templates/windows/cloudwatch-agent-windows-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/windows/cloudwatch-agent-windows-daemonset.yaml
@@ -16,6 +16,7 @@ spec:
   workingDir: "%CONTAINER_SANDBOX_MOUNT_POINT%\\Program Files\\Amazon\\AmazonCloudWatchAgent"
   mode: daemonset
   serviceAccount: {{ template "cloudwatch-agent.serviceAccountName" . }}
+  priorityClassName: {{ .Values.agent.priorityClassName }}
   nodeSelector:
     kubernetes.io/os: windows
   config: {{ .Values.agent.windowsDefaultConfig | toJson | quote }}

--- a/charts/amazon-cloudwatch-observability/templates/windows/fluent-bit-windows-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/windows/fluent-bit-windows-daemonset.yaml
@@ -28,6 +28,7 @@ spec:
           hostProcess: true
           runAsUserName: "NT AUTHORITY\\System"
       hostNetwork: true
+      priorityClassName: {{ .Values.containerLogs.fluentBit.priorityClassName }}
       nodeSelector:
         kubernetes.io/os: windows
       containers:

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -50,7 +50,7 @@ containerLogs:
       requests:
         cpu: 50m
         memory: 25Mi
-    priorityClassName: system-node-critical
+    priorityClassName: ""
     config:
       service: |
         [SERVICE]

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -514,6 +514,7 @@ agent:
       us-gov-east-1: 743662458514.dkr.ecr.us-gov-east-1.amazonaws.com
       us-gov-west-1: 743662458514.dkr.ecr.us-gov-west-1.amazonaws.com
   enabled: true
+  priorityClassName: ""
   resources:
     requests:
       memory: "128Mi"

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -50,6 +50,7 @@ containerLogs:
       requests:
         cpu: 50m
         memory: 25Mi
+    priorityClassName: system-node-critical
     config:
       service: |
         [SERVICE]


### PR DESCRIPTION
Issues:
#54 

In Kubernetes there is a good practice to specify a `system-node-critical` priority class for monitoring agents running as daemonsets.

ref: https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

