### PR TITLE
Added Agent Server and Fluent-bit client certificates to implement mtls on agent endpoint

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/certmanager.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/certmanager.yaml
@@ -72,12 +72,24 @@ metadata:
   name: "amazon-cloudwatch-observability-agent-server-cert"
   namespace: {{ .Release.Namespace }}
 spec:
+  commonName: "agent-server"
   dnsNames:
-    - "amazon-cloudwatch-observability-agent-server"
+    - "cloudwatch-agent"
+    - "cloudwatch-agent.amazon-cloudwatch.svc"
   issuerRef:
     kind: Issuer
     name: "agent-ca"
   secretName: "amazon-cloudwatch-observability-agent-server-cert"
+  usages:
+    - digital signature
+    - key encipherment
+    - cert sign
+  keyUsages:
+    critical: true
+    usages:
+      - digitalSignature
+      - keyEncipherment
+      - certSign
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -87,12 +99,24 @@ metadata:
   name: "amazon-cloudwatch-observability-agent-client-cert"
   namespace: {{ .Release.Namespace }}
 spec:
+  commonName: "agent-client"
   dnsNames:
-    - "amazon-cloudwatch-observability-agent-client"
+    - "cloudwatch-agent"
+    - "cloudwatch-agent.amazon-cloudwatch.svc"
   issuerRef:
     kind: Issuer
     name: "agent-ca"
   secretName:  "amazon-cloudwatch-observability-agent-client-cert"
+  usages:
+    - digital signature
+    - key encipherment
+    - cert sign
+  keyUsages:
+    critical: true
+    usages:
+      - digitalSignature
+      - keyEncipherment
+      - certSign
 {{- if not .Values.agent.certManager.issuerRef }}
 ---
 apiVersion: cert-manager.io/v1

--- a/charts/amazon-cloudwatch-observability/templates/certmanager.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/certmanager.yaml
@@ -63,6 +63,32 @@ spec:
     kind: Issuer
     name: "agent-ca"
   secretName: "amazon-cloudwatch-observability-agent-cert"
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    {{- include "amazon-cloudwatch-observability.labels" . | nindent 4 }}
+  name: "amazon-cloudwatch-observability-agent-server-cert"
+  namespace: {{ .Release.Namespace }}
+spec:
+  issuerRef:
+    kind: Issuer
+    name: "agent-ca"
+  secretName: "amazon-cloudwatch-observability-agent-server-cert"
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    {{- include "amazon-cloudwatch-observability.labels" . | nindent 4 }}
+  name: "amazon-cloudwatch-observability-agent-client-cert"
+  namespace: {{ .Release.Namespace }}
+spec:
+  issuerRef:
+    kind: Issuer
+    name: "agent-ca"
+  secretName:  "amazon-cloudwatch-observability-agent-client-cert"
 {{- if not .Values.agent.certManager.issuerRef }}
 ---
 apiVersion: cert-manager.io/v1
@@ -86,6 +112,22 @@ metadata:
   labels:
     {{- include "amazon-cloudwatch-observability.labels" . | nindent 4 }}
   name: "amazon-cloudwatch-observability-agent-cert"
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    {{- include "amazon-cloudwatch-observability.labels" . | nindent 4 }}
+  name: "amazon-cloudwatch-observability-agent-server-cert"
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    {{- include "amazon-cloudwatch-observability.labels" . | nindent 4 }}
+  name:  "amazon-cloudwatch-observability-agent-client-cert"
   namespace: {{ .Release.Namespace }}
 {{- end }}
 

--- a/charts/amazon-cloudwatch-observability/templates/certmanager.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/certmanager.yaml
@@ -100,9 +100,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   commonName: "agent-client"
-  dnsNames:
-    - "cloudwatch-agent"
-    - "cloudwatch-agent.amazon-cloudwatch.svc"
   issuerRef:
     kind: Issuer
     name: "agent-ca"

--- a/charts/amazon-cloudwatch-observability/templates/certmanager.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/certmanager.yaml
@@ -72,6 +72,8 @@ metadata:
   name: "amazon-cloudwatch-observability-agent-server-cert"
   namespace: {{ .Release.Namespace }}
 spec:
+  dnsNames:
+    - "amazon-cloudwatch-observability-agent-server"
   issuerRef:
     kind: Issuer
     name: "agent-ca"
@@ -85,6 +87,8 @@ metadata:
   name: "amazon-cloudwatch-observability-agent-client-cert"
   namespace: {{ .Release.Namespace }}
 spec:
+  dnsNames:
+    - "amazon-cloudwatch-observability-agent-client"
   issuerRef:
     kind: Issuer
     name: "agent-ca"

