### PR TITLE
Updating Linux fluent-bit image to the latest

### DIFF
--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -32,7 +32,7 @@ containerLogs:
   fluentBit:
     image:
       repository: aws-for-fluent-bit
-      tag: 2.32.0.20240304
+      tag: 2.32.2.20240627
       tagWindows: 2.31.12-windowsservercore
       repositoryDomainMap:
         public: public.ecr.aws/aws-observability


### PR DESCRIPTION
*Description of changes:*
the latest version for aws-for-fluent-bit mitigates the following CVEs  - 
[ALAS-2024-2519](https://alas.aws.amazon.com/AL2/ALAS-2024-2519.html),  [ALAS-2024-2521](https://alas.aws.amazon.com/AL2/ALAS-2024-2521.html), [ALAS-2024-2523](https://alas.aws.amazon.com/AL2/ALAS-2024-2523.html).

the latest image tag is taken from https://gallery.ecr.aws/aws-observability/aws-for-fluent-bit for LInux only
the latest images for Windows is unchanged


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

