### PR TITLE
Adding node js implementation

### DIFF
--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -1,0 +1,84 @@
+name: Run Image Scan for Amazon CloudWatch Observability Helm Chart
+
+on:
+  schedule:
+    - cron: 0 13 * * MON # Every Monday at 1PM UTC (9AM EST)
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  TERRAFORM_AWS_ASSUME_ROLE: ${{ secrets.TERRAFORM_AWS_ASSUME_ROLE }}
+  AWS_DEFAULT_REGION: us-west-2
+
+jobs:
+  ContainerImageScan:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        container_images:
+          - registry: ".manager.image.repositoryDomainMap.public"
+            repository: ".manager.image.repository"
+            tag: ".manager.image.tag"
+
+          - registry: ".manager.autoInstrumentationImage.java.repositoryDomain"
+            repository: ".manager.autoInstrumentationImage.java.repository"
+            tag: ".manager.autoInstrumentationImage.java.tag"
+
+          - registry: ".manager.autoInstrumentationImage.python.repositoryDomain"
+            repository: ".manager.autoInstrumentationImage.python.repository"
+            tag: ".manager.autoInstrumentationImage.python.tag"
+
+          - registry: ".manager.autoInstrumentationImage.dotnet.repositoryDomain"
+            repository: ".manager.autoInstrumentationImage.dotnet.repository"
+            tag: ".manager.autoInstrumentationImage.dotnet.tag"
+
+          - registry: ".agent.image.repositoryDomainMap.public"
+            repository: ".agent.image.repository"
+            tag: ".agent.image.tag"
+
+          - registry: ".dcgmExporter.image.repositoryDomainMap.public"
+            repository: ".dcgmExporter.image.repository"
+            tag: ".dcgmExporter.image.tag"
+
+          - registry: ".neuronMonitor.image.repositoryDomainMap.public"
+            repository: ".neuronMonitor.image.repository"
+            tag: ".neuronMonitor.image.tag"
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+
+      - name: "Get image registry"
+        id: registry
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq '${{ matrix.container_images.registry }}' charts/amazon-cloudwatch-observability/values.yaml
+
+      - name: "Get image repository"
+        id: repository
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq '${{ matrix.container_images.repository }}' charts/amazon-cloudwatch-observability/values.yaml
+
+      - name: "Get image tag"
+        id: tag
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq '${{ matrix.container_images.tag }}' charts/amazon-cloudwatch-observability/values.yaml
+
+      - name: "Scan for vulnerabilities"
+        uses: crazy-max/ghaction-container-scan@v3
+        with:
+          image: ${{ steps.registry.outputs.result }}/${{ steps.repository.outputs.result }}:${{ steps.tag.outputs.result }}
+          severity_threshold: HIGH

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,4 +1,17 @@
 =======================================================================
