### PR TITLE
Create separate agent daemonsets on windows for container insights and application signals

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/windows/cloudwatch-agent-windows-container-insights-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/windows/cloudwatch-agent-windows-container-insights-daemonset.yaml
@@ -1,6 +1,8 @@
 {{- if .Values.agent.enabled }}
 {{- $clusterName := .Values.clusterName | required ".Values.clusterName is required." -}}
 {{- $region := .Values.region | required ".Values.region is required." -}}
+{{- $config := `{"logs":{"metrics_collected":{"kubernetes":{"enhanced_container_insights":true}}}}` | fromJson -}}
+
 apiVersion: cloudwatch.aws.amazon.com/v1alpha1
 kind: AmazonCloudWatchAgent
 metadata:
@@ -18,16 +20,7 @@ spec:
   serviceAccount: {{ template "cloudwatch-agent.serviceAccountName" . }}
   nodeSelector:
     kubernetes.io/os: windows
-  config:
-    '{
-      "logs": {
-        "metrics_collected": {
-          "kubernetes": {
-            "enhanced_container_insights": true
-          }
-        }
-      }
-    }'
+  config: {{ include "cloudwatch-agent.modify-config" (merge (dict "Config" $config) .) }}
   {{- with .Values.agent.resources }}
   resources: {{- toYaml . | nindent 4}}
   {{- end }}

--- a/charts/amazon-cloudwatch-observability/templates/windows/cloudwatch-agent-windows-container-insights-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/windows/cloudwatch-agent-windows-container-insights-daemonset.yaml
@@ -4,13 +4,16 @@
 apiVersion: cloudwatch.aws.amazon.com/v1alpha1
 kind: AmazonCloudWatchAgent
 metadata:
-  name: {{ template "cloudwatch-agent.name" . }}-windows
+  name: {{ template "cloudwatch-agent.name" . }}-windows-container-insights
   namespace: {{ .Release.Namespace }}
 spec:
   podSecurityContext:
     windowsOptions:
+      hostProcess: true
       runAsUserName: "NT AUTHORITY\\System"
+  hostNetwork: true
   image: {{ template "cloudwatch-agent.image" . }}
+  workingDir: "%CONTAINER_SANDBOX_MOUNT_POINT%\\Program Files\\Amazon\\AmazonCloudWatchAgent"
   mode: daemonset
   serviceAccount: {{ template "cloudwatch-agent.serviceAccountName" . }}
   nodeSelector:
@@ -19,12 +22,9 @@ spec:
     '{
       "logs": {
         "metrics_collected": {
-          "application_signals": { }
-        }
-      },
-      "traces": {
-        "traces_collected": {
-          "application_signals": { }
+          "kubernetes": {
+            "enhanced_container_insights": true
+          }
         }
       }
     }'
@@ -48,6 +48,10 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
+    - name: RUN_IN_CONTAINER
+      value: "True"
+    - name: RUN_AS_HOST_PROCESS_CONTAINER
+      value: "True"
   {{- with .Values.tolerations }}
   tolerations: {{- toYaml . | nindent 2}}
   {{- end }}

--- a/charts/amazon-cloudwatch-observability/templates/windows/cloudwatch-agent-windows-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/windows/cloudwatch-agent-windows-daemonset.yaml
@@ -1,49 +1,40 @@
 {{- if .Values.agent.enabled }}
 {{- $clusterName := .Values.clusterName | required ".Values.clusterName is required." -}}
 {{- $region := .Values.region | required ".Values.region is required." -}}
+{{- range $i, $agent := $.Values.agentWorkloadsWindows }}
 apiVersion: cloudwatch.aws.amazon.com/v1alpha1
 kind: AmazonCloudWatchAgent
 metadata:
-  name: {{ template "cloudwatch-agent.name" . }}-windows
-  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "amazon-cloudwatch-observability.labels" $ | nindent 4}}
+  name: {{ $agent.name | default (include "cloudwatch-agent.name" $) }}
+  namespace: {{ $.Release.Namespace }}
 spec:
-  podSecurityContext:
-    windowsOptions:
-      hostProcess: true
-      runAsUserName: "NT AUTHORITY\\System"
-  hostNetwork: true
-  image: {{ template "cloudwatch-agent.image" . }}
-  workingDir: "%CONTAINER_SANDBOX_MOUNT_POINT%\\Program Files\\Amazon\\AmazonCloudWatchAgent"
-  mode: daemonset
-  serviceAccount: {{ template "cloudwatch-agent.serviceAccountName" . }}
-  nodeSelector:
-    kubernetes.io/os: windows
-  config: {{ .Values.agent.windowsDefaultConfig | toJson | quote }}
-  {{- with .Values.agent.resources }}
+  {{- with $agent.podSecurityContext }}
+  podSecurityContext: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if $agent.hostNetwork }}
+  hostNetwork: {{ $agent.hostNetwork | default false }}
+  {{- end }}
+  image: {{ template "cloudwatch-agent.image" $ }}
+  {{- if $agent.workingDir }}
+  workingDir: {{ $agent.workingDir | quote }}
+  {{- end }}
+  mode: {{ $agent.mode | default "daemonset" }}
+  serviceAccount: {{ template "cloudwatch-agent.serviceAccountName" $ }}
+  {{- with $agent.nodeSelector }}
+  nodeSelector: {{- toYaml . | nindent 4}}
+  {{- end }}
+  config: {{ $agent.config | default $.Values.agent.windowsDefaultConfig | toJson | quote }}
+  {{- with $.Values.agent.resources }}
   resources: {{- toYaml . | nindent 4}}
   {{- end }}
-  env:
-  - name: K8S_NODE_NAME
-    valueFrom:
-      fieldRef:
-        fieldPath: spec.nodeName
-  - name: HOST_IP
-    valueFrom:
-      fieldRef:
-        fieldPath: status.hostIP
-  - name: HOST_NAME
-    valueFrom:
-      fieldRef:
-        fieldPath: spec.nodeName
-  - name: K8S_NAMESPACE
-    valueFrom:
-      fieldRef:
-        fieldPath: metadata.namespace
-  - name: RUN_IN_CONTAINER
-    value: "True"
-  - name: RUN_AS_HOST_PROCESS_CONTAINER
-    value: "True"
-  {{- with .Values.tolerations }}
-  tolerations: {{- toYaml . | nindent 2}}
+  {{- with $agent.env }}
+  env: {{- toYaml . | nindent 4}}
   {{- end }}
+  {{- with $.Values.tolerations }}
+  tolerations: {{- toYaml . | nindent 4}}
+  {{- end }}
+---
+{{- end }}
 {{- end }}

--- a/charts/amazon-cloudwatch-observability/templates/windows/cloudwatch-agent-windows-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/windows/cloudwatch-agent-windows-daemonset.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.agent.enabled }}
 {{- $clusterName := .Values.clusterName | required ".Values.clusterName is required." -}}
 {{- $region := .Values.region | required ".Values.region is required." -}}
+{{- $config := `{"logs":{"metrics_collected":{"application_signals":{}}},"traces":{"traces_collected":{"application_signals":{}}}}` | fromJson -}}
 apiVersion: cloudwatch.aws.amazon.com/v1alpha1
 kind: AmazonCloudWatchAgent
 metadata:
@@ -15,19 +16,7 @@ spec:
   serviceAccount: {{ template "cloudwatch-agent.serviceAccountName" . }}
   nodeSelector:
     kubernetes.io/os: windows
-  config:
-    '{
-      "logs": {
-        "metrics_collected": {
-          "application_signals": { }
-        }
-      },
-      "traces": {
-        "traces_collected": {
-          "application_signals": { }
-        }
-      }
-    }'
+  config: {{ include "cloudwatch-agent.modify-config" (merge (dict "Config" $config) .) }}
   {{- with .Values.agent.resources }}
   resources: {{- toYaml . | nindent 4}}
   {{- end }}

--- a/charts/amazon-cloudwatch-observability/templates/windows/cloudwatch-agent-windows-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/windows/cloudwatch-agent-windows-daemonset.yaml
@@ -20,11 +20,10 @@ spec:
   {{- if $agent.workingDir }}
   workingDir: {{ $agent.workingDir | quote }}
   {{- end }}
-  mode: {{ $agent.mode | default "daemonset" }}
+  mode: daemonset
   serviceAccount: {{ template "cloudwatch-agent.serviceAccountName" $ }}
