### PR TITLE
Fix syntax issue with .net template

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
@@ -155,7 +155,7 @@ Get the current recommended auto instrumentation python image
 {{- end -}}
 
 {{/*
-Get the current recommended auto instrumentation .net image
+Get the current recommended auto instrumentation dotnet image
 */}}
 {{- define "auto-instrumentation-dotnet.image" -}}
 {{- printf "%s/%s:%s" .Values.manager.autoInstrumentationImage.dotnet.repositoryDomain .Values.manager.autoInstrumentationImage.dotnet.repository .Values.manager.autoInstrumentationImage.dotnet.tag -}}


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
Using the dot character "." is not escaped in helm templates, causing issues. Using "dotnet" instead of ".net" resolves the issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

