### PR TITLE
Adding NodeJS image to image-scanning GHA

### DIFF
--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -36,6 +36,10 @@ jobs:
             repository: ".manager.autoInstrumentationImage.dotnet.repository"
             tag: ".manager.autoInstrumentationImage.dotnet.tag"
 
+          - registry: ".manager.autoInstrumentationImage.nodejs.repositoryDomain"
+            repository: ".manager.autoInstrumentationImage.nodejs.repository"
+            tag: ".manager.autoInstrumentationImage.nodejs.tag"
+
           - registry: ".agent.image.repositoryDomainMap.public"
             repository: ".agent.image.repository"
             tag: ".agent.image.tag"


### PR DESCRIPTION
*Description of changes:*
Since the amazon-cloudwatch-observability helm-chart supports NodeJS, the ECR image needs to be scanned for vulneribilities


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

