### PR TITLE
Bump CloudWatchAgentOperator: 1.5.0 -> 1.6.0

### DIFF
--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -398,7 +398,7 @@ manager:
   name:
   image:
     repository: cloudwatch-agent-operator
-    tag: 1.5.0
+    tag: 1.6.0
     repositoryDomainMap:
       public: public.ecr.aws/cloudwatch-agent
       cn-north-1: 934860584483.dkr.ecr.cn-north-1.amazonaws.com.cn


### PR DESCRIPTION
*Description of changes:* Incrementing CloudWatchAgentOperator version to pull in https://github.com/aws/amazon-cloudwatch-agent-operator/pull/196.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