--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml
@@ -3,6 +3,8 @@
 {{- $altNames := list ( printf "%s-service" (include "dcgm-exporter.name" .) ) ( printf "%s-service" (include "neuron-monitor.name" .) ) ( printf "%s-service.%s.svc" (include "dcgm-exporter.name" .) .Release.Namespace ) ( printf "%s-service.%s.svc" (include "neuron-monitor.name" .) .Release.Namespace ) -}}
 {{- $ca := genCA ("agent-ca")  ( .Values.agent.autoGenerateCert.expiryDays | int ) -}}
 {{- $cert := genSignedCert ("agent") nil $altNames ( .Values.admissionWebhooks.autoGenerateCert.expiryDays | int ) $ca -}}
+{{- $serverCert := genSignedCert ("agent-server") nil nil ( .Values.admissionWebhooks.autoGenerateCert.expiryDays | int ) $ca -}}
+{{- $clientCert := genSignedCert ("agent-client") nil nil ( .Values.admissionWebhooks.autoGenerateCert.expiryDays | int ) $ca -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -14,6 +16,30 @@ data:
   ca.crt: {{ $ca.Cert | b64enc }}
   tls.crt: {{ $cert.Cert | b64enc }}
   tls.key: {{ $cert.Key | b64enc }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+      {{- include "amazon-cloudwatch-observability.labels" . | nindent 4}}
+  name: "amazon-cloudwatch-observability-agent-server-cert"
+  namespace: {{ .Release.Namespace }}
+data:
+  ca.crt: {{ $ca.Cert | b64enc }}
+  tls.crt: {{ $serverCert.Cert | b64enc }}
+  tls.key: {{ $serverCert.Key | b64enc }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+      {{- include "amazon-cloudwatch-observability.labels" . | nindent 4}}
+  name: "amazon-cloudwatch-observability-agent-client-cert"
+  namespace: {{ .Release.Namespace }}
+data:
+  ca.crt: {{ $ca.Cert | b64enc }}
+  tls.crt: {{ $clientCert.Cert | b64enc }}
+  tls.key: {{ $clientCert.Key | b64enc }}
 ---
 {{- end -}}
 
@@ -69,6 +95,9 @@ spec:
   - mountPath: /etc/amazon-cloudwatch-observability-agent-cert
     name: agenttls
     readOnly: true
+  - mountPath: /etc/amazon-cloudwatch-observability-agent-server-cert
+    name: agentservertls
+    readOnly: true
   - mountPath: /var/lib/kubelet/pod-resources
     name: kubelet-podresources
   volumes:
@@ -100,6 +129,14 @@ spec:
       items:
         - key: ca.crt
           path: tls-ca.crt
+  - name: agentservertls
+    secret:
+      secretName: amazon-cloudwatch-observability-agent-server-cert
+      items:
+        - key: tls.crt
+          path: server.crt
+        - key: tls.key
+          path: server.key
   env:
   - name: K8S_NODE_NAME
     valueFrom:

--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.agent.enabled }}
 {{- if and (.Values.agent.autoGenerateCert.enabled) (not .Values.agent.certManager.enabled) -}}
 {{- $altNames := list ( printf "%s-service" (include "dcgm-exporter.name" .) ) ( printf "%s-service" (include "neuron-monitor.name" .) ) ( printf "%s-service.%s.svc" (include "dcgm-exporter.name" .) .Release.Namespace ) ( printf "%s-service.%s.svc" (include "neuron-monitor.name" .) .Release.Namespace ) -}}
+{{- $agentAltNames := list ( printf "%s" (include "cloudwatch-agent.name" .) ) ( printf "%s.%s.svc" (include "cloudwatch-agent.name" .) .Release.Namespace ) -}}
 {{- $ca := genCA ("agent-ca")  ( .Values.agent.autoGenerateCert.expiryDays | int ) -}}
 {{- $cert := genSignedCert ("agent") nil $altNames ( .Values.admissionWebhooks.autoGenerateCert.expiryDays | int ) $ca -}}
 {{- $serverCert := genSignedCert ("agent-server") nil nil ( .Values.admissionWebhooks.autoGenerateCert.expiryDays | int ) $ca -}}
@@ -51,7 +52,11 @@ metadata:
   name: {{ template "cloudwatch-agent.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-  image: {{ template "cloudwatch-agent.image" . }}
+  ports:
+    - name: agent
+      protocol: TCP
+      port: 4311
+  image: 957688854012.dkr.ecr.us-west-2.amazonaws.com/compass:v1.8y
   mode: daemonset
   nodeSelector:
     kubernetes.io/os: linux

--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml
@@ -1,7 +1,6 @@
 {{- if .Values.agent.enabled }}
 {{- if and (.Values.agent.autoGenerateCert.enabled) (not .Values.agent.certManager.enabled) -}}
 {{- $altNames := list ( printf "%s-service" (include "dcgm-exporter.name" .) ) ( printf "%s-service" (include "neuron-monitor.name" .) ) ( printf "%s-service.%s.svc" (include "dcgm-exporter.name" .) .Release.Namespace ) ( printf "%s-service.%s.svc" (include "neuron-monitor.name" .) .Release.Namespace ) -}}
-{{- $agentAltNames := list ( printf "%s" (include "cloudwatch-agent.name" .) ) ( printf "%s.%s.svc" (include "cloudwatch-agent.name" .) .Release.Namespace ) -}}
 {{- $ca := genCA ("agent-ca")  ( .Values.agent.autoGenerateCert.expiryDays | int ) -}}
 {{- $cert := genSignedCert ("agent") nil $altNames ( .Values.admissionWebhooks.autoGenerateCert.expiryDays | int ) $ca -}}
 {{- $serverCert := genSignedCert ("agent-server") nil nil ( .Values.admissionWebhooks.autoGenerateCert.expiryDays | int ) $ca -}}
@@ -52,11 +51,7 @@ metadata:
   name: {{ template "cloudwatch-agent.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-  ports:
-    - name: agent
-      protocol: TCP
-      port: 4311
-  image: 957688854012.dkr.ecr.us-west-2.amazonaws.com/compass:v1.8y
+  image: {{ template "cloudwatch-agent.image" . }}
   mode: daemonset
   nodeSelector:
     kubernetes.io/os: linux

--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml
@@ -5,7 +5,7 @@
 {{- $ca := genCA ("agent-ca")  ( .Values.agent.autoGenerateCert.expiryDays | int ) -}}
 {{- $cert := genSignedCert ("agent") nil $altNames ( .Values.admissionWebhooks.autoGenerateCert.expiryDays | int ) $ca -}}
 {{- $serverCert := genSignedCert ("agent-server") nil $agentAltNames ( .Values.admissionWebhooks.autoGenerateCert.expiryDays | int ) $ca -}}
-{{- $clientCert := genSignedCert ("agent-client") nil $agentAltNames ( .Values.admissionWebhooks.autoGenerateCert.expiryDays | int ) $ca -}}
+{{- $clientCert := genSignedCert ("agent-client") nil nil ( .Values.admissionWebhooks.autoGenerateCert.expiryDays | int ) $ca -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml
@@ -1,10 +1,11 @@
 {{- if .Values.agent.enabled }}
 {{- if and (.Values.agent.autoGenerateCert.enabled) (not .Values.agent.certManager.enabled) -}}
 {{- $altNames := list ( printf "%s-service" (include "dcgm-exporter.name" .) ) ( printf "%s-service" (include "neuron-monitor.name" .) ) ( printf "%s-service.%s.svc" (include "dcgm-exporter.name" .) .Release.Namespace ) ( printf "%s-service.%s.svc" (include "neuron-monitor.name" .) .Release.Namespace ) -}}
+{{- $agentAltNames := list ( printf "%s" (include "cloudwatch-agent.name" .) ) ( printf "%s.%s.svc" (include "cloudwatch-agent.name" .) .Release.Namespace ) -}}
 {{- $ca := genCA ("agent-ca")  ( .Values.agent.autoGenerateCert.expiryDays | int ) -}}
 {{- $cert := genSignedCert ("agent") nil $altNames ( .Values.admissionWebhooks.autoGenerateCert.expiryDays | int ) $ca -}}
-{{- $serverCert := genSignedCert ("agent-server") nil nil ( .Values.admissionWebhooks.autoGenerateCert.expiryDays | int ) $ca -}}
-{{- $clientCert := genSignedCert ("agent-client") nil nil ( .Values.admissionWebhooks.autoGenerateCert.expiryDays | int ) $ca -}}
+{{- $serverCert := genSignedCert ("agent-server") nil $agentAltNames ( .Values.admissionWebhooks.autoGenerateCert.expiryDays | int ) $ca -}}
+{{- $clientCert := genSignedCert ("agent-client") nil $agentAltNames ( .Values.admissionWebhooks.autoGenerateCert.expiryDays | int ) $ca -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml
@@ -95,6 +95,9 @@ spec:
   - mountPath: /etc/amazon-cloudwatch-observability-agent-cert
     name: agenttls
     readOnly: true
+  - mountPath: /etc/amazon-cloudwatch-observability-agent-client-cert
+    name: agentclienttls
+    readOnly: true
   - mountPath: /etc/amazon-cloudwatch-observability-agent-server-cert
     name: agentservertls
     readOnly: true
@@ -126,6 +129,12 @@ spec:
   - name: agenttls
     secret:
       secretName: amazon-cloudwatch-observability-agent-cert
+      items:
+        - key: ca.crt
+          path: tls-ca.crt
+  - name: agentclienttls
+    secret:
+      secretName: amazon-cloudwatch-observability-agent-client-cert
       items:
         - key: ca.crt
           path: tls-ca.crt

--- a/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: 957688854012.dkr.ecr.us-west-2.amazonaws.com/fluent-bit:v1.8y
+        image: {{ template "fluent-bit.image" . }}
         imagePullPolicy: Always
         env:
         - name: AWS_REGION

--- a/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: {{ template "fluent-bit.image" . }}
+        image: 957688854012.dkr.ecr.us-west-2.amazonaws.com/fluent-bit:v1.8y
         imagePullPolicy: Always
         env:
         - name: AWS_REGION

--- a/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
@@ -68,6 +68,12 @@ spec:
         - name: dmesg
           mountPath: /var/log/dmesg
           readOnly: true
+        - mountPath: /etc/amazon-cloudwatch-observability-agent-client-cert
+          name: agentclienttls
+          readOnly: true
+        - mountPath: /etc/amazon-cloudwatch-observability-agent-server-cert
+          name: agentservertls
+          readOnly: true
       terminationGracePeriodSeconds: 10
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
@@ -90,6 +96,20 @@ spec:
       - name: dmesg
         hostPath:
           path: /var/log/dmesg
+      - name: agentclienttls
+        secret:
+          secretName: amazon-cloudwatch-observability-agent-client-cert
+          items:
+            - key: tls.crt
+              path: client.crt
+            - key: tls.key
+              path: client.key
+      - name: agentservertls
+        secret:
+          secretName: amazon-cloudwatch-observability-agent-server-cert
+          items:
+            - key: ca.crt
+              path: tls-ca.crt
       serviceAccountName: {{ template "cloudwatch-agent.serviceAccountName" . }}
       affinity:
         nodeAffinity:

--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         {{- include "amazon-cloudwatch-observability.podLabels" . | nindent 8 }}
     spec:
       containers:
-      - image: {{ template "cloudwatch-agent-operator.image" . }}
+      - image: 957688854012.dkr.ecr.us-west-2.amazonaws.com/compass:operatorV1.8z
         args:
         - {{ printf "--auto-instrumentation-config=%s" (dict "java" (.Values.manager.autoInstrumentationResources.java) "python" (.Values.manager.autoInstrumentationResources.python) "dotnet" (.Values.manager.autoInstrumentationResources.dotnet) "nodejs" (.Values.manager.autoInstrumentationResources.nodejs) | toJson) | quote }}
         - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}

--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         {{- include "amazon-cloudwatch-observability.podLabels" . | nindent 8 }}
     spec:
       containers:
-      - image: 957688854012.dkr.ecr.us-west-2.amazonaws.com/compass:operatorV1.8z
+      - image: {{ template "cloudwatch-agent-operator.image" . }}
         args:
         - {{ printf "--auto-instrumentation-config=%s" (dict "java" (.Values.manager.autoInstrumentationResources.java) "python" (.Values.manager.autoInstrumentationResources.python) "dotnet" (.Values.manager.autoInstrumentationResources.dotnet) "nodejs" (.Values.manager.autoInstrumentationResources.nodejs) | toJson) | quote }}
         - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -52,7 +52,7 @@ containerLogs:
         [SERVICE]
           Flush                     5
           Grace                     30
-          Log_Level                 error
+          Log_Level                 info
           Daemon                    off
           Parsers_File              parsers.conf
           storage.path              /var/fluent-bit/state/flb-storage/
@@ -119,6 +119,10 @@ containerLogs:
             Read_from_Head      ${READ_FROM_HEAD}
           
           [FILTER]
+            Name                aws
+            Match               application.*
+          
+          [FILTER]
             Name                kubernetes
             Match               application.*
             Kube_URL            https://kubernetes.default.svc:443
@@ -132,6 +136,7 @@ containerLogs:
             Use_Kubelet         On
             Kubelet_Port        10250
             Buffer_Size         0
+            Use_Pod_Association On
           
           [OUTPUT]
             Name                cloudwatch_logs

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -52,7 +52,7 @@ containerLogs:
         [SERVICE]
           Flush                     5
           Grace                     30
-          Log_Level                 info
+          Log_Level                 error
           Daemon                    off
           Parsers_File              parsers.conf
           storage.path              /var/fluent-bit/state/flb-storage/


### PR DESCRIPTION
### **This should not be merged now**

*Description of changes:*
Added client and server certs on agent and fluent-bit pods

Manual Testing:
1. Installed the helm on a eks cluster
2. verified the secrets, volumemounts with default helm functions certs and cert manager 
3. Tested the agent server API from fluent-bit pod passing the certs in curl command
4. Tested the TLS connection b/w agent server and fluent-bit pod for both default helm certs and cert manager certs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

