### PR TITLE
Made helm format more intuitive for auto-instrumentation resources values.

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
       - image: {{ template "cloudwatch-agent-operator.image" . }}
         args:
-        - {{ printf "--auto-instrumentation-config=%s" (dict "java" (.Values.manager.autoInstrumentationImage.java.resources) "python" (.Values.manager.autoInstrumentationImage.python.resources) "dotnet" (.Values.manager.autoInstrumentationImage.dotnet.resources) | toJson) | quote }}
+        - {{ printf "--auto-instrumentation-config=%s" (dict "java" (.Values.manager.autoInstrumentationResources.java.resources) "python" (.Values.manager.autoInstrumentationResources.python.resources) "dotnet" (.Values.manager.autoInstrumentationResources.dotnet.resources) | toJson) | quote }}
         - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}
         - "--auto-instrumentation-java-image={{ template "auto-instrumentation-java.image" . }}"
         - "--auto-instrumentation-python-image={{ template "auto-instrumentation-python.image" . }}"

--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
       - image: {{ template "cloudwatch-agent-operator.image" . }}
         args:
-        - {{ printf "--auto-instrumentation-config=%s" (dict "java" (.Values.manager.autoInstrumentationResources.java.resources) "python" (.Values.manager.autoInstrumentationResources.python.resources) "dotnet" (.Values.manager.autoInstrumentationResources.dotnet.resources) | toJson) | quote }}
+        - {{ printf "--auto-instrumentation-config=%s" (dict "java" (.Values.manager.autoInstrumentationResources.java) "python" (.Values.manager.autoInstrumentationResources.python) "dotnet" (.Values.manager.autoInstrumentationResources.dotnet) | toJson) | quote }}
         - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}
         - "--auto-instrumentation-java-image={{ template "auto-instrumentation-java.image" . }}"
         - "--auto-instrumentation-python-image={{ template "auto-instrumentation-python.image" . }}"

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -420,29 +420,26 @@ manager:
       tag: v1.1.0
   autoInstrumentationResources:
     java:
-      resources:
-        limits:
-          cpu: "500m"
-          memory: "64Mi"
-        requests:
-          cpu: "50m"
-          memory: "64Mi"
+      limits:
+        cpu: "500m"
+        memory: "64Mi"
+      requests:
+        cpu: "50m"
+        memory: "64Mi"
     python:
-      resources:
-        limits:
-          cpu: "500m"
-          memory: "32Mi"
-        requests:
-          cpu: "50m"
-          memory: "32Mi"
+      limits:
+        cpu: "500m"
+        memory: "32Mi"
+      requests:
+        cpu: "50m"
+        memory: "32Mi"
     dotnet:
-      resources:
-        limits:
-          cpu: "500m"
-          memory: "128Mi"
-        requests:
-          cpu: "50m"
-          memory: "128Mi"
+      limits:
+        cpu: "500m"
+        memory: "128Mi"
+      requests:
+        cpu: "50m"
+        memory: "128Mi"
   autoAnnotateAutoInstrumentation:
     java:
       namespaces: [ ]

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -410,6 +410,16 @@ manager:
       repositoryDomain: public.ecr.aws/aws-observability
       repository: adot-autoinstrumentation-java
       tag: v1.32.3
+    python:
+      repositoryDomain: public.ecr.aws/aws-observability
+      repository: adot-autoinstrumentation-python
+      tag: v0.3.0
+    dotnet:
+      repositoryDomain: public.ecr.aws/aws-observability
+      repository: adot-autoinstrumentation-dotnet
+      tag: v1.1.0
+  autoInstrumentationResources:
+    java:
       resources:
         limits:
           cpu: "500m"
@@ -418,9 +428,6 @@ manager:
           cpu: "50m"
           memory: "64Mi"
     python:
-      repositoryDomain: public.ecr.aws/aws-observability
-      repository: adot-autoinstrumentation-python
-      tag: v0.3.0
       resources:
         limits:
           cpu: "500m"
@@ -429,9 +436,6 @@ manager:
           cpu: "50m"
           memory: "32Mi"
     dotnet:
-      repositoryDomain: public.ecr.aws/aws-observability
-      repository: adot-autoinstrumentation-dotnet
-      tag: v1.1.0
       resources:
         limits:
           cpu: "500m"


### PR DESCRIPTION
*Description of changes:*
As per the [latest changes](https://github.com/aws-observability/helm-charts/pull/65) to allow configurable resource requests and limits through command arguments, the formatting in `values.yaml` could be made more intuitive since they're values for containers, not images.

*Testing:*
1. `helm upgrade --install amazon-cloudwatch-observability helm-charts/charts/amazon-cloudwatch-observability --values helm-charts/charts/amazon-cloudwatch-observability/values.yaml --set clusterName=<cluster-name> --set region=us-west-2`

<img width="667" alt="Screenshot 2024-08-12 at 11 07 19 AM" src="https://github.com/user-attachments/assets/61f89faa-b2de-4da4-9023-8d8f3ce35cc0">

Works the same.

2. `helm upgrade --install amazon-cloudwatch-observability helm-charts/charts/amazon-cloudwatch-observability --values helm-charts/charts/amazon-cloudwatch-observability/values.yaml --set clusterName=cloudwatchagent-operator --set region=us-west-2 --set manager.autoInstrumentationResources.java.limits.cpu=147m`

<img width="665" alt="Screenshot 2024-08-12 at 11 07 58 AM" src="https://github.com/user-attachments/assets/29598d7d-b462-46f1-a4b9-f07439ee402a">

Changes appropriately.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

