### PR TITLE
Add container image scanning workflow

### DIFF
--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -36,9 +36,9 @@ jobs:
             repository: ".manager.autoInstrumentationImage.dotnet.repository"
             tag: ".manager.autoInstrumentationImage.dotnet.tag"
 
-          - registry: ".agent.image.repositoryDomainMap.public",
-            repository: ".agent.image.repository",
-            tag": ".agent.image.tag"
+          - registry: ".agent.image.repositoryDomainMap.public"
+            repository: ".agent.image.repository"
+            tag: ".agent.image.tag"
 
           - registry: ".dcgmExporter.image.repositoryDomainMap.public"
             repository: ".dcgmExporter.image.repository"

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -19,13 +19,14 @@ jobs:
           fetch-depth: 0
 
       - name: "Get values.yaml for parsing"
-        uses: pietrobolcato/action-read-yaml@1.0.0
-        id: values_yaml
-        with:
-          config: charts/amazon-cloudwatch-observability/values.yaml
+        uses: mikefarah/yq@master
+        run: |
+          export VALUES_YAML=charts/amazon-cloudwatch-observability/values.yaml
+          export DCGM_EXPORTER_IMAGE=${yq '.dcgmExporter.image.repositoryDomainMap.public' $VALUES_YAML} \
+          /${yq '.dcgmExporter.image.repository' $VALUES_YAML}:${yq '.dcgmExporter.image.tag' $VALUES_YAML}
 
       - name: "[DCGM Exporter] Scan for vulnerabilities"
         uses: crazy-max/ghaction-container-scan@v3
         with:
-          image: ${{ steps.read_yaml.outputs['dcgmExporter.public'] }}/${{ steps.read_yaml.outputs['dcgmExporter.repository'] }}:${{ steps.read_yaml.outputs['dcgmExporter.tag'] }}
+          image: $DCGM_EXPORTER_IMAGE
           severity_threshold: HIGH

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -4,11 +4,6 @@ on:
   schedule:
     - cron: 0 13 * * 1 # Every Monday at 1PM UTC (9AM EST)
   workflow_dispatch:
-  # Used for testing, remove once confirmed working
-  pull_request:
-    types: [ opened, reopened, synchronize, ready_for_review ]
-    branches:
-      - main
 
 permissions:
   id-token: write
@@ -63,9 +58,6 @@ jobs:
         with:
           role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
-
-#      - name: Login ECR
-#        uses: aws-actions/amazon-ecr-login@v1
 
       - name: "Get image paths"
         id: image

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -14,7 +14,45 @@ jobs:
   ContainerImageScan:
     strategy:
       matrix:
-        yaml_root: [ ".manager.image", ".manager.autoInstrumentationImage.java", ".manager.autoInstrumentationImage.python", ".manager.autoInstrumentationImage.dotnet", "agent.image", ".dcgmExporter.image", ".neuronMonitor.image" ]
+        yaml: [
+          {
+            "domain": ".manager.image.repositoryDomainMap.public",
+            "repository": ".manager.image.repository",
+            "tag": ".manager.image.tag"
+          },
+          {
+            "domain": ".manager.autoInstrumentationImage.java.repositoryDomain",
+            "repository": ".manager.autoInstrumentationImage.java.repository",
+            "tag": ".manager.autoInstrumentationImage.java.tag"
+          },
+          {
+            "domain": ".manager.autoInstrumentationImage.python.repositoryDomain",
+            "repository": ".manager.autoInstrumentationImage.python.repository",
+            "tag": ".manager.autoInstrumentationImage.python.tag"
+          },
+          {
+            "domain": ".manager.autoInstrumentationImage.dotnet.repositoryDomain",
+            "repository": ".manager.autoInstrumentationImage.dotnet.repository",
+            "tag": ".manager.autoInstrumentationImage.dotnet.tag"
+          },
+          {
+            "domain": ".agent.image.repositoryDomainMap.public",
+            "repository": ".agent.image.repository",
+            "tag": ".agent.image.tag"
+          },
+
+          {
+            "domain": ".dcgmExporter.image.repositoryDomainMap.public",
+            "repository": ".dcgmExporter.image.repository",
+            "tag": ".dcgmExporter.image.tag"
+          },
+
+          {
+            "domain": ".neuronMonitor.image.repositoryDomainMap.public",
+            "repository": ".neuronMonitor.image.repository",
+            "tag": ".neuronMonitor.image.tag"
+          }
+        ]
 
     runs-on: ubuntu-latest
     steps:
@@ -27,7 +65,7 @@ jobs:
         uses: mikefarah/yq@master
         with:
           cmd:
-            echo CONTAINER_IMAGE="$(yq '${{ matrix.yaml_root }}.repositoryDomainMap.public' charts/amazon-cloudwatch-observability/values.yaml)/$(yq '${{ matrix.yaml_root }}.repository' charts/amazon-cloudwatch-observability/values.yaml):$(yq '${{ matrix.yaml_root }}.tag' charts/amazon-cloudwatch-observability/values.yaml)" >> $GITHUB_OUTPUT
+            echo CONTAINER_IMAGE="$(yq '${{ matrix.yaml.domain }}' charts/amazon-cloudwatch-observability/values.yaml)/$(yq '${{ matrix.yaml.repository }}' charts/amazon-cloudwatch-observability/values.yaml):$(yq '${{ matrix.yaml.tag }}' charts/amazon-cloudwatch-observability/values.yaml)" >> $GITHUB_OUTPUT
 
       - name: "Scan for vulnerabilities"
         uses: crazy-max/ghaction-container-scan@v3

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -17,13 +17,14 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
+c
       - name: "Get values.yaml for parsing"
         uses: mikefarah/yq@master
-        run: |
-          export VALUES_YAML=charts/amazon-cloudwatch-observability/values.yaml
-          export DCGM_EXPORTER_IMAGE=${yq '.dcgmExporter.image.repositoryDomainMap.public' $VALUES_YAML} \
-          /${yq '.dcgmExporter.image.repository' $VALUES_YAML}:${yq '.dcgmExporter.image.tag' $VALUES_YAML}
+        with:
+          cmd:
+            export VALUES_YAML=charts/amazon-cloudwatch-observability/values.yaml &
+            export DCGM_EXPORTER_IMAGE=${yq '.dcgmExporter.image.repositoryDomainMap.public' $VALUES_YAML} \
+            /${yq '.dcgmExporter.image.repository' $VALUES_YAML}:${yq '.dcgmExporter.image.tag' $VALUES_YAML}
 
       - name: "[DCGM Exporter] Scan for vulnerabilities"
         uses: crazy-max/ghaction-container-scan@v3

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -4,11 +4,6 @@ on:
   schedule:
     - cron: 0 13 * * 1 # Every Monday at 1PM UTC (9AM EST)
   workflow_dispatch:
-  # Used for testing, remove once confirmed working
-  pull_request:
-    types: [ opened, reopened, synchronize, ready_for_review ]
-    branches:
-      - main
 
 permissions:
   id-token: write

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -13,6 +13,7 @@ on:
 jobs:
   ContainerImageScan:
     strategy:
+      fail-fast: false
       matrix:
         yaml: [
           {
@@ -59,6 +60,15 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+
+      - name: Login ECR
+        uses: aws-actions/amazon-ecr-login@v1
 
       - name: "Get image paths"
         id: image

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -10,6 +10,10 @@ on:
       - main
   workflow_dispatch:
 
+env:
+  TERRAFORM_AWS_ASSUME_ROLE: ${{ secrets.TERRAFORM_AWS_ASSUME_ROLE }}
+  AWS_DEFAULT_REGION: us-west-2
+
 jobs:
   ContainerImageScan:
     strategy:

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -1,0 +1,31 @@
+name: Run Security Scan for Amazon CloudWatch Observability Helm Chart Images
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [ opened, reopened, synchronize, ready_for_review ]
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  ContainerScan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Get values.yaml for parsing
+        uses: pietrobolcato/action-read-yaml@1.0.0
+        id: values_yaml
+        with:
+          config: charts/amazon-cloudwatch-observability/values.yaml
+
+      - name: [DCGM Exporter] Scan for vulnerabilities
+        uses: crazy-max/ghaction-container-scan@v3
+        with:
+          image: ${{ steps.read_yaml.outputs['dcgmExporter.public'] }}/${{ steps.read_yaml.outputs['dcgmExporter.repository'] }}:${{ steps.read_yaml.outputs['dcgmExporter.tag'] }}
+          severity_threshold: HIGH

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -26,7 +26,7 @@ jobs:
         id: image
         uses: mikefarah/yq@master
         with:
-          command: |
+          cmd:
             echo CONTAINER_IMAGE="$(yq '${{ matrix.yaml_root }}.repositoryDomainMap.public' charts/amazon-cloudwatch-observability/values.yaml)/$(yq '${{ matrix.yaml_root }}.repository' charts/amazon-cloudwatch-observability/values.yaml):$(yq '${{ matrix.yaml_root }}.tag' charts/amazon-cloudwatch-observability/values.yaml)" >> $GITHUB_OUTPUT
 
       - name: "Scan for vulnerabilities"

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -1,4 +1,4 @@
-name: Run Security Scan for Amazon CloudWatch Observability Helm Chart Images
+name: Run Image Scan for Amazon CloudWatch Observability Helm Chart
 
 on:
   push:
@@ -18,13 +18,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get values.yaml for parsing
+      - name: "Get values.yaml for parsing"
         uses: pietrobolcato/action-read-yaml@1.0.0
         id: values_yaml
         with:
           config: charts/amazon-cloudwatch-observability/values.yaml
 
-      - name: [DCGM Exporter] Scan for vulnerabilities
+      - name: "[DCGM Exporter] Scan for vulnerabilities"
         uses: crazy-max/ghaction-container-scan@v3
         with:
           image: ${{ steps.read_yaml.outputs['dcgmExporter.public'] }}/${{ steps.read_yaml.outputs['dcgmExporter.repository'] }}:${{ steps.read_yaml.outputs['dcgmExporter.tag'] }}

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: 0 13 * * 1 # Every Monday at 1PM UTC (9AM EST)
   workflow_dispatch:
+  # Used for testing, remove once confirmed working
+  pull_request:
+    types: [ opened, reopened, synchronize, ready_for_review ]
+    branches:
+      - main
 
 permissions:
   id-token: write
@@ -59,15 +64,26 @@ jobs:
           role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
-      - name: "Get image paths"
-        id: image
+      - name: "Get image registry"
+        id: registry
         uses: mikefarah/yq@master
         with:
-          cmd:
-            echo CONTAINER_IMAGE="$(yq '${{ matrix.container_images.registry }}' charts/amazon-cloudwatch-observability/values.yaml)/$(yq '${{ matrix.container_images.repository }}' charts/amazon-cloudwatch-observability/values.yaml):$(yq '${{ matrix.container_images.tag }}' charts/amazon-cloudwatch-observability/values.yaml)" >> $GITHUB_OUTPUT
+          cmd: yq '${{ matrix.container_images.registry }}' charts/amazon-cloudwatch-observability/values.yaml
+
+      - name: "Get image repository"
+        id: repository
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq '${{ matrix.container_images.repository }}' charts/amazon-cloudwatch-observability/values.yaml
+
+      - name: "Get image tag"
+        id: tag
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq '${{ matrix.container_images.tag }}' charts/amazon-cloudwatch-observability/values.yaml
 
       - name: "Scan for vulnerabilities"
         uses: crazy-max/ghaction-container-scan@v3
         with:
-          image: ${{ steps.image.outputs.CONTAINER_IMAGE }}
+          image: ${{ steps.registry.outputs.result }}/${{ steps.repository.outputs.result }}:${{ steps.tag.outputs.result }}
           severity_threshold: HIGH

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-c
+
       - name: "Get values.yaml for parsing"
         uses: mikefarah/yq@master
         with:

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -4,11 +4,6 @@ on:
   schedule:
     - cron: 0 13 * * MON # Every Monday at 1PM UTC (9AM EST)
   workflow_dispatch:
-  # Used for testing, remove once confirmed working
-  pull_request:
-    types: [ opened, reopened, synchronize, ready_for_review ]
-    branches:
-      - main
 
 permissions:
   id-token: write
@@ -58,11 +53,11 @@ jobs:
         with:
           fetch-depth: 0
 
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v2
-#        with:
-#          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
-#          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
       - name: "Get image registry"
         id: registry

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -11,22 +11,26 @@ on:
   workflow_dispatch:
 
 jobs:
-  ContainerScan:
+  ContainerImageScan:
+    strategy:
+      matrix:
+        yaml_root: [ ".manager.image", ".manager.autoInstrumentationImage.java", ".manager.autoInstrumentationImage.python", ".manager.autoInstrumentationImage.dotnet", "agent.image", ".dcgmExporter.image", ".neuronMonitor.image" ]
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - name: "Get values.yaml for parsing"
-        id: yaml-parse
+      - name: "Get image paths"
+        id: image
         uses: mikefarah/yq@master
         with:
-          cmd:
-            echo DCGM_EXPORTER_IMAGE="$(yq '.dcgmExporter.image.repositoryDomainMap.public' charts/amazon-cloudwatch-observability/values.yaml)/$(yq '.dcgmExporter.image.repository' charts/amazon-cloudwatch-observability/values.yaml):$(yq '.dcgmExporter.image.tag' charts/amazon-cloudwatch-observability/values.yaml)" >> $GITHUB_OUTPUT
+          command: |
+            echo CONTAINER_IMAGE="$(yq '${{ matrix.yaml_root }}.repositoryDomainMap.public' charts/amazon-cloudwatch-observability/values.yaml)/$(yq '${{ matrix.yaml_root }}.repository' charts/amazon-cloudwatch-observability/values.yaml):$(yq '${{ matrix.yaml_root }}.tag' charts/amazon-cloudwatch-observability/values.yaml)" >> $GITHUB_OUTPUT
 
-      - name: "[DCGM Exporter] Scan for vulnerabilities"
+      - name: "Scan for vulnerabilities"
         uses: crazy-max/ghaction-container-scan@v3
         with:
-          image: ${{ steps.yaml-parse.outputs.DCGM_EXPORTER_IMAGE }}
+          image: ${{ steps.image.outputs.CONTAINER_IMAGE }}
           severity_threshold: HIGH

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -1,13 +1,8 @@
 name: Run Image Scan for Amazon CloudWatch Observability Helm Chart
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    types: [ opened, reopened, synchronize, ready_for_review ]
-    branches:
-      - main
+  schedule:
+    - cron: 0 13 * * 1 # Every Monday at 1PM UTC (9AM EST)
   workflow_dispatch:
 
 permissions:
@@ -24,45 +19,34 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        yaml: [
-          {
-            "domain": ".manager.image.repositoryDomainMap.public",
-            "repository": ".manager.image.repository",
-            "tag": ".manager.image.tag"
-          },
-          {
-            "domain": ".manager.autoInstrumentationImage.java.repositoryDomain",
-            "repository": ".manager.autoInstrumentationImage.java.repository",
-            "tag": ".manager.autoInstrumentationImage.java.tag"
-          },
-          {
-            "domain": ".manager.autoInstrumentationImage.python.repositoryDomain",
-            "repository": ".manager.autoInstrumentationImage.python.repository",
-            "tag": ".manager.autoInstrumentationImage.python.tag"
-          },
-          {
-            "domain": ".manager.autoInstrumentationImage.dotnet.repositoryDomain",
-            "repository": ".manager.autoInstrumentationImage.dotnet.repository",
-            "tag": ".manager.autoInstrumentationImage.dotnet.tag"
-          },
-          {
-            "domain": ".agent.image.repositoryDomainMap.public",
-            "repository": ".agent.image.repository",
-            "tag": ".agent.image.tag"
-          },
+        container_images:
+          - registry: ".manager.image.repositoryDomainMap.public"
+            repository: ".manager.image.repository"
+            tag: ".manager.image.tag"
 
-          {
-            "domain": ".dcgmExporter.image.repositoryDomainMap.public",
-            "repository": ".dcgmExporter.image.repository",
-            "tag": ".dcgmExporter.image.tag"
-          },
+          - registry: ".manager.autoInstrumentationImage.java.repositoryDomain"
+            repository: ".manager.autoInstrumentationImage.java.repository"
+            tag: ".manager.autoInstrumentationImage.java.tag"
 
-          {
-            "domain": ".neuronMonitor.image.repositoryDomainMap.public",
-            "repository": ".neuronMonitor.image.repository",
-            "tag": ".neuronMonitor.image.tag"
-          }
-        ]
+          - registry: ".manager.autoInstrumentationImage.python.repositoryDomain"
+            repository: ".manager.autoInstrumentationImage.python.repository"
+            tag: ".manager.autoInstrumentationImage.python.tag"
+
+          - registry: ".manager.autoInstrumentationImage.dotnet.repositoryDomain"
+            repository: ".manager.autoInstrumentationImage.dotnet.repository"
+            tag: ".manager.autoInstrumentationImage.dotnet.tag"
+
+          - registry: ".agent.image.repositoryDomainMap.public",
+            repository: ".agent.image.repository",
+            tag": ".agent.image.tag"
+
+          - registry: ".dcgmExporter.image.repositoryDomainMap.public"
+            repository: ".dcgmExporter.image.repository"
+            tag: ".dcgmExporter.image.tag"
+
+          - registry: ".neuronMonitor.image.repositoryDomainMap.public"
+            repository: ".neuronMonitor.image.repository"
+            tag: ".neuronMonitor.image.tag"
 
     steps:
       - uses: actions/checkout@v3
@@ -83,7 +67,7 @@ jobs:
         uses: mikefarah/yq@master
         with:
           cmd:
-            echo CONTAINER_IMAGE="$(yq '${{ matrix.yaml.domain }}' charts/amazon-cloudwatch-observability/values.yaml)/$(yq '${{ matrix.yaml.repository }}' charts/amazon-cloudwatch-observability/values.yaml):$(yq '${{ matrix.yaml.tag }}' charts/amazon-cloudwatch-observability/values.yaml)" >> $GITHUB_OUTPUT
+            echo CONTAINER_IMAGE="$(yq '${{ matrix.container_images.registry }}' charts/amazon-cloudwatch-observability/values.yaml)/$(yq '${{ matrix.container_images.repository }}' charts/amazon-cloudwatch-observability/values.yaml):$(yq '${{ matrix.container_images.tag }}' charts/amazon-cloudwatch-observability/values.yaml)" >> $GITHUB_OUTPUT
 
       - name: "Scan for vulnerabilities"
         uses: crazy-max/ghaction-container-scan@v3

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -19,13 +19,14 @@ jobs:
           fetch-depth: 0
 
       - name: "Get values.yaml for parsing"
+        id: yaml-parse
         uses: mikefarah/yq@master
         with:
           cmd:
-            export DCGM_EXPORTER_IMAGE=$(yq '.dcgmExporter.image.repositoryDomainMap.public' charts/amazon-cloudwatch-observability/values.yaml)/$(yq '.dcgmExporter.image.repository' charts/amazon-cloudwatch-observability/values.yaml):$(yq '.dcgmExporter.image.tag' charts/amazon-cloudwatch-observability/values.yaml)
+            echo DCGM_EXPORTER_IMAGE="$(yq '.dcgmExporter.image.repositoryDomainMap.public' charts/amazon-cloudwatch-observability/values.yaml)/$(yq '.dcgmExporter.image.repository' charts/amazon-cloudwatch-observability/values.yaml):$(yq '.dcgmExporter.image.tag' charts/amazon-cloudwatch-observability/values.yaml)" >> $GITHUB_OUTPUT
 
       - name: "[DCGM Exporter] Scan for vulnerabilities"
         uses: crazy-max/ghaction-container-scan@v3
         with:
-          image: $DCGM_EXPORTER_IMAGE
+          image: ${{ steps.yaml-parse.outputs.DCGM_EXPORTER_IMAGE }}
           severity_threshold: HIGH

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: 0 13 * * 1 # Every Monday at 1PM UTC (9AM EST)
   workflow_dispatch:
+  # Used for testing, remove once confirmed working
+  pull_request:
+    types: [ opened, reopened, synchronize, ready_for_review ]
+    branches:
+      - main
 
 permissions:
   id-token: write
@@ -59,8 +64,8 @@ jobs:
           role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
-      - name: Login ECR
-        uses: aws-actions/amazon-ecr-login@v1
+#      - name: Login ECR
+#        uses: aws-actions/amazon-ecr-login@v1
 
       - name: "Get image paths"
         id: image

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -10,12 +10,17 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  id-token: write
+  contents: read
+
 env:
   TERRAFORM_AWS_ASSUME_ROLE: ${{ secrets.TERRAFORM_AWS_ASSUME_ROLE }}
   AWS_DEFAULT_REGION: us-west-2
 
 jobs:
   ContainerImageScan:
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -59,7 +64,6 @@ jobs:
           }
         ]
 
