### PR TITLE
Add hostNetwork: true for cloudwatch agent pod on linux

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml
@@ -39,6 +39,7 @@ spec:
                 operator: NotIn
                 values:
                   - fargate
+  hostNetwork: true
   {{- if .Values.agent.config }}
   config: {{ include "cloudwatch-agent.modify-config" (merge (dict "Config" .Values.agent.config) . ) }}
   {{- else }}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-observability/helm-charts/issues/75
https://github.com/aws/amazon-cloudwatch-agent-operator/issues/119
https://github.com/aws/amazon-cloudwatch-agent/issues/1101

*Description of changes:*
Changing the cloudwatch agent daemonset to create pods with `hostNetwork: true`. This allows the agent pod to hit IMDS for clusters with a restricted hop limit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

