### PR TITLE
Allow Annotations on ServiceAccounts and Conditional Creation

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
@@ -192,6 +192,15 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Set the Annotations for operator ServiceAccount
+*/}}
+{{- define "amazon-cloudwatch-observability.serviceAccountAnnotations" -}}
+{{- if .Values.manager.serviceAccount.annotations }}
+{{- .Values.manager.serviceAccount.annotations | toYaml }}
+{{- end }}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "cloudwatch-agent.serviceAccountName" -}}
@@ -199,6 +208,15 @@ Create the name of the service account to use
 {{- default (include "cloudwatch-agent.name" .) .Values.agent.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.agent.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Set the Annotations for cloudwatch-agent ServiceAccount
+*/}}
+{{- define "cloudwatch-agent.serviceAccountAnnotations" -}}
+{{- if .Values.agent.serviceAccount.annotations }}
+{{- .Values.agent.serviceAccount.annotations | toYaml }}
 {{- end }}
 {{- end }}
 

--- a/charts/amazon-cloudwatch-observability/templates/cloudwatch-agent-serviceaccount.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/cloudwatch-agent-serviceaccount.yaml
@@ -4,4 +4,6 @@ kind: ServiceAccount
 metadata:
   name: {{ template "cloudwatch-agent.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "cloudwatch-agent.serviceAccountAnnotations" . | nindent 4}}
 {{- end }}

--- a/charts/amazon-cloudwatch-observability/templates/operator-serviceaccount.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.manager.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -5,3 +6,6 @@ metadata:
     {{- include "amazon-cloudwatch-observability.labels" . | nindent 4}}
   name: {{ template "amazon-cloudwatch-observability.managerServiceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "amazon-cloudwatch-observability.serviceAccountAnnotations" . | nindent 4}}
+{{- end }}

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -547,6 +547,7 @@ agent:
     issuerAnnotations: { }
   serviceAccount:
     name: # override agent service account name
+    annotations: { } # optional annotations for the service account
   config: # optional config that can be provided to override the defaultConfig
   defaultConfig:
     {


### PR DESCRIPTION
*Description of changes:*

For the operator ServiceAccount, the configuration for 'create' and 'annotations' were present in the values file, but not evaluated in the template.

For the agent ServiceAccount, added the 'annotations' configuration in both the template and the values file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