-    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -22,9 +22,7 @@ jobs:
         uses: mikefarah/yq@master
         with:
           cmd:
-            export VALUES_YAML=charts/amazon-cloudwatch-observability/values.yaml &
-            export DCGM_EXPORTER_IMAGE=${yq '.dcgmExporter.image.repositoryDomainMap.public' $VALUES_YAML} \
-            /${yq '.dcgmExporter.image.repository' $VALUES_YAML}:${yq '.dcgmExporter.image.tag' $VALUES_YAML}
+            export DCGM_EXPORTER_IMAGE=$(yq '.dcgmExporter.image.repositoryDomainMap.public' charts/amazon-cloudwatch-observability/values.yaml)/$(yq '.dcgmExporter.image.repository' charts/amazon-cloudwatch-observability/values.yaml):$(yq '.dcgmExporter.image.tag' charts/amazon-cloudwatch-observability/values.yaml)
 
       - name: "[DCGM Exporter] Scan for vulnerabilities"
         uses: crazy-max/ghaction-container-scan@v3

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -2,8 +2,13 @@ name: Run Image Scan for Amazon CloudWatch Observability Helm Chart
 
 on:
   schedule:
-    - cron: 0 13 * * 1 # Every Monday at 1PM UTC (9AM EST)
+    - cron: 0 13 * * MON # Every Monday at 1PM UTC (9AM EST)
   workflow_dispatch:
+  # Used for testing, remove once confirmed working
+  pull_request:
+    types: [ opened, reopened, synchronize, ready_for_review ]
+    branches:
+      - main
 
 permissions:
   id-token: write
@@ -53,11 +58,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
-          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v2
+#        with:
+#          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
+#          aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
       - name: "Get image registry"
         id: registry


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Adds a workflow to scan container images found in our helm chart with a threshold of HIGH severity. Anything lower will not fail the workflow. This workflow runs daily at 9AM EST

Sample run: https://github.com/aws-observability/helm-charts/actions/runs/10370994979/job/28710210827?pr=81


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