+amazon-cloudwatch-observability v1.9.0 (2024-07-22)
+========================================================================
+Bug Fixes:
+* Add nodeAffinity rule to not spin up resources on Fargate instances (#58)
+* Increase the default memory limit of DCGM Exporter to 500Mi to fix OOM crashing issue (#67)
+
+Enhancements:
+* Support parameterized resources configuration (#63)
+* Upgrade Java SDK to v1.32.3
+* Upgrade Python SDK to v0.3.0
+* Upgrade CWAgent to v1.300042.1
+
+=======================================================================
 amazon-cloudwatch-observability v1.8.0 (2024-07-02)
 ========================================================================
 Bug Fixes:

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,4 +1,13 @@
 =======================================================================
+amazon-cloudwatch-observability v1.10.0 (2024-07-30)
+========================================================================
+New Features:
+* Adding support for .Net auto instrumentation for Application Signals (#64)
+
+Enhancements:
+* Upgrade CWAgent Operator to v1.5.0
+
+=======================================================================
 amazon-cloudwatch-observability v1.9.0 (2024-07-22)
 ========================================================================
 Bug Fixes:

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,4 +1,18 @@
 =======================================================================
+amazon-cloudwatch-observability v2.0.0 (2024-08-15)
+========================================================================
+Breaking Changes:
+* Enforce default requests and limits for auto instrumentation init containers
+
+Enhancements:
+* Allow configurable requests and limits for auto instrumentation init containers (#65)
+* Restructure resources configurations for AppSignals (#80)
+* Upgrade CWAgent to v1.300044.0
+* Upgrade CWAgent Operator to v1.6.0
+* Upgrade .Net SDK to v1.2.0
+* Upgrade FluentBit for Linux to 2.32.2.20240627
+
+=======================================================================
 amazon-cloudwatch-observability v1.10.0 (2024-07-30)
 ========================================================================
 New Features:

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,4 +1,15 @@
 =======================================================================
+amazon-cloudwatch-observability v1.8.0 (2024-07-02)
+========================================================================
+Bug Fixes:
+* Add GOMEMLIMIT environment variable for Neuron Monitor to fix OOM crash issue (#56)
+
+Enhancements:
+* Update Windows Fluent-Bit configuration to export Kubelet and kube-proxy service logs to host log group (#45)
+* Upgrade CWAgent Operator to v1.4.1
+* Upgrade CWAgent to v1.300041.0
+
+=======================================================================
 amazon-cloudwatch-observability v1.7.0 (2024-05-23)
 ========================================================================
 Enhancements:

--- a/charts/amazon-cloudwatch-observability/Chart.yaml
+++ b/charts/amazon-cloudwatch-observability/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: amazon-cloudwatch-observability
-version: 1.8.0
+version: 1.9.0
 appVersion: 1.0.0
 description: A Helm chart for Amazon CloudWatch Observability
 type: application

--- a/charts/amazon-cloudwatch-observability/Chart.yaml
+++ b/charts/amazon-cloudwatch-observability/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: amazon-cloudwatch-observability
-version: 1.9.0
+version: 1.10.0
 appVersion: 1.0.0
 description: A Helm chart for Amazon CloudWatch Observability
 type: application

--- a/charts/amazon-cloudwatch-observability/Chart.yaml
+++ b/charts/amazon-cloudwatch-observability/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: amazon-cloudwatch-observability
-version: 1.7.0
+version: 1.8.0
 appVersion: 1.0.0
 description: A Helm chart for Amazon CloudWatch Observability
 type: application

--- a/charts/amazon-cloudwatch-observability/Chart.yaml
+++ b/charts/amazon-cloudwatch-observability/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: amazon-cloudwatch-observability
-version: 1.10.0
+version: 2.0.0
 appVersion: 1.0.0
 description: A Helm chart for Amazon CloudWatch Observability
 type: application

--- a/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
@@ -155,6 +155,11 @@ Get the current recommended auto instrumentation python image
 {{- end -}}
 
 {{/*
+Get the current recommended auto instrumentation nodejs image
+*/}}
+{{- define "auto-instrumentation-nodejs.image" -}}
+{{- printf "%s/%s:%s" .Values.manager.autoInstrumentationImage.nodejs.repositoryDomain .Values.manager.autoInstrumentationImage.nodejs.repository .Values.manager.autoInstrumentationImage.nodejs.tag -}}
+{{/*
 Get the current recommended auto instrumentation dotnet image
 */}}
 {{- define "auto-instrumentation-dotnet.image" -}}

--- a/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
@@ -159,12 +159,15 @@ Get the current recommended auto instrumentation nodejs image
 */}}
 {{- define "auto-instrumentation-nodejs.image" -}}
 {{- printf "%s/%s:%s" .Values.manager.autoInstrumentationImage.nodejs.repositoryDomain .Values.manager.autoInstrumentationImage.nodejs.repository .Values.manager.autoInstrumentationImage.nodejs.tag -}}
+{{- end -}}
+
 {{/*
 Get the current recommended auto instrumentation dotnet image
 */}}
 {{- define "auto-instrumentation-dotnet.image" -}}
 {{- printf "%s/%s:%s" .Values.manager.autoInstrumentationImage.dotnet.repositoryDomain .Values.manager.autoInstrumentationImage.dotnet.repository .Values.manager.autoInstrumentationImage.dotnet.tag -}}
 {{- end -}}
+
 
 {{/*
 Common labels

--- a/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
@@ -155,6 +155,13 @@ Get the current recommended auto instrumentation python image
 {{- end -}}
 
 {{/*
+Get the current recommended auto instrumentation .net image
+*/}}
+{{- define "auto-instrumentation-dotnet.image" -}}
+{{- printf "%s/%s:%s" .Values.manager.autoInstrumentationImage.dotnet.repositoryDomain .Values.manager.autoInstrumentationImage.dotnet.repository .Values.manager.autoInstrumentationImage.dotnet.tag -}}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "amazon-cloudwatch-observability.labels" -}}

--- a/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
@@ -155,7 +155,7 @@ Get the current recommended auto instrumentation python image
 {{- end -}}
 
 {{/*
-Get the current recommended auto instrumentation .net image
+Get the current recommended auto instrumentation dotnet image
 */}}
 {{- define "auto-instrumentation-dotnet.image" -}}
 {{- printf "%s/%s:%s" .Values.manager.autoInstrumentationImage.dotnet.repositoryDomain .Values.manager.autoInstrumentationImage.dotnet.repository .Values.manager.autoInstrumentationImage.dotnet.tag -}}

--- a/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
@@ -154,12 +154,6 @@ Get the current recommended auto instrumentation python image
 {{- printf "%s/%s:%s" .Values.manager.autoInstrumentationImage.python.repositoryDomain .Values.manager.autoInstrumentationImage.python.repository .Values.manager.autoInstrumentationImage.python.tag -}}
 {{- end -}}
 
-{{/*
-Get the current recommended auto instrumentation nodejs image
-*/}}
-{{- define "auto-instrumentation-nodejs.image" -}}
-{{- printf "%s/%s:%s" .Values.manager.autoInstrumentationImage.nodejs.repositoryDomain .Values.manager.autoInstrumentationImage.nodejs.repository .Values.manager.autoInstrumentationImage.nodejs.tag -}}
-{{- end -}}
 
 {{/*
 Get the current recommended auto instrumentation dotnet image
@@ -168,6 +162,12 @@ Get the current recommended auto instrumentation dotnet image
 {{- printf "%s/%s:%s" .Values.manager.autoInstrumentationImage.dotnet.repositoryDomain .Values.manager.autoInstrumentationImage.dotnet.repository .Values.manager.autoInstrumentationImage.dotnet.tag -}}
 {{- end -}}
 
+{{/*
+Get the current recommended auto instrumentation nodejs image
+*/}}
+{{- define "auto-instrumentation-nodejs.image" -}}
+{{- printf "%s/%s:%s" .Values.manager.autoInstrumentationImage.nodejs.repositoryDomain .Values.manager.autoInstrumentationImage.nodejs.repository .Values.manager.autoInstrumentationImage.nodejs.tag -}}
+{{- end -}}
 
 {{/*
 Common labels

--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml
@@ -45,7 +45,7 @@ spec:
   config: {{ include "cloudwatch-agent.modify-config" (merge (dict "Config" .Values.agent.defaultConfig) . ) }}
   {{- end }}
   {{- with .Values.agent.resources }}
-  resources: {{- toYaml . | nindent 2}}
+  resources: {{- toYaml . | nindent 4}}
   {{- end }}
   volumeMounts:
   - mountPath: /rootfs

--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml
@@ -30,6 +30,15 @@ spec:
   nodeSelector:
     kubernetes.io/os: linux
   serviceAccount: {{ template "cloudwatch-agent.serviceAccountName" . }}
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: {{ .Values.fargateLabelKey }}
+                operator: NotIn
+                values:
+                  - fargate
   {{- if .Values.agent.config }}
   config: {{ include "cloudwatch-agent.modify-config" (merge (dict "Config" .Values.agent.config) . ) }}
   {{- else }}

--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml
@@ -44,13 +44,9 @@ spec:
   {{- else }}
   config: {{ include "cloudwatch-agent.modify-config" (merge (dict "Config" .Values.agent.defaultConfig) . ) }}
   {{- end }}
-  resources:
-    requests:
-      memory: "128Mi"
-      cpu: "250m"
-    limits:
-      memory: "512Mi"
-      cpu: "500m"
+  {{- with .Values.agent.resources }}
+  resources: {{- toYaml . | nindent 2}}
+  {{- end }}
   volumeMounts:
   - mountPath: /rootfs
     name: rootfs

--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml
@@ -39,6 +39,7 @@ spec:
                 operator: NotIn
                 values:
                   - fargate
+  hostNetwork: true
   {{- if .Values.agent.config }}
   config: {{ include "cloudwatch-agent.modify-config" (merge (dict "Config" .Values.agent.config) . ) }}
   {{- else }}

--- a/charts/amazon-cloudwatch-observability/templates/linux/dcgm-exporter-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/dcgm-exporter-daemonset.yaml
@@ -23,13 +23,9 @@ spec:
                 operator: NotIn
                 values:
                   - fargate
-  resources:
-    requests:
-      cpu: 250m
-      memory: 128Mi
-    limits:
-      cpu: 500m
-      memory: 250Mi
+  {{- with .Values.dcgmExporter.resources }}
+  resources: {{- toYaml . | nindent 2}}
+  {{- end }}
   env:
   - name: "DCGM_EXPORTER_KUBERNETES"
     value: "true"

--- a/charts/amazon-cloudwatch-observability/templates/linux/dcgm-exporter-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/dcgm-exporter-daemonset.yaml
@@ -24,7 +24,7 @@ spec:
                 values:
                   - fargate
   {{- with .Values.dcgmExporter.resources }}
-  resources: {{- toYaml . | nindent 2}}
+  resources: {{- toYaml . | nindent 4}}
   {{- end }}
   env:
   - name: "DCGM_EXPORTER_KUBERNETES"

--- a/charts/amazon-cloudwatch-observability/templates/linux/dcgm-exporter-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/dcgm-exporter-daemonset.yaml
@@ -15,10 +15,14 @@ spec:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
-        - matchExpressions:
-          - key: {{ .Values.nodeLabelKey }}
-            operator: In
-            values: {{ .Values.gpuInstances | toYaml | nindent 16 }}
+          - matchExpressions:
+              - key: {{ .Values.nodeLabelKey }}
+                operator: In
+                values: {{ .Values.gpuInstances | toYaml | nindent 16 }}
+              - key: {{ .Values.fargateLabelKey }}
+                operator: NotIn
+                values:
+                  - fargate
   resources:
     requests:
       cpu: 250m

--- a/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
@@ -47,13 +47,9 @@ spec:
               fieldPath: metadata.name
         - name: CI_VERSION
           value: "k8s/1.3.17"
-        resources:
-          limits:
-            cpu: 500m
-            memory: 250Mi
-          requests:
-            cpu: 50m
-            memory: 25Mi
+        {{- with .Values.containerLogs.fluentBit.resources }}
+        resources: {{- toYaml . | nindent 6}}
+        {{- end }}
         volumeMounts:
         # Please don't change below read-only permissions
         - name: fluentbitstate

--- a/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
@@ -48,7 +48,7 @@ spec:
         - name: CI_VERSION
           value: "k8s/1.3.17"
         {{- with .Values.containerLogs.fluentBit.resources }}
-        resources: {{- toYaml . | nindent 6}}
+        resources: {{- toYaml . | nindent 10}}
         {{- end }}
         volumeMounts:
         # Please don't change below read-only permissions

--- a/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
@@ -95,6 +95,15 @@ spec:
         hostPath:
           path: /var/log/dmesg
       serviceAccountName: {{ template "cloudwatch-agent.serviceAccountName" . }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: {{ .Values.fargateLabelKey }}
+                    operator: NotIn
+                    values:
+                      - fargate
       nodeSelector:
         kubernetes.io/os: linux
       {{- with .Values.tolerations }}

--- a/charts/amazon-cloudwatch-observability/templates/linux/neuron-monitor-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/neuron-monitor-daemonset.yaml
@@ -25,13 +25,9 @@ spec:
                 operator: NotIn
                 values:
                   - fargate
-  resources:
-    limits:
-      cpu: 500m
-      memory: 256Mi
-    requests:
-      cpu: 256m
-      memory: 128Mi
+  {{- with .Values.neuronMonitor.resources }}
+  resources: {{- toYaml . | nindent 2}}
+  {{- end }}
   env:
   - name: NODE_NAME
     valueFrom:

--- a/charts/amazon-cloudwatch-observability/templates/linux/neuron-monitor-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/neuron-monitor-daemonset.yaml
@@ -14,13 +14,17 @@ spec:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
           - matchExpressions:
-            - key: kubernetes.io/os
-              operator: In
-              values:
-                - linux
-            - key: {{ .Values.nodeLabelKey }}
-              operator: In
-              values: {{ .Values.neuronInstances | toYaml | nindent 20 }}
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                  - linux
+              - key: {{ .Values.nodeLabelKey }}
+                operator: In
+                values: {{ .Values.neuronInstances | toYaml | nindent 20 }}
+              - key: {{ .Values.fargateLabelKey }}
+                operator: NotIn
+                values:
+                  - fargate
   resources:
     limits:
       cpu: 500m
@@ -41,7 +45,7 @@ spec:
   - name: "metrics"
     port: {{ .Values.neuronMonitor.service.port }}
   command:
-  - "/opt/bin/entrypoint.sh"
+    - "/opt/bin/entrypoint.sh"
   args:
     port: "{{ .Values.neuronMonitor.service.port }}"
     cert-file: "/etc/amazon-cloudwatch-observability-neuron-cert/server.crt"

--- a/charts/amazon-cloudwatch-observability/templates/linux/neuron-monitor-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/neuron-monitor-daemonset.yaml
@@ -35,6 +35,8 @@ spec:
         fieldPath: spec.nodeName
   - name: PATH
     value: /usr/local/bin:/usr/bin:/bin:/opt/aws/neuron/bin
+  - name: GOMEMLIMIT
+    value: 160MiB
   ports:
   - name: "metrics"
     port: {{ .Values.neuronMonitor.service.port }}

--- a/charts/amazon-cloudwatch-observability/templates/linux/neuron-monitor-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/neuron-monitor-daemonset.yaml
@@ -26,7 +26,7 @@ spec:
                 values:
                   - fargate
   {{- with .Values.neuronMonitor.resources }}
-  resources: {{- toYaml . | nindent 2}}
+  resources: {{- toYaml . | nindent 4}}
   {{- end }}
   env:
   - name: NODE_NAME

--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -37,7 +37,7 @@ spec:
         - containerPort: {{ .Values.manager.ports.containerPort }}
           name: webhook-server
           protocol: TCP
-        resources: {{ toYaml .Values.manager.resources | nindent 12 }}
+        resources: {{ toYaml .Values.manager.resources | nindent 10 }}
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert

--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -26,6 +26,7 @@ spec:
       containers:
       - image: {{ template "cloudwatch-agent-operator.image" . }}
         args:
+        - {{ printf "--auto-instrumentation-config=%s" (dict "java" (.Values.manager.autoInstrumentationImage.java.resources) "python" (.Values.manager.autoInstrumentationImage.python.resources) "dotnet" (.Values.manager.autoInstrumentationImage.dotnet.resources) | toJson) | quote }}
         - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}
         - "--auto-instrumentation-java-image={{ template "auto-instrumentation-java.image" . }}"
         - "--auto-instrumentation-python-image={{ template "auto-instrumentation-python.image" . }}"

--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -29,6 +29,7 @@ spec:
         - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}
         - "--auto-instrumentation-java-image={{ template "auto-instrumentation-java.image" . }}"
         - "--auto-instrumentation-python-image={{ template "auto-instrumentation-python.image" . }}"
+        - "--auto-instrumentation-dotnet-image={{ template "auto-instrumentation-dotnet.image" . }}"
         - "--feature-gates=operator.autoinstrumentation.multi-instrumentation,operator.autoinstrumentation.multi-instrumentation.skip-container-validation"
         command:
         - /manager

--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
       - image: {{ template "cloudwatch-agent-operator.image" . }}
         args:
-        - {{ printf "--auto-instrumentation-config=%s" (dict "java" (.Values.manager.autoInstrumentationImage.java.resources) "python" (.Values.manager.autoInstrumentationImage.python.resources) "dotnet" (.Values.manager.autoInstrumentationImage.dotnet.resources) | toJson) | quote }}
+        - {{ printf "--auto-instrumentation-config=%s" (dict "java" (.Values.manager.autoInstrumentationResources.java) "python" (.Values.manager.autoInstrumentationResources.python) "dotnet" (.Values.manager.autoInstrumentationResources.dotnet) | toJson) | quote }}
         - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}
         - "--auto-instrumentation-java-image={{ template "auto-instrumentation-java.image" . }}"
         - "--auto-instrumentation-python-image={{ template "auto-instrumentation-python.image" . }}"

--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -24,27 +24,27 @@ spec:
         {{- include "amazon-cloudwatch-observability.podLabels" . | nindent 8 }}
     spec:
       containers:
-        - image: {{ template "cloudwatch-agent-operator.image" . }}
-          args:
-            - {{ printf "--auto-instrumentation-config=%s" (dict "java" (.Values.manager.autoInstrumentationResources.java) "python" (.Values.manager.autoInstrumentationResources.python) "dotnet" (.Values.manager.autoInstrumentationResources.dotnet) "nodejs" (.Values.manager.autoInstrumentationResources.nodejs) | toJson) | quote }}
-            - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}
-            - "--auto-instrumentation-java-image={{ template "auto-instrumentation-java.image" . }}"
-            - "--auto-instrumentation-python-image={{ template "auto-instrumentation-python.image" . }}"
-            - "--auto-instrumentation-nodejs-image={{ template "auto-instrumentation-nodejs.image" . }}"
-            - "--auto-instrumentation-dotnet-image={{ template "auto-instrumentation-dotnet.image" . }}"
-            - "--feature-gates=operator.autoinstrumentation.multi-instrumentation,operator.autoinstrumentation.multi-instrumentation.skip-container-validation"
-          command:
-            - /manager
-          name: manager
-          ports:
-            - containerPort: {{ .Values.manager.ports.containerPort }}
-              name: webhook-server
-              protocol: TCP
-          resources: {{ toYaml .Values.manager.resources | nindent 10 }}
-          volumeMounts:
-            - mountPath: /tmp/k8s-webhook-server/serving-certs
-              name: cert
-              readOnly: true
+      - image: {{ template "cloudwatch-agent-operator.image" . }}
+        args:
+          - {{ printf "--auto-instrumentation-config=%s" (dict "java" (.Values.manager.autoInstrumentationResources.java) "python" (.Values.manager.autoInstrumentationResources.python) "dotnet" (.Values.manager.autoInstrumentationResources.dotnet) "nodejs" (.Values.manager.autoInstrumentationResources.nodejs) | toJson) | quote }}
+          - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}
+          - "--auto-instrumentation-java-image={{ template "auto-instrumentation-java.image" . }}"
+          - "--auto-instrumentation-python-image={{ template "auto-instrumentation-python.image" . }}"
+          - "--auto-instrumentation-nodejs-image={{ template "auto-instrumentation-nodejs.image" . }}"
+          - "--auto-instrumentation-dotnet-image={{ template "auto-instrumentation-dotnet.image" . }}"
+          - "--feature-gates=operator.autoinstrumentation.multi-instrumentation,operator.autoinstrumentation.multi-instrumentation.skip-container-validation"
+        command:
+          - /manager
+        name: manager
+        ports:
+          - containerPort: {{ .Values.manager.ports.containerPort }}
+            name: webhook-server
+            protocol: TCP
+        resources: {{ toYaml .Values.manager.resources | nindent 10 }}
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
       serviceAccountName: {{ template "amazon-cloudwatch-observability.managerServiceAccountName" . }}
       terminationGracePeriodSeconds: 10
       volumes:

--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -24,33 +24,34 @@ spec:
         {{- include "amazon-cloudwatch-observability.podLabels" . | nindent 8 }}
     spec:
       containers:
-      - image: {{ template "cloudwatch-agent-operator.image" . }}
-        args:
-        - {{ printf "--auto-instrumentation-config=%s" (dict "java" (.Values.manager.autoInstrumentationResources.java) "python" (.Values.manager.autoInstrumentationResources.python) "dotnet" (.Values.manager.autoInstrumentationResources.dotnet) | toJson) | quote }}
-        - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}
-        - "--auto-instrumentation-java-image={{ template "auto-instrumentation-java.image" . }}"
-        - "--auto-instrumentation-python-image={{ template "auto-instrumentation-python.image" . }}"
-        - "--auto-instrumentation-dotnet-image={{ template "auto-instrumentation-dotnet.image" . }}"
-        - "--feature-gates=operator.autoinstrumentation.multi-instrumentation,operator.autoinstrumentation.multi-instrumentation.skip-container-validation"
-        command:
-        - /manager
-        name: manager
-        ports:
-        - containerPort: {{ .Values.manager.ports.containerPort }}
-          name: webhook-server
-          protocol: TCP
-        resources: {{ toYaml .Values.manager.resources | nindent 10 }}
-        volumeMounts:
-        - mountPath: /tmp/k8s-webhook-server/serving-certs
-          name: cert
-          readOnly: true
+        - image: {{ template "cloudwatch-agent-operator.image" . }}
+          args:
+            - {{ printf "--auto-instrumentation-config=%s" (dict "java" (.Values.manager.autoInstrumentationResources.java) "python" (.Values.manager.autoInstrumentationResources.python) "dotnet" (.Values.manager.autoInstrumentationResources.dotnet) | toJson) | quote }}
+            - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}
+            - "--auto-instrumentation-java-image={{ template "auto-instrumentation-java.image" . }}"
+            - "--auto-instrumentation-python-image={{ template "auto-instrumentation-python.image" . }}"
+            - "--auto-instrumentation-nodejs-image={{ template "auto-instrumentation-nodejs.image" . }}"
+            - "--auto-instrumentation-dotnet-image={{ template "auto-instrumentation-dotnet.image" . }}"
+            - "--feature-gates=operator.autoinstrumentation.multi-instrumentation,operator.autoinstrumentation.multi-instrumentation.skip-container-validation"
+          command:
+            - /manager
+          name: manager
+          ports:
+            - containerPort: {{ .Values.manager.ports.containerPort }}
+              name: webhook-server
+              protocol: TCP
+          resources: {{ toYaml .Values.manager.resources | nindent 10 }}
+          volumeMounts:
+            - mountPath: /tmp/k8s-webhook-server/serving-certs
+              name: cert
+              readOnly: true
       serviceAccountName: {{ template "amazon-cloudwatch-observability.managerServiceAccountName" . }}
       terminationGracePeriodSeconds: 10
       volumes:
-      - name: cert
-        secret:
-          defaultMode: 420
-          secretName: {{ template "amazon-cloudwatch-observability.certificateSecretName" . }}
+        - name: cert
+          secret:
+            defaultMode: 420
+            secretName: {{ template "amazon-cloudwatch-observability.certificateSecretName" . }}
       nodeSelector:
         kubernetes.io/os: linux
       {{- with .Values.tolerations }}

--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -26,20 +26,20 @@ spec:
       containers:
       - image: {{ template "cloudwatch-agent-operator.image" . }}
         args:
-          - {{ printf "--auto-instrumentation-config=%s" (dict "java" (.Values.manager.autoInstrumentationResources.java) "python" (.Values.manager.autoInstrumentationResources.python) "dotnet" (.Values.manager.autoInstrumentationResources.dotnet) "nodejs" (.Values.manager.autoInstrumentationResources.nodejs) | toJson) | quote }}
-          - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}
-          - "--auto-instrumentation-java-image={{ template "auto-instrumentation-java.image" . }}"
-          - "--auto-instrumentation-python-image={{ template "auto-instrumentation-python.image" . }}"
-          - "--auto-instrumentation-nodejs-image={{ template "auto-instrumentation-nodejs.image" . }}"
-          - "--auto-instrumentation-dotnet-image={{ template "auto-instrumentation-dotnet.image" . }}"
-          - "--feature-gates=operator.autoinstrumentation.multi-instrumentation,operator.autoinstrumentation.multi-instrumentation.skip-container-validation"
+        - {{ printf "--auto-instrumentation-config=%s" (dict "java" (.Values.manager.autoInstrumentationResources.java) "python" (.Values.manager.autoInstrumentationResources.python) "dotnet" (.Values.manager.autoInstrumentationResources.dotnet) "nodejs" (.Values.manager.autoInstrumentationResources.nodejs) | toJson) | quote }}
+        - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}
+        - "--auto-instrumentation-java-image={{ template "auto-instrumentation-java.image" . }}"
+        - "--auto-instrumentation-python-image={{ template "auto-instrumentation-python.image" . }}"
+        - "--auto-instrumentation-nodejs-image={{ template "auto-instrumentation-nodejs.image" . }}"
+        - "--auto-instrumentation-dotnet-image={{ template "auto-instrumentation-dotnet.image" . }}"
+        - "--feature-gates=operator.autoinstrumentation.multi-instrumentation,operator.autoinstrumentation.multi-instrumentation.skip-container-validation"
         command:
-          - /manager
+        - /manager
         name: manager
         ports:
-          - containerPort: {{ .Values.manager.ports.containerPort }}
-            name: webhook-server
-            protocol: TCP
+        - containerPort: {{ .Values.manager.ports.containerPort }}
+          name: webhook-server
+          protocol: TCP
         resources: {{ toYaml .Values.manager.resources | nindent 10 }}
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
@@ -48,10 +48,10 @@ spec:
       serviceAccountName: {{ template "amazon-cloudwatch-observability.managerServiceAccountName" . }}
       terminationGracePeriodSeconds: 10
       volumes:
-        - name: cert
-          secret:
-            defaultMode: 420
-            secretName: {{ template "amazon-cloudwatch-observability.certificateSecretName" . }}
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: {{ template "amazon-cloudwatch-observability.certificateSecretName" . }}
       nodeSelector:
         kubernetes.io/os: linux
       {{- with .Values.tolerations }}

--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -30,8 +30,8 @@ spec:
         - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}
         - "--auto-instrumentation-java-image={{ template "auto-instrumentation-java.image" . }}"
         - "--auto-instrumentation-python-image={{ template "auto-instrumentation-python.image" . }}"
-        - "--auto-instrumentation-nodejs-image={{ template "auto-instrumentation-nodejs.image" . }}"
         - "--auto-instrumentation-dotnet-image={{ template "auto-instrumentation-dotnet.image" . }}"
+        - "--auto-instrumentation-nodejs-image={{ template "auto-instrumentation-nodejs.image" . }}"
         - "--feature-gates=operator.autoinstrumentation.multi-instrumentation,operator.autoinstrumentation.multi-instrumentation.skip-container-validation"
         command:
         - /manager

--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
         - image: {{ template "cloudwatch-agent-operator.image" . }}
           args:
-            - {{ printf "--auto-instrumentation-config=%s" (dict "java" (.Values.manager.autoInstrumentationResources.java) "python" (.Values.manager.autoInstrumentationResources.python) "dotnet" (.Values.manager.autoInstrumentationResources.dotnet) | toJson) | quote }}
+            - {{ printf "--auto-instrumentation-config=%s" (dict "java" (.Values.manager.autoInstrumentationResources.java) "python" (.Values.manager.autoInstrumentationResources.python) "dotnet" (.Values.manager.autoInstrumentationResources.dotnet) "nodejs" (.Values.manager.autoInstrumentationResources.nodejs) | toJson) | quote }}
             - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}
             - "--auto-instrumentation-java-image={{ template "auto-instrumentation-java.image" . }}"
             - "--auto-instrumentation-python-image={{ template "auto-instrumentation-python.image" . }}"

--- a/charts/amazon-cloudwatch-observability/templates/windows/cloudwatch-agent-windows-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/windows/cloudwatch-agent-windows-daemonset.yaml
@@ -19,13 +19,9 @@ spec:
   nodeSelector:
     kubernetes.io/os: windows
   config: {{ .Values.agent.windowsDefaultConfig | toJson | quote }}
-  resources:
-    requests:
-      memory: "128Mi"
-      cpu: "250m"
-    limits:
-      memory: "512Mi"
-      cpu: "500m"
+  {{- with .Values.agent.resources }}
+  resources: {{- toYaml . | nindent 2}}
+  {{- end }}
   env:
   - name: K8S_NODE_NAME
     valueFrom:

--- a/charts/amazon-cloudwatch-observability/templates/windows/cloudwatch-agent-windows-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/windows/cloudwatch-agent-windows-daemonset.yaml
@@ -20,7 +20,7 @@ spec:
     kubernetes.io/os: windows
   config: {{ .Values.agent.windowsDefaultConfig | toJson | quote }}
   {{- with .Values.agent.resources }}
-  resources: {{- toYaml . | nindent 2}}
+  resources: {{- toYaml . | nindent 4}}
   {{- end }}
   env:
   - name: K8S_NODE_NAME

--- a/charts/amazon-cloudwatch-observability/templates/windows/fluent-bit-windows-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/windows/fluent-bit-windows-daemonset.yaml
@@ -53,13 +53,9 @@ spec:
               fieldPath: metadata.name
         - name: CI_VERSION
           value: "k8s/1.3.17"
-        resources:
-          limits:
-            cpu: 500m
-            memory: 600Mi
-          requests:
-            cpu: 300m
-            memory: 300Mi
+        {{- with .Values.containerLogs.fluentBit.resources }}
+        resources: {{- toYaml . | nindent 6}}
+        {{- end }}
         volumeMounts:
           - name: fluent-bit-config
             mountPath: fluent-bit\configuration\

--- a/charts/amazon-cloudwatch-observability/templates/windows/fluent-bit-windows-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/windows/fluent-bit-windows-daemonset.yaml
@@ -54,7 +54,7 @@ spec:
         - name: CI_VERSION
           value: "k8s/1.3.17"
         {{- with .Values.containerLogs.fluentBit.resources }}
-        resources: {{- toYaml . | nindent 6}}
+        resources: {{- toYaml . | nindent 10}}
         {{- end }}
         volumeMounts:
           - name: fluent-bit-config

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -412,11 +412,11 @@ manager:
     java:
       repositoryDomain: public.ecr.aws/aws-observability
       repository: adot-autoinstrumentation-java
-      tag: v1.32.2
+      tag: v1.32.3
     python:
       repositoryDomain: public.ecr.aws/aws-observability
       repository: adot-autoinstrumentation-python
-      tag: v0.2.0
+      tag: v0.3.0
   autoAnnotateAutoInstrumentation:
     java:
       namespaces: [ ]
@@ -505,7 +505,7 @@ agent:
   name:
   image:
     repository: cloudwatch-agent
-    tag: 1.300041.0b681
+    tag: 1.300042.1b746
     repositoryDomainMap:
       public: public.ecr.aws/cloudwatch-agent
       cn-north-1: 934860584483.dkr.ecr.cn-north-1.amazonaws.com.cn

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -18,6 +18,8 @@ clusterName:
 region:
 
 nodeLabelKey: node.kubernetes.io/instance-type
+fargateLabelKey: eks.amazonaws.com/compute-type
+
 ## NVIDIA GPU instance types
 gpuInstances: [ p2.xlarge, p2.8xlarge, p2.16xlarge, p3.2xlarge, p3.8xlarge, p3.16xlarge, p3dn.24xlarge, p4d.24xlarge, p4de.24xlarge, p5.48xlarge, g3s.xlarge, g3.4xlarge, g3.8xlarge, g3.16xlarge, g4dn.xlarge, g4dn.2xlarge, g4dn.4xlarge, g4dn.8xlarge, g4dn.16xlarge, g4dn.12xlarge, g4dn.metal, g4ad.xlarge, g4ad.2xlarge, g4ad.4xlarge, g4ad.8xlarge, g4ad.16xlarge, g5.xlarge, g5.2xlarge, g5.4xlarge, g5.8xlarge, g5.16xlarge, g5.12xlarge, g5.24xlarge, g5.48xlarge, g5g.xlarge, g5g.2xlarge, g5g.4xlarge, g5g.8xlarge, g5g.16xlarge, g5g.metal, ml.p5.48xlarge, ml.p4d.24xlarge, ml.p4de.24xlarge, ml.p3.2xlarge, ml.p3.8xlarge, ml.p3.16xlarge, ml.p3dn.24xlarge, ml.p2.xlarge, ml.p2.8xlarge, ml.p2.16xlarge, ml.g3s.xlarge, ml.g3.4xlarge, ml.g3.8xlarge, ml.g3.16xlarge, ml.g4dn.xlarge, ml.g4dn.2xlarge, ml.g4dn.4xlarge, ml.g4dn.8xlarge, ml.g4dn.16xlarge, ml.g4dn.12xlarge, ml.g4dn.metal, ml.g4ad.xlarge, ml.g4ad.2xlarge, ml.g4ad.4xlarge, ml.g4ad.8xlarge, ml.g4ad.16xlarge, ml.g5.xlarge, ml.g5.2xlarge, ml.g5.4xlarge, ml.g5.8xlarge, ml.g5.16xlarge, ml.g5.12xlarge, ml.g5.24xlarge, ml.g5.48xlarge, ml.g5g.xlarge, ml.g5g.2xlarge, ml.g5g.4xlarge, ml.g5g.8xlarge, ml.g5g.16xlarge, ml.g5g.metal]
 
@@ -60,14 +62,14 @@ containerLogs:
           Regex               ^(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
           Time_Key            time
           Time_Format         %b %d %H:%M:%S
-  
+        
         [PARSER]
           Name                container_firstline
           Format              regex
           Regex               (?<log>(?<="log":")\S(?!\.).*?)(?<!\\)".*(?<stream>(?<="stream":").*?)".*(?<time>\d{4}-\d{1,2}-\d{1,2}T\d{2}:\d{2}:\d{2}\.\w*).*(?=})
           Time_Key            time
           Time_Format         %Y-%m-%dT%H:%M:%S.%LZ
-    
+        
         [PARSER]
           Name                cwagent_firstline
           Format              regex
@@ -89,7 +91,7 @@ containerLogs:
             Rotate_Wait         30
             storage.type        filesystem
             Read_from_Head      ${READ_FROM_HEAD}
-      
+          
           [INPUT]
             Name                tail
             Tag                 application.*
@@ -100,7 +102,7 @@ containerLogs:
             Skip_Long_Lines     On
             Refresh_Interval    10
             Read_from_Head      ${READ_FROM_HEAD}
-      
+          
           [INPUT]
             Name                tail
             Tag                 application.*
@@ -111,7 +113,7 @@ containerLogs:
             Skip_Long_Lines     On
             Refresh_Interval    10
             Read_from_Head      ${READ_FROM_HEAD}
-      
+          
           [FILTER]
             Name                kubernetes
             Match               application.*
@@ -126,7 +128,7 @@ containerLogs:
             Use_Kubelet         On
             Kubelet_Port        10250
             Buffer_Size         0
-      
+          
           [OUTPUT]
             Name                cloudwatch_logs
             Match               application.*
@@ -145,7 +147,7 @@ containerLogs:
             DB                  /var/fluent-bit/state/systemd.db
             Path                /var/log/journal
             Read_From_Tail      ${READ_FROM_TAIL}
-      
+          
           [INPUT]
             Name                tail
             Tag                 dataplane.tail.*
@@ -158,7 +160,7 @@ containerLogs:
             Rotate_Wait         30
             storage.type        filesystem
             Read_from_Head      ${READ_FROM_HEAD}
-      
+          
           [FILTER]
             Name                modify
             Match               dataplane.systemd.*
@@ -166,12 +168,12 @@ containerLogs:
             Rename              _SYSTEMD_UNIT               systemd_unit
             Rename              MESSAGE                     message
             Remove_regex        ^((?!hostname|systemd_unit|message).)*$
-      
+          
           [FILTER]
             Name                aws
             Match               dataplane.*
             imds_version        v2
-      
+          
           [OUTPUT]
             Name                cloudwatch_logs
             Match               dataplane.*
@@ -235,7 +237,7 @@ containerLogs:
           Daemon                      off
           net.dns.resolver            LEGACY
           Parsers_File                parsers.conf
-          
+        
           @INCLUDE application-log.conf
           @INCLUDE dataplane-log.conf
           @INCLUDE host-log.conf
@@ -273,7 +275,7 @@ containerLogs:
             Rotate_Wait         30
             Refresh_Interval    10
             Read_from_Head      ${READ_FROM_HEAD}
-    
+          
           [INPUT]
             Name                tail
             Tag                 application.*
@@ -285,7 +287,7 @@ containerLogs:
             Rotate_Wait         30
             Refresh_Interval    10
             Read_from_Head      ${READ_FROM_HEAD}
-      
+          
           [INPUT]
             Name                tail
             Tag                 application.*
@@ -297,7 +299,7 @@ containerLogs:
             Rotate_Wait         30
             Refresh_Interval    10
             Read_from_Head      ${READ_FROM_HEAD}
-      
+          
           [OUTPUT]
             Name                cloudwatch_logs
             Match               application.*
@@ -318,7 +320,7 @@ containerLogs:
             Rotate_Wait         30
             Refresh_Interval    10
             Read_from_Head      ${READ_FROM_HEAD}
-    
+          
           [INPUT]
             Name                tail
             Tag                 dataplane.tail.C.ProgramData.Amazon.EKS.logs.vpc-bridge
@@ -337,7 +339,7 @@ containerLogs:
             Channels            EKS
             DB                  C:\\var\\fluent-bit\\state\\flb_eks_winlog.db
             Interval_Sec        60
-    
+          
           [FILTER]
             Name                aws
             Match               dataplane.*
@@ -347,7 +349,7 @@ containerLogs:
             Name                aws
             Match               winlog.*
             imds_version        v2
-      
+          
           [OUTPUT]
             Name                cloudwatch_logs
             Match               dataplane.*
@@ -371,12 +373,12 @@ containerLogs:
             Channels            System
             DB                  C:\\var\\fluent-bit\\state\\flb_system_winlog.db
             Interval_Sec        60
-      
+          
           [FILTER]
             Name                aws
             Match               winlog.*
             imds_version        v2
-      
+          
           [OUTPUT]
             Name                cloudwatch_logs
             Match               winlog.*
@@ -514,7 +516,7 @@ agent:
   ## TLS Certificate Option 2: Use certManager to generate self-signed certificate.
   ## certManager must be enabled. If enabled, it takes precedence over option 1.
   certManager:
-    enabled:  false
+    enabled: false
     ## Provide the issuer kind and name to do the cert auth job.
     ## By default, OpenTelemetry Operator will use self-signer issuer.
     issuerRef: { }
@@ -565,7 +567,7 @@ dcgmExporter:
       us-gov-east-1: 743662458514.dkr.ecr.us-gov-east-1.amazonaws.com
       us-gov-west-1: 743662458514.dkr.ecr.us-gov-west-1.amazonaws.com
   configmap: dcgm-exporter-config-map
-  arguments: ["--web-config-file=/etc/dcgm-exporter/web-config.yaml"]
+  arguments: ["--web-config-file=/etc/dcgm-exporter/web-config.yaml" ]
   service:
     enable: true
     type: ClusterIP

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -410,35 +410,36 @@ manager:
       repositoryDomain: public.ecr.aws/aws-observability
       repository: adot-autoinstrumentation-java
       tag: v1.32.3
-      resources:
-        limits:
-          cpu: "500m"
-          memory: "64Mi"
-        requests:
-          cpu: "50m"
-          memory: "64Mi"
     python:
       repositoryDomain: public.ecr.aws/aws-observability
       repository: adot-autoinstrumentation-python
       tag: v0.3.0
-      resources:
-        limits:
-          cpu: "500m"
-          memory: "32Mi"
-        requests:
-          cpu: "50m"
-          memory: "32Mi"
     dotnet:
       repositoryDomain: public.ecr.aws/aws-observability
       repository: adot-autoinstrumentation-dotnet
       tag: v1.1.0
-      resources:
-        limits:
-          cpu: "500m"
-          memory: "128Mi"
-        requests:
-          cpu: "50m"
-          memory: "128Mi"
+  autoInstrumentationResources:
+    java:
+      limits:
+        cpu: "500m"
+        memory: "64Mi"
+      requests:
+        cpu: "50m"
+        memory: "64Mi"
+    python:
+      limits:
+        cpu: "500m"
+        memory: "32Mi"
+      requests:
+        cpu: "50m"
+        memory: "32Mi"
+    dotnet:
+      limits:
+        cpu: "500m"
+        memory: "128Mi"
+      requests:
+        cpu: "50m"
+        memory: "128Mi"
   autoAnnotateAutoInstrumentation:
     java:
       namespaces: [ ]

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -32,7 +32,7 @@ containerLogs:
   fluentBit:
     image:
       repository: aws-for-fluent-bit
-      tag: 2.32.0.20240304
+      tag: 2.32.2.20240627
       tagWindows: 2.31.12-windowsservercore
       repositoryDomainMap:
         public: public.ecr.aws/aws-observability

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -392,7 +392,7 @@ manager:
   name:
   image:
     repository: cloudwatch-agent-operator
-    tag: 1.4.0
+    tag: 1.4.1
     repositoryDomainMap:
       public: public.ecr.aws/cloudwatch-agent
       cn-north-1: 934860584483.dkr.ecr.cn-north-1.amazonaws.com.cn
@@ -496,7 +496,7 @@ agent:
   name:
   image:
     repository: cloudwatch-agent
-    tag: 1.300040.0b650
+    tag: 1.300041.0b681
     repositoryDomainMap:
       public: public.ecr.aws/cloudwatch-agent
       cn-north-1: 934860584483.dkr.ecr.cn-north-1.amazonaws.com.cn

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -571,6 +571,12 @@ agent:
           "kubernetes": {
             "enhanced_container_insights": true
           },
+          "application_signals": { }
+        }
+      },
+      "traces": {
+        "traces_collected": {
+          "application_signals": { }
         }
       }
     }

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -25,7 +25,7 @@ neuronInstances: [ trn1.2xlarge, trn1.32xlarge, trn1n.32xlarge, inf1.xlarge, inf
 
 ## Provide default tolerations
 tolerations:
-- operator: Exists
+  - operator: Exists
 
 containerLogs:
   enabled: true
@@ -414,6 +414,10 @@ manager:
       repositoryDomain: public.ecr.aws/aws-observability
       repository: adot-autoinstrumentation-python
       tag: v0.3.0
+    nodejs:
+      repositoryDomain: 637423224110.dkr.ecr.us-east-1.amazonaws.com/aws-observability
+      repository: adot-autoinstrumentation-node-staging
+      tag: latest
     dotnet:
       repositoryDomain: public.ecr.aws/aws-observability
       repository: adot-autoinstrumentation-dotnet
@@ -447,6 +451,11 @@ manager:
       daemonsets: [ ]
       statefulsets: [ ]
     python:
+      namespaces: [ ]
+      deployments: [ ]
+      daemonsets: [ ]
+      statefulsets: [ ]
+    nodejs:
       namespaces: [ ]
       deployments: [ ]
       daemonsets: [ ]

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -25,7 +25,7 @@ neuronInstances: [ trn1.2xlarge, trn1.32xlarge, trn1n.32xlarge, inf1.xlarge, inf
 
 ## Provide default tolerations
 tolerations:
-  - operator: Exists
+- operator: Exists
 
 containerLogs:
   enabled: true

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -444,6 +444,13 @@ manager:
       requests:
         cpu: "50m"
         memory: "128Mi"
+    nodejs:
+      limits:
+        cpu: "500m"
+        memory: "128Mi"
+      requests:
+        cpu: "50m"
+        memory: "128Mi"
   autoAnnotateAutoInstrumentation:
     java:
       namespaces: [ ]

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -415,9 +415,9 @@ manager:
       repository: adot-autoinstrumentation-python
       tag: v0.3.0
     nodejs:
-      repositoryDomain: 637423224110.dkr.ecr.us-east-1.amazonaws.com/aws-observability
-      repository: adot-autoinstrumentation-node-staging
-      tag: latest
+      repositoryDomain: ghcr.io/open-telemetry/opentelemetry-operator
+      repository: autoinstrumentation-nodejs
+      tag: 0.52.1
     dotnet:
       repositoryDomain: public.ecr.aws/aws-observability
       repository: adot-autoinstrumentation-dotnet

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -417,7 +417,7 @@ manager:
     dotnet:
       repositoryDomain: public.ecr.aws/aws-observability
       repository: adot-autoinstrumentation-dotnet
-      tag: v1.1.0
+      tag: v1.2.0
   autoInstrumentationResources:
     java:
       limits:
@@ -533,7 +533,7 @@ agent:
   name:
   image:
     repository: cloudwatch-agent
-    tag: 1.300042.1b746
+    tag: 1.300044.0b793
     repositoryDomainMap:
       public: public.ecr.aws/cloudwatch-agent
       cn-north-1: 934860584483.dkr.ecr.cn-north-1.amazonaws.com.cn

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -398,7 +398,7 @@ manager:
   name:
   image:
     repository: cloudwatch-agent-operator
-    tag: 1.5.0
+    tag: 1.6.0
     repositoryDomainMap:
       public: public.ecr.aws/cloudwatch-agent
       cn-north-1: 934860584483.dkr.ecr.cn-north-1.amazonaws.com.cn
@@ -410,14 +410,35 @@ manager:
       repositoryDomain: public.ecr.aws/aws-observability
       repository: adot-autoinstrumentation-java
       tag: v1.32.3
+      resources:
+        limits:
+          cpu: "500m"
+          memory: "64Mi"
+        requests:
+          cpu: "50m"
+          memory: "64Mi"
     python:
       repositoryDomain: public.ecr.aws/aws-observability
       repository: adot-autoinstrumentation-python
       tag: v0.3.0
+      resources:
+        limits:
+          cpu: "500m"
+          memory: "32Mi"
+        requests:
+          cpu: "50m"
+          memory: "32Mi"
     dotnet:
       repositoryDomain: public.ecr.aws/aws-observability
       repository: adot-autoinstrumentation-dotnet
       tag: v1.1.0
+      resources:
+        limits:
+          cpu: "500m"
+          memory: "128Mi"
+        requests:
+          cpu: "50m"
+          memory: "128Mi"
   autoAnnotateAutoInstrumentation:
     java:
       namespaces: [ ]

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -413,15 +413,15 @@ manager:
     python:
       repositoryDomain: public.ecr.aws/aws-observability
       repository: adot-autoinstrumentation-python
-      tag: v0.3.0
+      tag: v0.4.0
     nodejs:
-      repositoryDomain: ghcr.io/open-telemetry/opentelemetry-operator
-      repository: autoinstrumentation-nodejs
-      tag: 0.52.1
+      repositoryDomain: public.ecr.aws/aws-observability
+      repository: adot-autoinstrumentation-node
+      tag: v0.1.1
     dotnet:
       repositoryDomain: public.ecr.aws/aws-observability
       repository: adot-autoinstrumentation-dotnet
-      tag: v1.2.0
+      tag: v1.3.0
   autoInstrumentationResources:
     java:
       limits:
@@ -452,10 +452,6 @@ manager:
         cpu: "50m"
         memory: "128Mi"
       tag: v0.2.0
-    nodejs:
-      repositoryDomain: ghcr.io/open-telemetry/opentelemetry-operator
-      repository: autoinstrumentation-nodejs
-      tag: 0.51.0
   autoAnnotateAutoInstrumentation:
     java:
       namespaces: [ ]

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -586,7 +586,7 @@ dcgmExporter:
       memory: 128Mi
     limits:
       cpu: 500m
-      memory: 250Mi
+      memory: 500Mi
   configmap: dcgm-exporter-config-map
   arguments: ["--web-config-file=/etc/dcgm-exporter/web-config.yaml" ]
   service:

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -8,9 +8,6 @@ replicaCount: 1
 ##
 nameOverride: ""
 
-## Reference one or more secrets to be used when pulling images from authenticated repositories.
-imagePullSecrets: [ ]
-
 ## Provide the ClusterName (this is a required parameter)
 clusterName:
 
@@ -401,7 +398,7 @@ manager:
   name:
   image:
     repository: cloudwatch-agent-operator
-    tag: 1.4.1
+    tag: 1.5.0
     repositoryDomainMap:
       public: public.ecr.aws/cloudwatch-agent
       cn-north-1: 934860584483.dkr.ecr.cn-north-1.amazonaws.com.cn
@@ -417,6 +414,10 @@ manager:
       repositoryDomain: public.ecr.aws/aws-observability
       repository: adot-autoinstrumentation-python
       tag: v0.3.0
+    dotnet:
+      repositoryDomain: public.ecr.aws/aws-observability
+      repository: adot-autoinstrumentation-dotnet
+      tag: v1.1.0
   autoAnnotateAutoInstrumentation:
     java:
       namespaces: [ ]
@@ -424,6 +425,11 @@ manager:
       daemonsets: [ ]
       statefulsets: [ ]
     python:
+      namespaces: [ ]
+      deployments: [ ]
+      daemonsets: [ ]
+      statefulsets: [ ]
+    dotnet:
       namespaces: [ ]
       deployments: [ ]
       daemonsets: [ ]

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -43,6 +43,13 @@ containerLogs:
         cn-northwest-1: 128054284489.dkr.ecr.cn-northwest-1.amazonaws.com.cn
         us-gov-east-1: 161423150738.dkr.ecr.us-gov-east-1.amazonaws.com
         us-gov-west-1: 161423150738.dkr.ecr.us-gov-west-1.amazonaws.com
+    resources:
+      limits:
+        cpu: 500m
+        memory: 250Mi
+      requests:
+        cpu: 50m
+        memory: 25Mi
     config:
       service: |
         [SERVICE]
@@ -506,6 +513,13 @@ agent:
       us-gov-east-1: 743662458514.dkr.ecr.us-gov-east-1.amazonaws.com
       us-gov-west-1: 743662458514.dkr.ecr.us-gov-west-1.amazonaws.com
   enabled: true
+  resources:
+    requests:
+      memory: "128Mi"
+      cpu: "250m"
+    limits:
+      memory: "512Mi"
+      cpu: "500m"
   ## TLS Certificate Option 1: Use Helm to automatically generate self-signed certificate.
   ## autoGenerateCert must be enabled. This is the default option.
   ## If true, Helm will automatically create a self-signed cert and secret for you.
@@ -566,6 +580,13 @@ dcgmExporter:
       cn-northwest-1: 934860584483.dkr.ecr.cn-northwest-1.amazonaws.com.cn
       us-gov-east-1: 743662458514.dkr.ecr.us-gov-east-1.amazonaws.com
       us-gov-west-1: 743662458514.dkr.ecr.us-gov-west-1.amazonaws.com
+  resources:
+    requests:
+      cpu: 250m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 250Mi
   configmap: dcgm-exporter-config-map
   arguments: ["--web-config-file=/etc/dcgm-exporter/web-config.yaml" ]
   service:
@@ -584,6 +605,13 @@ neuronMonitor:
     tag: 1.0.1
     repositoryDomainMap:
       public: public.ecr.aws/neuron
+  resources:
+    limits:
+      cpu: 500m
+      memory: 256Mi
+    requests:
+      cpu: 256m
+      memory: 128Mi
   configmap: neuron-monitor-config-map
   service:
     enable: true


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Add the NodeJS auto instrumentation sdk to the cloudwatch agent operator as a command argument [PR](https://github.com/aws/amazon-cloudwatch-agent-operator/pull/209)

Uses `https://ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-nodejs:0.52.1` image for nodejs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