-  {{- with $agent.nodeSelector }}
-  nodeSelector: {{- toYaml . | nindent 4}}
-  {{- end }}
+  nodeSelector:
+    kubernetes.io/os: windows
   config: {{ $agent.config | default $.Values.agent.windowsDefaultConfig | toJson | quote }}
   {{- with $.Values.agent.resources }}
   resources: {{- toYaml . | nindent 4}}

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -602,38 +602,6 @@ agentWorkloadsWindows:
     nodeSelector:
       kubernetes.io/os: windows
     mode: daemonset
-    hostNetwork: true
-    podSecurityContext:
-      windowsOptions:
-        hostProcess: true
-        runAsUserName: "NT AUTHORITY\\System"
-    workingDir: "%CONTAINER_SANDBOX_MOUNT_POINT%\\Program Files\\Amazon\\AmazonCloudWatchAgent"
-    env:
-    - name: K8S_NODE_NAME
-      valueFrom:
-        fieldRef:
-          fieldPath: spec.nodeName
-    - name: HOST_IP
-      valueFrom:
-        fieldRef:
-          fieldPath: status.hostIP
-    - name: HOST_NAME
-      valueFrom:
-        fieldRef:
-          fieldPath: spec.nodeName
-    - name: K8S_NAMESPACE
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.namespace
-    - name: RUN_IN_CONTAINER
-      value: "True"
-    - name: RUN_AS_HOST_PROCESS_CONTAINER
-      value: "True"
-
-  - name: cloudwatch-agent-windows-application-signals
-    nodeSelector:
-      kubernetes.io/os: windows
-    mode: daemonset
     config:
       {
         "logs": {
@@ -667,6 +635,38 @@ agentWorkloadsWindows:
         valueFrom:
           fieldRef:
             fieldPath: metadata.namespace
+
+  - name: cloudwatch-agent-windows-container-insights
+    nodeSelector:
+      kubernetes.io/os: windows
+    mode: daemonset
+    hostNetwork: true
+    podSecurityContext:
+      windowsOptions:
+        hostProcess: true
+        runAsUserName: "NT AUTHORITY\\System"
+    workingDir: "%CONTAINER_SANDBOX_MOUNT_POINT%\\Program Files\\Amazon\\AmazonCloudWatchAgent"
+    env:
+      - name: K8S_NODE_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: spec.nodeName
+      - name: HOST_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.hostIP
+      - name: HOST_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: spec.nodeName
+      - name: K8S_NAMESPACE
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.namespace
+      - name: RUN_IN_CONTAINER
+        value: "True"
+      - name: RUN_AS_HOST_PROCESS_CONTAINER
+        value: "True"
 
 dcgmExporter:
   name:

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -569,7 +569,7 @@ agent:
     issuerAnnotations: { }
   serviceAccount:
     name: # override agent service account name
-  config: # optional config that can be provided to override the defaultConfig
+  config: &config # optional config that can be provided to override the defaultConfig
   defaultConfig:
     {
       "logs": {
@@ -592,16 +592,82 @@ agent:
         "metrics_collected": {
           "kubernetes": {
             "enhanced_container_insights": true
-          },
-          "application_signals": { }
-        }
-      },
-      "traces": {
-        "traces_collected": {
-          "application_signals": { }
+          }
         }
       }
     }
+
+agentWorkloadsWindows:
+  - name: cloudwatch-agent-windows
+    nodeSelector:
+      kubernetes.io/os: windows
+    mode: daemonset
+    config: *config
+    hostNetwork: true
+    podSecurityContext:
+      windowsOptions:
+        hostProcess: true
+        runAsUserName: "NT AUTHORITY\\System"
+    workingDir: "%CONTAINER_SANDBOX_MOUNT_POINT%\\Program Files\\Amazon\\AmazonCloudWatchAgent"
+    env:
+    - name: K8S_NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.hostIP
+    - name: HOST_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    - name: K8S_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: RUN_IN_CONTAINER
+      value: "True"
+    - name: RUN_AS_HOST_PROCESS_CONTAINER
+      value: "True"
+
+  - name: cloudwatch-agent-windows-application-signals
+    nodeSelector:
+      kubernetes.io/os: windows
+    mode: daemonset
+    config:
+      {
+        "logs": {
+          "metrics_collected": {
+            "application_signals": { }
+          }
+        },
+        "traces": {
+          "traces_collected": {
+            "application_signals": { }
+          }
+        }
+      }
+    podSecurityContext:
+      windowsOptions:
+        runAsUserName: "NT AUTHORITY\\System"
+    env:
+      - name: K8S_NODE_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: spec.nodeName
+      - name: HOST_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.hostIP
+      - name: HOST_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: spec.nodeName
+      - name: K8S_NAMESPACE
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.namespace
 
 dcgmExporter:
   name:

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -25,7 +25,7 @@ neuronInstances: [ trn1.2xlarge, trn1.32xlarge, trn1n.32xlarge, inf1.xlarge, inf
 
 ## Provide default tolerations
 tolerations:
-  - operator: Exists
+- operator: Exists
 
 containerLogs:
   enabled: true

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -569,7 +569,7 @@ agent:
     issuerAnnotations: { }
   serviceAccount:
     name: # override agent service account name
-  config: &config # optional config that can be provided to override the defaultConfig
+  config:  # optional config that can be provided to override the defaultConfig
   defaultConfig:
     {
       "logs": {
@@ -602,7 +602,6 @@ agentWorkloadsWindows:
     nodeSelector:
       kubernetes.io/os: windows
     mode: daemonset
-    config: *config
     hostNetwork: true
     podSecurityContext:
       windowsOptions:

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -569,7 +569,7 @@ agent:
     issuerAnnotations: { }
   serviceAccount:
     name: # override agent service account name
-  config:  # optional config that can be provided to override the defaultConfig
+  config: # optional config that can be provided to override the defaultConfig
   defaultConfig:
     {
       "logs": {
@@ -599,9 +599,6 @@ agent:
 
 agentWorkloadsWindows:
   - name: cloudwatch-agent-windows
-    nodeSelector:
-      kubernetes.io/os: windows
-    mode: daemonset
     config:
       {
         "logs": {
@@ -637,9 +634,6 @@ agentWorkloadsWindows:
             fieldPath: metadata.namespace
 
   - name: cloudwatch-agent-windows-container-insights
-    nodeSelector:
-      kubernetes.io/os: windows
-    mode: daemonset
     hostNetwork: true
     podSecurityContext:
       windowsOptions:

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -25,7 +25,7 @@ neuronInstances: [ trn1.2xlarge, trn1.32xlarge, trn1n.32xlarge, inf1.xlarge, inf
 
 ## Provide default tolerations
 tolerations:
-- operator: Exists
+  - operator: Exists
 
 containerLogs:
   enabled: true
@@ -586,81 +586,6 @@ agent:
         }
       }
     }
-  windowsDefaultConfig:
-    {
-      "logs": {
-        "metrics_collected": {
-          "kubernetes": {
-            "enhanced_container_insights": true
-          }
-        }
-      }
-    }
-
-agentWorkloadsWindows:
-  - name: cloudwatch-agent-windows
-    config:
-      {
-        "logs": {
-          "metrics_collected": {
-            "application_signals": { }
-          }
-        },
-        "traces": {
-          "traces_collected": {
-            "application_signals": { }
-          }
-        }
-      }
-    podSecurityContext:
-      windowsOptions:
-        runAsUserName: "NT AUTHORITY\\System"
-    env:
-      - name: K8S_NODE_NAME
-        valueFrom:
-          fieldRef:
-            fieldPath: spec.nodeName
-      - name: HOST_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.hostIP
-      - name: HOST_NAME
-        valueFrom:
-          fieldRef:
-            fieldPath: spec.nodeName
-      - name: K8S_NAMESPACE
-        valueFrom:
-          fieldRef:
-            fieldPath: metadata.namespace
-
-  - name: cloudwatch-agent-windows-container-insights
-    hostNetwork: true
-    podSecurityContext:
-      windowsOptions:
-        hostProcess: true
-        runAsUserName: "NT AUTHORITY\\System"
-    workingDir: "%CONTAINER_SANDBOX_MOUNT_POINT%\\Program Files\\Amazon\\AmazonCloudWatchAgent"
-    env:
-      - name: K8S_NODE_NAME
-        valueFrom:
-          fieldRef:
-            fieldPath: spec.nodeName
-      - name: HOST_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.hostIP
-      - name: HOST_NAME
-        valueFrom:
-          fieldRef:
-            fieldPath: spec.nodeName
-      - name: K8S_NAMESPACE
-        valueFrom:
-          fieldRef:
-            fieldPath: metadata.namespace
-      - name: RUN_IN_CONTAINER
-        value: "True"
-      - name: RUN_AS_HOST_PROCESS_CONTAINER
-        value: "True"
 
 dcgmExporter:
   name:

--- a/integration-tests/amazon-cloudwatch-observability/validator/resourceCount_linuxonly_test.go
+++ b/integration-tests/amazon-cloudwatch-observability/validator/resourceCount_linuxonly_test.go
@@ -20,9 +20,9 @@ const (
 	// - cloudwatch-agent-windows
 	// - cloudwatch-agent-windows-headless
 	// - cloudwatch-agent-windows-monitoring
-	// - cloudwatch-agent-windows-application-signals
-	// - cloudwatch-agent-windows-application-signals-headless
-	// - cloudwatch-agent-windows-application-signals-monitoring
+	// - cloudwatch-agent-windows-container-insights
+	// - cloudwatch-agent-windows-container-insights-headless
+	// - cloudwatch-agent-windows-container-insights-monitoring
 	serviceCountWindows = 6
 
 	// DaemonSet count on Linux:
@@ -34,7 +34,7 @@ const (
 
 	// DaemonSet count on Windows:
 	// - cloudwatch-agent-windows
-	// - cloudwatch-agent-windows-application-signals
+	// - cloudwatch-agent-windows-container-insights
 	// - fluent-bit-windows
 	daemonsetCountWindows = 3
 

--- a/integration-tests/amazon-cloudwatch-observability/validator/resourceCount_linuxonly_test.go
+++ b/integration-tests/amazon-cloudwatch-observability/validator/resourceCount_linuxonly_test.go
@@ -7,12 +7,35 @@
 package validator
 
 const (
-	// Services count on Linux and Windows
-	serviceCountLinux   = 6
-	serviceCountWindows = 3
+	// Services count on Linux:
+	// - amazon-cloudwatch-observability-webhook-service
+	// - cloudwatch-agent
+	// - cloudwatch-agent-headless
+	// - cloudwatch-agent-monitoring
+	// - dcgm-exporter-service
+	// - neuron-monitor-service
+	serviceCountLinux = 6
 
-	// DaemonSet count on Linux and Windows
-	daemonsetCountLinux   = 4
+	// Services count on Windows:
+	// - cloudwatch-agent-windows
+	// - cloudwatch-agent-windows-headless
+	// - cloudwatch-agent-windows-monitoring
+	// - cloudwatch-agent-windows-application-signals
+	// - cloudwatch-agent-windows-application-signals-headless
+	// - cloudwatch-agent-windows-application-signals-monitoring
+	serviceCountWindows = 6
+
+	// DaemonSet count on Linux:
+	// - cloudwatch-agent
+	// - dcgm-exporter
+	// - fluent-bit
+	// - neuron-monitor
+	daemonsetCountLinux = 4
+
+	// DaemonSet count on Windows:
+	// - cloudwatch-agent-windows
+	// - cloudwatch-agent-windows-application-signals
+	// - fluent-bit-windows
 	daemonsetCountWindows = 3
 
 	// Pods count on Linux and Windows

--- a/integration-tests/amazon-cloudwatch-observability/validator/resourceCount_linuxonly_test.go
+++ b/integration-tests/amazon-cloudwatch-observability/validator/resourceCount_linuxonly_test.go
@@ -7,15 +7,15 @@
 package validator
 
 const (
-	// Services count for CW agent on Linux and Windows
+	// Services count on Linux and Windows
 	serviceCountLinux   = 6
 	serviceCountWindows = 3
 
-	// DaemonSet count for CW agent on Linux and Windows
+	// DaemonSet count on Linux and Windows
 	daemonsetCountLinux   = 4
-	daemonsetCountWindows = 2
+	daemonsetCountWindows = 3
 
-	// Pods count for CW agent on Linux and Windows
+	// Pods count on Linux and Windows
 	podCountLinux   = 3
 	podCountWindows = 0
 )

--- a/integration-tests/amazon-cloudwatch-observability/validator/resourceCount_windowslinux_test.go
+++ b/integration-tests/amazon-cloudwatch-observability/validator/resourceCount_windowslinux_test.go
@@ -20,9 +20,9 @@ const (
 	// - cloudwatch-agent-windows
 	// - cloudwatch-agent-windows-headless
 	// - cloudwatch-agent-windows-monitoring
-	// - cloudwatch-agent-windows-application-signals
-	// - cloudwatch-agent-windows-application-signals-headless
-	// - cloudwatch-agent-windows-application-signals-monitoring
+	// - cloudwatch-agent-windows-container-insights
+	// - cloudwatch-agent-windows-container-insights-headless
+	// - cloudwatch-agent-windows-container-insights-monitoring
 	serviceCountWindows = 6
 
 	// DaemonSet count on Linux:
@@ -34,7 +34,7 @@ const (
 
 	// DaemonSet count on Windows:
 	// - cloudwatch-agent-windows
-	// - cloudwatch-agent-windows-application-signals
+	// - cloudwatch-agent-windows-container-insights
 	// - fluent-bit-windows
 	daemonsetCountWindows = 3
 

--- a/integration-tests/amazon-cloudwatch-observability/validator/resourceCount_windowslinux_test.go
+++ b/integration-tests/amazon-cloudwatch-observability/validator/resourceCount_windowslinux_test.go
@@ -7,12 +7,35 @@
 package validator
 
 const (
-	// Services count on Linux and Windows
-	serviceCountLinux   = 6
-	serviceCountWindows = 3
+	// Services count on Linux:
+	// - amazon-cloudwatch-observability-webhook-service
+	// - cloudwatch-agent
+	// - cloudwatch-agent-headless
+	// - cloudwatch-agent-monitoring
+	// - dcgm-exporter-service
+	// - neuron-monitor-service
+	serviceCountLinux = 6
 
-	// DaemonSet count on Linux and Windows
-	daemonsetCountLinux   = 4
+	// Services count on Windows:
+	// - cloudwatch-agent-windows
+	// - cloudwatch-agent-windows-headless
+	// - cloudwatch-agent-windows-monitoring
+	// - cloudwatch-agent-windows-application-signals
+	// - cloudwatch-agent-windows-application-signals-headless
+	// - cloudwatch-agent-windows-application-signals-monitoring
+	serviceCountWindows = 6
+
+	// DaemonSet count on Linux:
+	// - cloudwatch-agent
+	// - dcgm-exporter
+	// - fluent-bit
+	// - neuron-monitor
+	daemonsetCountLinux = 4
+
+	// DaemonSet count on Windows:
+	// - cloudwatch-agent-windows
+	// - cloudwatch-agent-windows-application-signals
+	// - fluent-bit-windows
 	daemonsetCountWindows = 3
 
 	// Pods count on Linux and Windows

--- a/integration-tests/amazon-cloudwatch-observability/validator/resourceCount_windowslinux_test.go
+++ b/integration-tests/amazon-cloudwatch-observability/validator/resourceCount_windowslinux_test.go
@@ -7,15 +7,15 @@
 package validator
 
 const (
-	// Services count for CW agent on Linux and Windows
+	// Services count on Linux and Windows
 	serviceCountLinux   = 6
 	serviceCountWindows = 3
 
-	// DaemonSet count for CW agent on Linux and Windows
+	// DaemonSet count on Linux and Windows
 	daemonsetCountLinux   = 4
-	daemonsetCountWindows = 2
+	daemonsetCountWindows = 3
 
-	// Pods count for CW agent on Linux and Windows
+	// Pods count on Linux and Windows
 	podCountLinux   = 3
-	podCountWindows = 2
+	podCountWindows = 3
 )


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Currently, kubernetes networking is not supported on windows containers with host networking:
```
The following networking functionality is not supported on Windows nodes:

    Host networking mode

```
From https://kubernetes.io/docs/concepts/services-networking/windows-networking/

We need host networking to have the agent run as a host process container to retrieve container insights metrics from HCS [(Host Compute Service)](https://learn.microsoft.com/en-us/virtualization/api/hcs/overview).

In order to allow container insights and application signals, we need 2 daemonsets for windows. One running as a host process container, and another that is not.

This PR introduces a a new daemonset specifically for container insights `cloudwatch-agent-windows-container-insights`, and the current `cloudwatch-agent-windows` will be used for application signals.

This PR also addressing missing cluster name in the windows configs

*Testing*
Ran helm template:
```
helm template amazon-cloudwatch-observability charts/amazon-cloudwatch-observability --set clusterName=test-dotnet --set region=us-east-1 --include-crds --namespace amazon-cloudwatch 
```

Pods:
```
NAMESPACE           NAME                                                              READY   STATUS                 RESTARTS       AGE
amazon-cloudwatch   amazon-cloudwatch-observability-controller-manager-65955f4bvddt   1/1     Running                0              4m14s
amazon-cloudwatch   cloudwatch-agent-t9wcr                                            1/1     Running                0              4m13s
amazon-cloudwatch   cloudwatch-agent-windows-container-insights-ffbdw                 1/1     Running                0              3m26s
amazon-cloudwatch   cloudwatch-agent-windows-rr8ls                                    1/1     Running                0              3m26s
amazon-cloudwatch   cloudwatch-agent-xddb2                                            1/1     Running                0              4m13s
```

services
```
kubectl get services -n amazon-cloudwatch
NAME                                                     TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                      AGE
amazon-cloudwatch-observability-webhook-service          ClusterIP   10.100.223.138   <none>        443/TCP                      4m26s
cloudwatch-agent                                         ClusterIP   10.100.79.246    <none>        4315/TCP,4316/TCP,2000/TCP   4m24s
cloudwatch-agent-headless                                ClusterIP   None             <none>        4315/TCP,4316/TCP,2000/TCP   4m24s
cloudwatch-agent-monitoring                              ClusterIP   10.100.8.181     <none>        8888/TCP                     4m24s
cloudwatch-agent-windows                                 ClusterIP   10.100.157.47    <none>        4315/TCP,4316/TCP,2000/TCP   3m37s
cloudwatch-agent-windows-container-insights              ClusterIP   10.100.39.29     <none>        4315/TCP,4316/TCP,2000/TCP   3m37s
cloudwatch-agent-windows-container-insights-headless     ClusterIP   None             <none>        4315/TCP,4316/TCP,2000/TCP   3m37s
cloudwatch-agent-windows-container-insights-monitoring   ClusterIP   10.100.240.0     <none>        8888/TCP                     3m37s
cloudwatch-agent-windows-headless                        ClusterIP   None             <none>        4315/TCP,4316/TCP,2000/TCP   3m37s
cloudwatch-agent-windows-monitoring                      ClusterIP   10.100.105.192   <none>        8888/TCP                     3m37s
dcgm-exporter-service                                    ClusterIP   10.100.202.190   <none>        9400/TCP                     4m24s
neuron-monitor-service                                   ClusterIP   10.100.157.169   <none>        8000/TCP                     4m24s
```

AmazonCloudWatchAgent resources
```
kubectl describe amazoncloudwatchagent cloudwatch-agent-windows -n amazon-cloudwatch
Name:         cloudwatch-agent-windows
Namespace:    amazon-cloudwatch
Labels:       app.kubernetes.io/managed-by=amazon-cloudwatch-agent-operator
Annotations:  <none>
API Version:  cloudwatch.aws.amazon.com/v1alpha1
Kind:         AmazonCloudWatchAgent
Metadata:
  Creation Timestamp:  2024-08-29T21:02:58Z
  Generation:          2
  Resource Version:    6245391
  UID:                 de98c358-d07f-4326-a8d4-08192f334c7a
Spec:
  Config:  {"agent":{"region":"us-east-1"},"logs":{"metrics_collected":{"application_signals":{"hosted_in":"test-dotnet"}}},"traces":{"traces_collected":{"application_signals":{}}}}
  ```
  
```
kubectl describe amazoncloudwatchagent cloudwatch-agent-windows-container-insights -n amazon-cloudwatch
Name:         cloudwatch-agent-windows-container-insights
Namespace:    amazon-cloudwatch
Labels:       app.kubernetes.io/managed-by=amazon-cloudwatch-agent-operator
Annotations:  <none>
API Version:  cloudwatch.aws.amazon.com/v1alpha1
Kind:         AmazonCloudWatchAgent
Metadata:
  Creation Timestamp:  2024-08-29T21:20:20Z
  Generation:          1
  Resource Version:    6245408
  UID:                 7c1fa594-3517-4655-b593-9c8266a4040e
Spec:
  Config:  {"agent":{"region":"us-east-1"},"logs":{"metrics_collected":{"kubernetes":{"cluster_name":"test-dotnet","enhanced_container_insights":true}}}}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

