### PR TITLE
Adding support for supplemental YAML config for cloudwatch-agent on Linux

### DIFF
--- a/charts/amazon-cloudwatch-observability/crds/cloudwatch.aws.amazon.com_amazoncloudwatchagents.yaml
+++ b/charts/amazon-cloudwatch-observability/crds/cloudwatch.aws.amazon.com_amazoncloudwatchagents.yaml
@@ -3,9 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
-  labels:
-    app.kubernetes.io/name: amazon-cloudwatch-agent-operator
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: amazoncloudwatchagents.cloudwatch.aws.amazon.com
 spec:
   group: cloudwatch.aws.amazon.com
@@ -48,14 +46,19 @@ spec:
             API.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -63,51 +66,54 @@ spec:
               description: AmazonCloudWatchAgentSpec defines the desired state of AmazonCloudWatchAgent.
               properties:
                 additionalContainers:
-                  description: "AdditionalContainers allows injecting additional containers
-                  into the Collector's pod definition. These sidecar containers can
-                  be used for authentication proxies, log shipping sidecars, agents
-                  for shipping metrics to their cloud, or in general sidecars that
-                  do not support automatic injection. This option only applies to
-                  Deployment, DaemonSet, and StatefulSet deployment modes of the collector.
-                  It does not apply to the sidecar deployment mode. More info about
-                  sidecars: https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/
-                  \n Container names managed by the operator: * `otc-container` \n
-                  Overriding containers managed by the operator is outside the scope
-                  of what the maintainers will support and by doing so, you wil accept
-                  the risk of it breaking things."
+                  description: |-
+                    AdditionalContainers allows injecting additional containers into the Collector's pod definition.
+                    These sidecar containers can be used for authentication proxies, log shipping sidecars, agents for shipping
+                    metrics to their cloud, or in general sidecars that do not support automatic injection. This option only
+                    applies to Deployment, DaemonSet, and StatefulSet deployment modes of the collector. It does not apply to the sidecar
+                    deployment mode. More info about sidecars:
+                    https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/
+                    
+                    
+                    Container names managed by the operator:
+                    * `otc-container`
+                    
+                    
+                    Overriding containers managed by the operator is outside the scope of what the maintainers will support and by
+                    doing so, you wil accept the risk of it breaking things.
                   items:
                     description: A single application container that you want to run
                       within a pod.
                     properties:
                       args:
-                        description: 'Arguments to the entrypoint. The container image''s
-                        CMD is used if this is not provided. Variable references $(VAR_NAME)
-                        are expanded using the container''s environment. If a variable
-                        cannot be resolved, the reference in the input string will
-                        be unchanged. Double $$ are reduced to a single $, which allows
-                        for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                        produce the string literal "$(VAR_NAME)". Escaped references
-                        will never be expanded, regardless of whether the variable
-                        exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                        description: |-
+                          Arguments to the entrypoint.
+                          The container image's CMD is used if this is not provided.
+                          Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                          cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                          produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                          of whether the variable exists or not. Cannot be updated.
+                          More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                         items:
                           type: string
                         type: array
                       command:
-                        description: 'Entrypoint array. Not executed within a shell.
-                        The container image''s ENTRYPOINT is used if this is not provided.
-                        Variable references $(VAR_NAME) are expanded using the container''s
-                        environment. If a variable cannot be resolved, the reference
-                        in the input string will be unchanged. Double $$ are reduced
-                        to a single $, which allows for escaping the $(VAR_NAME) syntax:
-                        i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                        Escaped references will never be expanded, regardless of whether
-                        the variable exists or not. Cannot be updated. More info:
-                        https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                        description: |-
+                          Entrypoint array. Not executed within a shell.
+                          The container image's ENTRYPOINT is used if this is not provided.
+                          Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                          cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                          produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                          of whether the variable exists or not. Cannot be updated.
+                          More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                         items:
                           type: string
                         type: array
                       env:
-                        description: List of environment variables to set in the container.
+                        description: |-
+                          List of environment variables to set in the container.
                           Cannot be updated.
                         items:
                           description: EnvVar represents an environment variable present
@@ -118,16 +124,16 @@ spec:
                                 a C_IDENTIFIER.
                               type: string
                             value:
-                              description: 'Variable references $(VAR_NAME) are expanded
-                              using the previously defined environment variables in
-                              the container and any service environment variables.
-                              If a variable cannot be resolved, the reference in the
-                              input string will be unchanged. Double $$ are reduced
-                              to a single $, which allows for escaping the $(VAR_NAME)
-                              syntax: i.e. "$$(VAR_NAME)" will produce the string
-                              literal "$(VAR_NAME)". Escaped references will never
-                              be expanded, regardless of whether the variable exists
-                              or not. Defaults to "".'
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
                               type: string
                             valueFrom:
                               description: Source for the environment variable's value.
@@ -140,10 +146,10 @@ spec:
                                       description: The key to select.
                                       type: string
                                     name:
-                                      description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                     optional:
                                       description: Specify whether the ConfigMap or
@@ -154,11 +160,9 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: 'Selects a field of the pod: supports
-                                  metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                  `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                  spec.serviceAccountName, status.hostIP, status.podIP,
-                                  status.podIPs.'
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
                                       description: Version of the schema the FieldPath
@@ -173,11 +177,9 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: 'Selects a resource of the container:
-                                  only resources limits and requests (limits.cpu,
-                                  limits.memory, limits.ephemeral-storage, requests.cpu,
-                                  requests.memory and requests.ephemeral-storage)
-                                  are currently supported.'
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
                                       description: 'Container name: required for volumes,
@@ -207,10 +209,10 @@ spec:
                                         be a valid secret key.
                                       type: string
                                     name:
-                                      description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                     optional:
                                       description: Specify whether the Secret or its
@@ -226,13 +228,13 @@ spec:
                           type: object
                         type: array
                       envFrom:
-                        description: List of sources to populate environment variables
-                          in the container. The keys defined within a source must be
-                          a C_IDENTIFIER. All invalid keys will be reported as an event
-                          when the container is starting. When a key exists in multiple
-                          sources, the value associated with the last source will take
-                          precedence. Values defined by an Env with a duplicate key
-                          will take precedence. Cannot be updated.
+                        description: |-
+                          List of sources to populate environment variables in the container.
+                          The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                          will be reported as an event when the container is starting. When a key exists in multiple
+                          sources, the value associated with the last source will take precedence.
+                          Values defined by an Env with a duplicate key will take precedence.
+                          Cannot be updated.
                         items:
                           description: EnvFromSource represents the source of a set
                             of ConfigMaps
@@ -241,9 +243,10 @@ spec:
                               description: The ConfigMap to select from
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
                                   description: Specify whether the ConfigMap must be
@@ -259,9 +262,10 @@ spec:
                               description: The Secret to select from
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
                                   description: Specify whether the Secret must be defined
@@ -271,40 +275,42 @@ spec:
                           type: object
                         type: array
                       image:
-                        description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
-                        This field is optional to allow higher level config management
-                        to default or override container images in workload controllers
-                        like Deployments and StatefulSets.'
+                        description: |-
+                          Container image name.
+                          More info: https://kubernetes.io/docs/concepts/containers/images
+                          This field is optional to allow higher level config management to default or override
+                          container images in workload controllers like Deployments and StatefulSets.
                         type: string
                       imagePullPolicy:
-                        description: 'Image pull policy. One of Always, Never, IfNotPresent.
-                        Defaults to Always if :latest tag is specified, or IfNotPresent
-                        otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                        description: |-
+                          Image pull policy.
+                          One of Always, Never, IfNotPresent.
+                          Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                         type: string
                       lifecycle:
-                        description: Actions that the management system should take
-                          in response to container lifecycle events. Cannot be updated.
+                        description: |-
+                          Actions that the management system should take in response to container lifecycle events.
+                          Cannot be updated.
                         properties:
                           postStart:
-                            description: 'PostStart is called immediately after a container
-                            is created. If the handler fails, the container is terminated
-                            and restarted according to its restart policy. Other management
-                            of the container blocks until the hook completes. More
-                            info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                            description: |-
+                              PostStart is called immediately after a container is created. If the handler fails,
+                              the container is terminated and restarted according to its restart policy.
+                              Other management of the container blocks until the hook completes.
+                              More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                             properties:
                               exec:
                                 description: Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory for
-                                      the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions
-                                      ('|', etc) won't work. To use a shell, you need
-                                      to explicitly call out to that shell. Exit status
-                                      of 0 is treated as live/healthy and non-zero is
-                                      unhealthy.
+                                    description: |-
+                                      Command is the command line to execute inside the container, the working directory for the
+                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                      a shell, you need to explicitly call out to that shell.
+                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                     items:
                                       type: string
                                     type: array
@@ -313,9 +319,9 @@ spec:
                                 description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to
-                                      the pod IP. You probably want to set "Host" in
-                                      httpHeaders instead.
+                                    description: |-
+                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                      "Host" in httpHeaders instead.
                                     type: string
                                   httpHeaders:
                                     description: Custom headers to set in the request.
@@ -325,9 +331,9 @@ spec:
                                         to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name. This will
-                                            be canonicalized upon output, so case-variant
-                                            names will be understood as the same header.
+                                          description: |-
+                                            The header field name.
+                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                           type: string
                                         value:
                                           description: The header field value
@@ -344,13 +350,15 @@ spec:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    description: |-
+                                      Name or number of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
+                                    description: |-
+                                      Scheme to use for connecting to the host.
+                                      Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
@@ -368,10 +376,10 @@ spec:
                                   - seconds
                                 type: object
                               tcpSocket:
-                                description: Deprecated. TCPSocket is NOT supported
-                                  as a LifecycleHandler and kept for the backward compatibility.
-                                  There are no validation of this field and lifecycle
-                                  hooks will fail in runtime when tcp handler is specified.
+                                description: |-
+                                  Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                  for the backward compatibility. There are no validation of this field and
+                                  lifecycle hooks will fail in runtime when tcp handler is specified.
                                 properties:
                                   host:
                                     description: 'Optional: Host name to connect to,
@@ -381,40 +389,37 @@ spec:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    description: |-
+                                      Number or name of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                             type: object
                           preStop:
-                            description: 'PreStop is called immediately before a container
-                            is terminated due to an API request or management event
-                            such as liveness/startup probe failure, preemption, resource
-                            contention, etc. The handler is not called if the container
-                            crashes or exits. The Pod''s termination grace period
-                            countdown begins before the PreStop hook is executed.
-                            Regardless of the outcome of the handler, the container
-                            will eventually terminate within the Pod''s termination
-                            grace period (unless delayed by finalizers). Other management
-                            of the container blocks until the hook completes or until
-                            the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                            description: |-
+                              PreStop is called immediately before a container is terminated due to an
+                              API request or management event such as liveness/startup probe failure,
+                              preemption, resource contention, etc. The handler is not called if the
+                              container crashes or exits. The Pod's termination grace period countdown begins before the
+                              PreStop hook is executed. Regardless of the outcome of the handler, the
+                              container will eventually terminate within the Pod's termination grace
+                              period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                              or until the termination grace period is reached.
+                              More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                             properties:
                               exec:
                                 description: Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory for
-                                      the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions
-                                      ('|', etc) won't work. To use a shell, you need
-                                      to explicitly call out to that shell. Exit status
-                                      of 0 is treated as live/healthy and non-zero is
-                                      unhealthy.
+                                    description: |-
+                                      Command is the command line to execute inside the container, the working directory for the
+                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                      a shell, you need to explicitly call out to that shell.
+                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                     items:
                                       type: string
                                     type: array
@@ -423,9 +428,9 @@ spec:
                                 description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to
-                                      the pod IP. You probably want to set "Host" in
-                                      httpHeaders instead.
+                                    description: |-
+                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                      "Host" in httpHeaders instead.
                                     type: string
                                   httpHeaders:
                                     description: Custom headers to set in the request.
@@ -435,9 +440,9 @@ spec:
                                         to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name. This will
-                                            be canonicalized upon output, so case-variant
-                                            names will be understood as the same header.
+                                          description: |-
+                                            The header field name.
+                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                           type: string
                                         value:
                                           description: The header field value
@@ -454,13 +459,15 @@ spec:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    description: |-
+                                      Name or number of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
+                                    description: |-
+                                      Scheme to use for connecting to the host.
+                                      Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
@@ -478,10 +485,10 @@ spec:
                                   - seconds
                                 type: object
                               tcpSocket:
-                                description: Deprecated. TCPSocket is NOT supported
-                                  as a LifecycleHandler and kept for the backward compatibility.
-                                  There are no validation of this field and lifecycle
-                                  hooks will fail in runtime when tcp handler is specified.
+                                description: |-
+                                  Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                  for the backward compatibility. There are no validation of this field and
+                                  lifecycle hooks will fail in runtime when tcp handler is specified.
                                 properties:
                                   host:
                                     description: 'Optional: Host name to connect to,
@@ -491,9 +498,10 @@ spec:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    description: |-
+                                      Number or name of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
@@ -501,30 +509,30 @@ spec:
                             type: object
                         type: object
                       livenessProbe:
-                        description: 'Periodic probe of container liveness. Container
-                        will be restarted if the probe fails. Cannot be updated. More
-                        info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        description: |-
+                          Periodic probe of container liveness.
+                          Container will be restarted if the probe fails.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         properties:
                           exec:
                             description: Exec specifies the action to take.
                             properties:
                               command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for the
-                                  command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|', etc)
-                                  won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
+                                description: |-
+                                  Command is the command line to execute inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                  a shell, you need to explicitly call out to that shell.
+                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                 items:
                                   type: string
                                 type: array
                             type: object
                           failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
+                            description: |-
+                              Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                              Defaults to 3. Minimum value is 1.
                             format: int32
                             type: integer
                           grpc:
@@ -536,10 +544,12 @@ spec:
                                 format: int32
                                 type: integer
                               service:
-                                description: "Service is the name of the service to
-                                place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                \n If this is not specified, the default behavior
-                                is defined by gRPC."
+                                description: |-
+                                  Service is the name of the service to place in the gRPC HealthCheckRequest
+                                  (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                  
+                                  
+                                  If this is not specified, the default behavior is defined by gRPC.
                                 type: string
                             required:
                               - port
@@ -548,9 +558,9 @@ spec:
                             description: HTTPGet specifies the http request to perform.
                             properties:
                               host:
-                                description: Host name to connect to, defaults to the
-                                  pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
+                                description: |-
+                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                  "Host" in httpHeaders instead.
                                 type: string
                               httpHeaders:
                                 description: Custom headers to set in the request. HTTP
@@ -560,9 +570,9 @@ spec:
                                     to be used in HTTP probes
                                   properties:
                                     name:
-                                      description: The header field name. This will
-                                        be canonicalized upon output, so case-variant
-                                        names will be understood as the same header.
+                                      description: |-
+                                        The header field name.
+                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                       type: string
                                     value:
                                       description: The header field value
@@ -579,33 +589,35 @@ spec:
                                 anyOf:
                                   - type: integer
                                   - type: string
-                                description: Name or number of the port to access on
-                                  the container. Number must be in the range 1 to 65535.
+                                description: |-
+                                  Name or number of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
                                   Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                               scheme:
-                                description: Scheme to use for connecting to the host.
+                                description: |-
+                                  Scheme to use for connecting to the host.
                                   Defaults to HTTP.
                                 type: string
                             required:
                               - port
                             type: object
                           initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                            started before liveness probes are initiated. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            description: |-
+                              Number of seconds after the container has started before liveness probes are initiated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                             format: int32
                             type: integer
                           periodSeconds:
-                            description: How often (in seconds) to perform the probe.
+                            description: |-
+                              How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                             format: int32
                             type: integer
                           successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
+                            description: |-
+                              Minimum consecutive successes for the probe to be considered successful after having failed.
+                              Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                             format: int32
                             type: integer
                           tcpSocket:
@@ -620,78 +632,82 @@ spec:
                                 anyOf:
                                   - type: integer
                                   - type: string
-                                description: Number or name of the port to access on
-                                  the container. Number must be in the range 1 to 65535.
+                                description: |-
+                                  Number or name of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
                                   Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                             required:
                               - port
                             type: object
                           terminationGracePeriodSeconds:
-                            description: Optional duration in seconds the pod needs
-                              to terminate gracefully upon probe failure. The grace
-                              period is the duration in seconds after the processes
-                              running in the pod are sent a termination signal and the
-                              time when the processes are forcibly halted with a kill
-                              signal. Set this value longer than the expected cleanup
-                              time for your process. If this value is nil, the pod's
-                              terminationGracePeriodSeconds will be used. Otherwise,
-                              this value overrides the value provided by the pod spec.
-                              Value must be non-negative integer. The value zero indicates
-                              stop immediately via the kill signal (no opportunity to
-                              shut down). This is a beta field and requires enabling
-                              ProbeTerminationGracePeriod feature gate. Minimum value
-                              is 1. spec.terminationGracePeriodSeconds is used if unset.
+                            description: |-
+                              Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                              The grace period is the duration in seconds after the processes running in the pod are sent
+                              a termination signal and the time when the processes are forcibly halted with a kill signal.
+                              Set this value longer than the expected cleanup time for your process.
+                              If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                              value overrides the value provided by the pod spec.
+                              Value must be non-negative integer. The value zero indicates stop immediately via
+                              the kill signal (no opportunity to shut down).
+                              This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                              Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                             format: int64
                             type: integer
                           timeoutSeconds:
-                            description: 'Number of seconds after which the probe times
-                            out. Defaults to 1 second. Minimum value is 1. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            description: |-
+                              Number of seconds after which the probe times out.
+                              Defaults to 1 second. Minimum value is 1.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                             format: int32
                             type: integer
                         type: object
                       name:
-                        description: Name of the container specified as a DNS_LABEL.
+                        description: |-
+                          Name of the container specified as a DNS_LABEL.
                           Each container in a pod must have a unique name (DNS_LABEL).
                           Cannot be updated.
                         type: string
                       ports:
-                        description: List of ports to expose from the container. Not
-                          specifying a port here DOES NOT prevent that port from being
-                          exposed. Any port which is listening on the default "0.0.0.0"
-                          address inside a container will be accessible from the network.
-                          Modifying this array with strategic merge patch may corrupt
-                          the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                        description: |-
+                          List of ports to expose from the container. Not specifying a port here
+                          DOES NOT prevent that port from being exposed. Any port which is
+                          listening on the default "0.0.0.0" address inside a container will be
+                          accessible from the network.
+                          Modifying this array with strategic merge patch may corrupt the data.
+                          For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                           Cannot be updated.
                         items:
                           description: ContainerPort represents a network port in a
                             single container.
                           properties:
                             containerPort:
-                              description: Number of port to expose on the pod's IP
-                                address. This must be a valid port number, 0 < x < 65536.
+                              description: |-
+                                Number of port to expose on the pod's IP address.
+                                This must be a valid port number, 0 < x < 65536.
                               format: int32
                               type: integer
                             hostIP:
                               description: What host IP to bind the external port to.
                               type: string
                             hostPort:
-                              description: Number of port to expose on the host. If
-                                specified, this must be a valid port number, 0 < x <
-                                65536. If HostNetwork is specified, this must match
-                                ContainerPort. Most containers do not need this.
+                              description: |-
+                                Number of port to expose on the host.
+                                If specified, this must be a valid port number, 0 < x < 65536.
+                                If HostNetwork is specified, this must match ContainerPort.
+                                Most containers do not need this.
                               format: int32
                               type: integer
                             name:
-                              description: If specified, this must be an IANA_SVC_NAME
-                                and unique within the pod. Each named port in a pod
-                                must have a unique name. Name for the port that can
-                                be referred to by services.
+                              description: |-
+                                If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                named port in a pod must have a unique name. Name for the port that can be
+                                referred to by services.
                               type: string
                             protocol:
                               default: TCP
-                              description: Protocol for port. Must be UDP, TCP, or SCTP.
+                              description: |-
+                                Protocol for port. Must be UDP, TCP, or SCTP.
                                 Defaults to "TCP".
                               type: string
                           required:
@@ -703,30 +719,30 @@ spec:
                           - protocol
                         x-kubernetes-list-type: map
                       readinessProbe:
-                        description: 'Periodic probe of container service readiness.
-                        Container will be removed from service endpoints if the probe
-                        fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        description: |-
+                          Periodic probe of container service readiness.
+                          Container will be removed from service endpoints if the probe fails.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         properties:
                           exec:
                             description: Exec specifies the action to take.
                             properties:
                               command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for the
-                                  command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|', etc)
-                                  won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
+                                description: |-
+                                  Command is the command line to execute inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                  a shell, you need to explicitly call out to that shell.
+                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                 items:
                                   type: string
                                 type: array
                             type: object
                           failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
+                            description: |-
+                              Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                              Defaults to 3. Minimum value is 1.
                             format: int32
                             type: integer
                           grpc:
@@ -738,10 +754,12 @@ spec:
                                 format: int32
                                 type: integer
                               service:
-                                description: "Service is the name of the service to
-                                place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                \n If this is not specified, the default behavior
-                                is defined by gRPC."
+                                description: |-
+                                  Service is the name of the service to place in the gRPC HealthCheckRequest
+                                  (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                  
+                                  
+                                  If this is not specified, the default behavior is defined by gRPC.
                                 type: string
                             required:
                               - port
@@ -750,9 +768,9 @@ spec:
                             description: HTTPGet specifies the http request to perform.
                             properties:
                               host:
-                                description: Host name to connect to, defaults to the
-                                  pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
+                                description: |-
+                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                  "Host" in httpHeaders instead.
                                 type: string
                               httpHeaders:
                                 description: Custom headers to set in the request. HTTP
@@ -762,9 +780,9 @@ spec:
                                     to be used in HTTP probes
                                   properties:
                                     name:
-                                      description: The header field name. This will
-                                        be canonicalized upon output, so case-variant
-                                        names will be understood as the same header.
+                                      description: |-
+                                        The header field name.
+                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                       type: string
                                     value:
                                       description: The header field value
@@ -781,33 +799,35 @@ spec:
                                 anyOf:
                                   - type: integer
                                   - type: string
-                                description: Name or number of the port to access on
-                                  the container. Number must be in the range 1 to 65535.
+                                description: |-
+                                  Name or number of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
                                   Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                               scheme:
-                                description: Scheme to use for connecting to the host.
+                                description: |-
+                                  Scheme to use for connecting to the host.
                                   Defaults to HTTP.
                                 type: string
                             required:
                               - port
                             type: object
                           initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                            started before liveness probes are initiated. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            description: |-
+                              Number of seconds after the container has started before liveness probes are initiated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                             format: int32
                             type: integer
                           periodSeconds:
-                            description: How often (in seconds) to perform the probe.
+                            description: |-
+                              How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                             format: int32
                             type: integer
                           successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
+                            description: |-
+                              Minimum consecutive successes for the probe to be considered successful after having failed.
+                              Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                             format: int32
                             type: integer
                           tcpSocket:
@@ -822,34 +842,33 @@ spec:
                                 anyOf:
                                   - type: integer
                                   - type: string
-                                description: Number or name of the port to access on
-                                  the container. Number must be in the range 1 to 65535.
+                                description: |-
+                                  Number or name of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
                                   Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                             required:
                               - port
                             type: object
                           terminationGracePeriodSeconds:
-                            description: Optional duration in seconds the pod needs
-                              to terminate gracefully upon probe failure. The grace
-                              period is the duration in seconds after the processes
-                              running in the pod are sent a termination signal and the
-                              time when the processes are forcibly halted with a kill
-                              signal. Set this value longer than the expected cleanup
-                              time for your process. If this value is nil, the pod's
-                              terminationGracePeriodSeconds will be used. Otherwise,
-                              this value overrides the value provided by the pod spec.
-                              Value must be non-negative integer. The value zero indicates
-                              stop immediately via the kill signal (no opportunity to
-                              shut down). This is a beta field and requires enabling
-                              ProbeTerminationGracePeriod feature gate. Minimum value
-                              is 1. spec.terminationGracePeriodSeconds is used if unset.
+                            description: |-
+                              Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                              The grace period is the duration in seconds after the processes running in the pod are sent
+                              a termination signal and the time when the processes are forcibly halted with a kill signal.
+                              Set this value longer than the expected cleanup time for your process.
+                              If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                              value overrides the value provided by the pod spec.
+                              Value must be non-negative integer. The value zero indicates stop immediately via
+                              the kill signal (no opportunity to shut down).
+                              This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                              Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                             format: int64
                             type: integer
                           timeoutSeconds:
-                            description: 'Number of seconds after which the probe times
-                            out. Defaults to 1 second. Minimum value is 1. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            description: |-
+                              Number of seconds after which the probe times out.
+                              Defaults to 1 second. Minimum value is 1.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                             format: int32
                             type: integer
                         type: object
@@ -860,12 +879,14 @@ spec:
                             policy for the container.
                           properties:
                             resourceName:
-                              description: 'Name of the resource to which this resource
-                              resize policy applies. Supported values: cpu, memory.'
+                              description: |-
+                                Name of the resource to which this resource resize policy applies.
+                                Supported values: cpu, memory.
                               type: string
                             restartPolicy:
-                              description: Restart policy to apply when specified resource
-                                is resized. If not specified, it defaults to NotRequired.
+                              description: |-
+                                Restart policy to apply when specified resource is resized.
+                                If not specified, it defaults to NotRequired.
                               type: string
                           required:
                             - resourceName
@@ -874,22 +895,29 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                       resources:
-                        description: 'Compute Resources required by this container.
-                        Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        description: |-
+                          Compute Resources required by this container.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         properties:
                           claims:
-                            description: "Claims lists the names of resources, defined
-                            in spec.resourceClaims, that are used by this container.
-                            \n This is an alpha field and requires enabling the DynamicResourceAllocation
-                            feature gate. \n This field is immutable. It can only
-                            be set for containers."
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+                              
+                              
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+                              
+                              
+                              This field is immutable. It can only be set for containers.
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: Name must match the name of one entry
-                                    in pod.spec.resourceClaims of the Pod where this
-                                    field is used. It makes that resource available
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
                                     inside a container.
                                   type: string
                               required:
@@ -906,8 +934,9 @@ spec:
                                 - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -916,52 +945,52 @@ spec:
                                 - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of compute
-                            resources required. If Requests is omitted for a container,
-                            it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. Requests
-                            cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       restartPolicy:
-                        description: 'RestartPolicy defines the restart behavior of
-                        individual containers in a pod. This field may only be set
-                        for init containers, and the only allowed value is "Always".
-                        For non-init containers or when this field is not specified,
-                        the restart behavior is defined by the Pod''s restart policy
-                        and the container type. Setting the RestartPolicy as "Always"
-                        for the init container will have the following effect: this
-                        init container will be continually restarted on exit until
-                        all regular containers have terminated. Once all regular containers
-                        have completed, all init containers with restartPolicy "Always"
-                        will be shut down. This lifecycle differs from normal init
-                        containers and is often referred to as a "sidecar" container.
-                        Although this init container still starts in the init container
-                        sequence, it does not wait for the container to complete before
-                        proceeding to the next init container. Instead, the next init
-                        container starts immediately after this init container is
-                        started, or after any startupProbe has successfully completed.'
+                        description: |-
+                          RestartPolicy defines the restart behavior of individual containers in a pod.
+                          This field may only be set for init containers, and the only allowed value is "Always".
+                          For non-init containers or when this field is not specified,
+                          the restart behavior is defined by the Pod's restart policy and the container type.
+                          Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                          this init container will be continually restarted on
+                          exit until all regular containers have terminated. Once all regular
+                          containers have completed, all init containers with restartPolicy "Always"
+                          will be shut down. This lifecycle differs from normal init containers and
+                          is often referred to as a "sidecar" container. Although this init
+                          container still starts in the init container sequence, it does not wait
+                          for the container to complete before proceeding to the next init
+                          container. Instead, the next init container starts immediately after this
+                          init container is started, or after any startupProbe has successfully
+                          completed.
                         type: string
                       securityContext:
-                        description: 'SecurityContext defines the security options the
-                        container should be run with. If set, the fields of SecurityContext
-                        override the equivalent fields of PodSecurityContext. More
-                        info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                        description: |-
+                          SecurityContext defines the security options the container should be run with.
+                          If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                          More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                         properties:
                           allowPrivilegeEscalation:
-                            description: 'AllowPrivilegeEscalation controls whether
-                            a process can gain more privileges than its parent process.
-                            This bool directly controls if the no_new_privs flag will
-                            be set on the container process. AllowPrivilegeEscalation
-                            is true always when the container is: 1) run as Privileged
-                            2) has CAP_SYS_ADMIN Note that this field cannot be set
-                            when spec.os.name is windows.'
+                            description: |-
+                              AllowPrivilegeEscalation controls whether a process can gain more
+                              privileges than its parent process. This bool directly controls if
+                              the no_new_privs flag will be set on the container process.
+                              AllowPrivilegeEscalation is true always when the container is:
+                              1) run as Privileged
+                              2) has CAP_SYS_ADMIN
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: boolean
                           capabilities:
-                            description: The capabilities to add/drop when running containers.
-                              Defaults to the default set of capabilities granted by
-                              the container runtime. Note that this field cannot be
-                              set when spec.os.name is windows.
+                            description: |-
+                              The capabilities to add/drop when running containers.
+                              Defaults to the default set of capabilities granted by the container runtime.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               add:
                                 description: Added capabilities
@@ -979,60 +1008,60 @@ spec:
                                 type: array
                             type: object
                           privileged:
-                            description: Run container in privileged mode. Processes
-                              in privileged containers are essentially equivalent to
-                              root on the host. Defaults to false. Note that this field
-                              cannot be set when spec.os.name is windows.
+                            description: |-
+                              Run container in privileged mode.
+                              Processes in privileged containers are essentially equivalent to root on the host.
+                              Defaults to false.
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: boolean
                           procMount:
-                            description: procMount denotes the type of proc mount to
-                              use for the containers. The default is DefaultProcMount
-                              which uses the container runtime defaults for readonly
-                              paths and masked paths. This requires the ProcMountType
-                              feature flag to be enabled. Note that this field cannot
-                              be set when spec.os.name is windows.
+                            description: |-
+                              procMount denotes the type of proc mount to use for the containers.
+                              The default is DefaultProcMount which uses the container runtime defaults for
+                              readonly paths and masked paths.
+                              This requires the ProcMountType feature flag to be enabled.
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
-                            description: Whether this container has a read-only root
-                              filesystem. Default is false. Note that this field cannot
-                              be set when spec.os.name is windows.
+                            description: |-
+                              Whether this container has a read-only root filesystem.
+                              Default is false.
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: boolean
                           runAsGroup:
-                            description: The GID to run the entrypoint of the container
-                              process. Uses runtime default if unset. May also be set
-                              in PodSecurityContext.  If set in both SecurityContext
-                              and PodSecurityContext, the value specified in SecurityContext
-                              takes precedence. Note that this field cannot be set when
-                              spec.os.name is windows.
+                            description: |-
+                              The GID to run the entrypoint of the container process.
+                              Uses runtime default if unset.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
                             format: int64
                             type: integer
                           runAsNonRoot:
-                            description: Indicates that the container must run as a
-                              non-root user. If true, the Kubelet will validate the
-                              image at runtime to ensure that it does not run as UID
-                              0 (root) and fail to start the container if it does. If
-                              unset or false, no such validation will be performed.
-                              May also be set in PodSecurityContext.  If set in both
-                              SecurityContext and PodSecurityContext, the value specified
-                              in SecurityContext takes precedence.
+                            description: |-
+                              Indicates that the container must run as a non-root user.
+                              If true, the Kubelet will validate the image at runtime to ensure that it
+                              does not run as UID 0 (root) and fail to start the container if it does.
+                              If unset or false, no such validation will be performed.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
                             type: boolean
                           runAsUser:
-                            description: The UID to run the entrypoint of the container
-                              process. Defaults to user specified in image metadata
-                              if unspecified. May also be set in PodSecurityContext.  If
-                              set in both SecurityContext and PodSecurityContext, the
-                              value specified in SecurityContext takes precedence. Note
-                              that this field cannot be set when spec.os.name is windows.
+                            description: |-
+                              The UID to run the entrypoint of the container process.
+                              Defaults to user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
                             format: int64
                             type: integer
                           seLinuxOptions:
-                            description: The SELinux context to be applied to the container.
-                              If unspecified, the container runtime will allocate a
-                              random SELinux context for each container.  May also be
-                              set in PodSecurityContext.  If set in both SecurityContext
-                              and PodSecurityContext, the value specified in SecurityContext
-                              takes precedence. Note that this field cannot be set when
-                              spec.os.name is windows.
+                            description: |-
+                              The SELinux context to be applied to the container.
+                              If unspecified, the container runtime will allocate a random SELinux context for each
+                              container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               level:
                                 description: Level is SELinux level label that applies
@@ -1052,98 +1081,93 @@ spec:
                                 type: string
                             type: object
                           seccompProfile:
-                            description: The seccomp options to use by this container.
-                              If seccomp options are provided at both the pod & container
-                              level, the container options override the pod options.
-                              Note that this field cannot be set when spec.os.name is
-                              windows.
+                            description: |-
+                              The seccomp options to use by this container. If seccomp options are
+                              provided at both the pod & container level, the container options
+                              override the pod options.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               localhostProfile:
-                                description: localhostProfile indicates a profile defined
-                                  in a file on the node should be used. The profile
-                                  must be preconfigured on the node to work. Must be
-                                  a descending path, relative to the kubelet's configured
-                                  seccomp profile location. Must be set if type is "Localhost".
-                                  Must NOT be set for any other type.
+                                description: |-
+                                  localhostProfile indicates a profile defined in a file on the node should be used.
+                                  The profile must be preconfigured on the node to work.
+                                  Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                  Must be set if type is "Localhost". Must NOT be set for any other type.
                                 type: string
                               type:
-                                description: "type indicates which kind of seccomp profile
-                                will be applied. Valid options are: \n Localhost -
-                                a profile defined in a file on the node should be
-                                used. RuntimeDefault - the container runtime default
-                                profile should be used. Unconfined - no profile should
-                                be applied."
+                                description: |-
+                                  type indicates which kind of seccomp profile will be applied.
+                                  Valid options are:
+                                  
+                                  
+                                  Localhost - a profile defined in a file on the node should be used.
+                                  RuntimeDefault - the container runtime default profile should be used.
+                                  Unconfined - no profile should be applied.
                                 type: string
                             required:
                               - type
                             type: object
                           windowsOptions:
-                            description: The Windows specific settings applied to all
-                              containers. If unspecified, the options from the PodSecurityContext
-                              will be used. If set in both SecurityContext and PodSecurityContext,
-                              the value specified in SecurityContext takes precedence.
-                              Note that this field cannot be set when spec.os.name is
-                              linux.
+                            description: |-
+                              The Windows specific settings applied to all containers.
+                              If unspecified, the options from the PodSecurityContext will be used.
+                              If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is linux.
                             properties:
                               gmsaCredentialSpec:
-                                description: GMSACredentialSpec is where the GMSA admission
-                                  webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                  inlines the contents of the GMSA credential spec named
-                                  by the GMSACredentialSpecName field.
+                                description: |-
+                                  GMSACredentialSpec is where the GMSA admission webhook
+                                  (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                  GMSA credential spec named by the GMSACredentialSpecName field.
                                 type: string
                               gmsaCredentialSpecName:
                                 description: GMSACredentialSpecName is the name of the
                                   GMSA credential spec to use.
                                 type: string
                               hostProcess:
-                                description: HostProcess determines if a container should
-                                  be run as a 'Host Process' container. All of a Pod's
-                                  containers must have the same effective HostProcess
-                                  value (it is not allowed to have a mix of HostProcess
-                                  containers and non-HostProcess containers). In addition,
-                                  if HostProcess is true then HostNetwork must also
-                                  be set to true.
+                                description: |-
+                                  HostProcess determines if a container should be run as a 'Host Process' container.
+                                  All of a Pod's containers must have the same effective HostProcess value
+                                  (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                  In addition, if HostProcess is true then HostNetwork must also be set to true.
                                 type: boolean
                               runAsUserName:
-                                description: The UserName in Windows to run the entrypoint
-                                  of the container process. Defaults to the user specified
-                                  in image metadata if unspecified. May also be set
-                                  in PodSecurityContext. If set in both SecurityContext
-                                  and PodSecurityContext, the value specified in SecurityContext
-                                  takes precedence.
+                                description: |-
+                                  The UserName in Windows to run the entrypoint of the container process.
+                                  Defaults to the user specified in image metadata if unspecified.
+                                  May also be set in PodSecurityContext. If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
                                 type: string
                             type: object
                         type: object
                       startupProbe:
-                        description: 'StartupProbe indicates that the Pod has successfully
-                        initialized. If specified, no other probes are executed until
-                        this completes successfully. If this probe fails, the Pod
-                        will be restarted, just as if the livenessProbe failed. This
-                        can be used to provide different probe parameters at the beginning
-                        of a Pod''s lifecycle, when it might take a long time to load
-                        data or warm a cache, than during steady-state operation.
-                        This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        description: |-
+                          StartupProbe indicates that the Pod has successfully initialized.
+                          If specified, no other probes are executed until this completes successfully.
+                          If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                          This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                          when it might take a long time to load data or warm a cache, than during steady-state operation.
+                          This cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         properties:
                           exec:
                             description: Exec specifies the action to take.
                             properties:
                               command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for the
-                                  command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|', etc)
-                                  won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
+                                description: |-
+                                  Command is the command line to execute inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                  a shell, you need to explicitly call out to that shell.
+                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                 items:
                                   type: string
                                 type: array
                             type: object
                           failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
+                            description: |-
+                              Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                              Defaults to 3. Minimum value is 1.
                             format: int32
                             type: integer
                           grpc:
@@ -1155,10 +1179,12 @@ spec:
                                 format: int32
                                 type: integer
                               service:
-                                description: "Service is the name of the service to
-                                place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                \n If this is not specified, the default behavior
-                                is defined by gRPC."
+                                description: |-
+                                  Service is the name of the service to place in the gRPC HealthCheckRequest
+                                  (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                  
+                                  
+                                  If this is not specified, the default behavior is defined by gRPC.
                                 type: string
                             required:
                               - port
@@ -1167,9 +1193,9 @@ spec:
                             description: HTTPGet specifies the http request to perform.
                             properties:
                               host:
-                                description: Host name to connect to, defaults to the
-                                  pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
+                                description: |-
+                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                  "Host" in httpHeaders instead.
                                 type: string
                               httpHeaders:
                                 description: Custom headers to set in the request. HTTP
@@ -1179,9 +1205,9 @@ spec:
                                     to be used in HTTP probes
                                   properties:
                                     name:
-                                      description: The header field name. This will
-                                        be canonicalized upon output, so case-variant
-                                        names will be understood as the same header.
+                                      description: |-
+                                        The header field name.
+                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                       type: string
                                     value:
                                       description: The header field value
@@ -1198,33 +1224,35 @@ spec:
                                 anyOf:
                                   - type: integer
                                   - type: string
-                                description: Name or number of the port to access on
-                                  the container. Number must be in the range 1 to 65535.
+                                description: |-
+                                  Name or number of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
                                   Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                               scheme:
-                                description: Scheme to use for connecting to the host.
+                                description: |-
+                                  Scheme to use for connecting to the host.
                                   Defaults to HTTP.
                                 type: string
                             required:
                               - port
                             type: object
                           initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                            started before liveness probes are initiated. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            description: |-
+                              Number of seconds after the container has started before liveness probes are initiated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                             format: int32
                             type: integer
                           periodSeconds:
-                            description: How often (in seconds) to perform the probe.
+                            description: |-
+                              How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                             format: int32
                             type: integer
                           successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
+                            description: |-
+                              Minimum consecutive successes for the probe to be considered successful after having failed.
+                              Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                             format: int32
                             type: integer
                           tcpSocket:
@@ -1239,77 +1267,76 @@ spec:
                                 anyOf:
                                   - type: integer
                                   - type: string
-                                description: Number or name of the port to access on
-                                  the container. Number must be in the range 1 to 65535.
+                                description: |-
+                                  Number or name of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
                                   Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                             required:
                               - port
                             type: object
                           terminationGracePeriodSeconds:
-                            description: Optional duration in seconds the pod needs
-                              to terminate gracefully upon probe failure. The grace
-                              period is the duration in seconds after the processes
-                              running in the pod are sent a termination signal and the
-                              time when the processes are forcibly halted with a kill
-                              signal. Set this value longer than the expected cleanup
-                              time for your process. If this value is nil, the pod's
-                              terminationGracePeriodSeconds will be used. Otherwise,
-                              this value overrides the value provided by the pod spec.
-                              Value must be non-negative integer. The value zero indicates
-                              stop immediately via the kill signal (no opportunity to
-                              shut down). This is a beta field and requires enabling
-                              ProbeTerminationGracePeriod feature gate. Minimum value
-                              is 1. spec.terminationGracePeriodSeconds is used if unset.
+                            description: |-
+                              Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                              The grace period is the duration in seconds after the processes running in the pod are sent
+                              a termination signal and the time when the processes are forcibly halted with a kill signal.
+                              Set this value longer than the expected cleanup time for your process.
+                              If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                              value overrides the value provided by the pod spec.
+                              Value must be non-negative integer. The value zero indicates stop immediately via
+                              the kill signal (no opportunity to shut down).
+                              This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                              Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                             format: int64
                             type: integer
                           timeoutSeconds:
-                            description: 'Number of seconds after which the probe times
-                            out. Defaults to 1 second. Minimum value is 1. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            description: |-
+                              Number of seconds after which the probe times out.
+                              Defaults to 1 second. Minimum value is 1.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                             format: int32
                             type: integer
                         type: object
                       stdin:
-                        description: Whether this container should allocate a buffer
-                          for stdin in the container runtime. If this is not set, reads
-                          from stdin in the container will always result in EOF. Default
-                          is false.
+                        description: |-
+                          Whether this container should allocate a buffer for stdin in the container runtime. If this
+                          is not set, reads from stdin in the container will always result in EOF.
+                          Default is false.
                         type: boolean
                       stdinOnce:
-                        description: Whether the container runtime should close the
-                          stdin channel after it has been opened by a single attach.
-                          When stdin is true the stdin stream will remain open across
-                          multiple attach sessions. If stdinOnce is set to true, stdin
-                          is opened on container start, is empty until the first client
-                          attaches to stdin, and then remains open and accepts data
-                          until the client disconnects, at which time stdin is closed
-                          and remains closed until the container is restarted. If this
-                          flag is false, a container processes that reads from stdin
-                          will never receive an EOF. Default is false
+                        description: |-
+                          Whether the container runtime should close the stdin channel after it has been opened by
+                          a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                          sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                          first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                          at which time stdin is closed and remains closed until the container is restarted. If this
+                          flag is false, a container processes that reads from stdin will never receive an EOF.
+                          Default is false
                         type: boolean
                       terminationMessagePath:
-                        description: 'Optional: Path at which the file to which the
-                        container''s termination message will be written is mounted
-                        into the container''s filesystem. Message written is intended
-                        to be brief final status, such as an assertion failure message.
-                        Will be truncated by the node if greater than 4096 bytes.
-                        The total message length across all containers will be limited
-                        to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
+                        description: |-
+                          Optional: Path at which the file to which the container's termination message
+                          will be written is mounted into the container's filesystem.
+                          Message written is intended to be brief final status, such as an assertion failure message.
+                          Will be truncated by the node if greater than 4096 bytes. The total message length across
+                          all containers will be limited to 12kb.
+                          Defaults to /dev/termination-log.
+                          Cannot be updated.
                         type: string
                       terminationMessagePolicy:
-                        description: Indicate how the termination message should be
-                          populated. File will use the contents of terminationMessagePath
-                          to populate the container status message on both success and
-                          failure. FallbackToLogsOnError will use the last chunk of
-                          container log output if the termination message file is empty
-                          and the container exited with an error. The log output is
-                          limited to 2048 bytes or 80 lines, whichever is smaller. Defaults
-                          to File. Cannot be updated.
+                        description: |-
+                          Indicate how the termination message should be populated. File will use the contents of
+                          terminationMessagePath to populate the container status message on both success and failure.
+                          FallbackToLogsOnError will use the last chunk of container log output if the termination
+                          message file is empty and the container exited with an error.
+                          The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                          Defaults to File.
+                          Cannot be updated.
                         type: string
                       tty:
-                        description: Whether this container should allocate a TTY for
-                          itself, also requires 'stdin' to be true. Default is false.
+                        description: |-
+                          Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                          Default is false.
                         type: boolean
                       volumeDevices:
                         description: volumeDevices is the list of block devices to be
@@ -1332,40 +1359,44 @@ spec:
                           type: object
                         type: array
                       volumeMounts:
-                        description: Pod volumes to mount into the container's filesystem.
+                        description: |-
+                          Pod volumes to mount into the container's filesystem.
                           Cannot be updated.
                         items:
                           description: VolumeMount describes a mounting of a Volume
                             within a container.
                           properties:
                             mountPath:
-                              description: Path within the container at which the volume
-                                should be mounted.  Must not contain ':'.
+                              description: |-
+                                Path within the container at which the volume should be mounted.  Must
+                                not contain ':'.
                               type: string
                             mountPropagation:
-                              description: mountPropagation determines how mounts are
-                                propagated from the host to container and the other
-                                way around. When not set, MountPropagationNone is used.
+                              description: |-
+                                mountPropagation determines how mounts are propagated from the host
+                                to container and the other way around.
+                                When not set, MountPropagationNone is used.
                                 This field is beta in 1.10.
                               type: string
                             name:
                               description: This must match the Name of a Volume.
                               type: string
                             readOnly:
-                              description: Mounted read-only if true, read-write otherwise
-                                (false or unspecified). Defaults to false.
+                              description: |-
+                                Mounted read-only if true, read-write otherwise (false or unspecified).
+                                Defaults to false.
                               type: boolean
                             subPath:
-                              description: Path within the volume from which the container's
-                                volume should be mounted. Defaults to "" (volume's root).
+                              description: |-
+                                Path within the volume from which the container's volume should be mounted.
+                                Defaults to "" (volume's root).
                               type: string
                             subPathExpr:
-                              description: Expanded path within the volume from which
-                                the container's volume should be mounted. Behaves similarly
-                                to SubPath but environment variable references $(VAR_NAME)
-                                are expanded using the container's environment. Defaults
-                                to "" (volume's root). SubPathExpr and SubPath are mutually
-                                exclusive.
+                              description: |-
+                                Expanded path within the volume from which the container's volume should be mounted.
+                                Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                Defaults to "" (volume's root).
+                                SubPathExpr and SubPath are mutually exclusive.
                               type: string
                           required:
                             - mountPath
@@ -1373,9 +1404,11 @@ spec:
                           type: object
                         type: array
                       workingDir:
-                        description: Container's working directory. If not specified,
-                          the container runtime's default will be used, which might
-                          be configured in the container image. Cannot be updated.
+                        description: |-
+                          Container's working directory.
+                          If not specified, the container runtime's default will be used, which
+                          might be configured in the container image.
+                          Cannot be updated.
                         type: string
                     required:
                       - name
@@ -1389,22 +1422,20 @@ spec:
                         pod.
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to
-                            nodes that satisfy the affinity expressions specified by
-                            this field, but it may choose a node that violates one or
-                            more of the expressions. The node that is most preferred
-                            is the one with the greatest sum of weights, i.e. for each
-                            node that meets all of the scheduling requirements (resource
-                            request, requiredDuringScheduling affinity expressions,
-                            etc.), compute a sum by iterating through the elements of
-                            this field and adding "weight" to the sum if the node matches
-                            the corresponding matchExpressions; the node(s) with the
-                            highest sum are the most preferred.
+                          description: |-
+                            The scheduler will prefer to schedule pods to nodes that satisfy
+                            the affinity expressions specified by this field, but it may choose
+                            a node that violates one or more of the expressions. The node that is
+                            most preferred is the one with the greatest sum of weights, i.e.
+                            for each node that meets all of the scheduling requirements (resource
+                            request, requiredDuringScheduling affinity expressions, etc.),
+                            compute a sum by iterating through the elements of this field and adding
+                            "weight" to the sum if the node matches the corresponding matchExpressions; the
+                            node(s) with the highest sum are the most preferred.
                           items:
-                            description: An empty preferred scheduling term matches
-                              all objects with implicit weight 0 (i.e. it's a no-op).
-                              A null preferred scheduling term matches no objects (i.e.
-                              is also a no-op).
+                            description: |-
+                              An empty preferred scheduling term matches all objects with implicit weight 0
+                              (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                             properties:
                               preference:
                                 description: A node selector term, associated with the
@@ -1414,30 +1445,26 @@ spec:
                                     description: A list of node selector requirements
                                       by node's labels.
                                     items:
-                                      description: A node selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
+                                      description: |-
+                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                        that relates the key and values.
                                       properties:
                                         key:
                                           description: The label key that the selector
                                             applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
+                                          description: |-
+                                            Represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                           type: string
                                         values:
-                                          description: An array of string values. If
-                                            the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values array
-                                            must be empty. If the operator is Gt or
-                                            Lt, the values array must have a single
-                                            element, which will be interpreted as an
-                                            integer. This array is replaced during a
-                                            strategic merge patch.
+                                          description: |-
+                                            An array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                            array must have a single element, which will be interpreted as an integer.
+                                            This array is replaced during a strategic merge patch.
                                           items:
                                             type: string
                                           type: array
@@ -1450,30 +1477,26 @@ spec:
                                     description: A list of node selector requirements
                                       by node's fields.
                                     items:
-                                      description: A node selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
+                                      description: |-
+                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                        that relates the key and values.
                                       properties:
                                         key:
                                           description: The label key that the selector
                                             applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
+                                          description: |-
+                                            Represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                           type: string
                                         values:
-                                          description: An array of string values. If
-                                            the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values array
-                                            must be empty. If the operator is Gt or
-                                            Lt, the values array must have a single
-                                            element, which will be interpreted as an
-                                            integer. This array is replaced during a
-                                            strategic merge patch.
+                                          description: |-
+                                            An array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                            array must have a single element, which will be interpreted as an integer.
+                                            This array is replaced during a strategic merge patch.
                                           items:
                                             type: string
                                           type: array
@@ -1495,50 +1518,46 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this
-                            field are not met at scheduling time, the pod will not be
-                            scheduled onto the node. If the affinity requirements specified
-                            by this field cease to be met at some point during pod execution
-                            (e.g. due to an update), the system may or may not try to
-                            eventually evict the pod from its node.
+                          description: |-
+                            If the affinity requirements specified by this field are not met at
+                            scheduling time, the pod will not be scheduled onto the node.
+                            If the affinity requirements specified by this field cease to be met
+                            at some point during pod execution (e.g. due to an update), the system
+                            may or may not try to eventually evict the pod from its node.
                           properties:
                             nodeSelectorTerms:
                               description: Required. A list of node selector terms.
                                 The terms are ORed.
                               items:
-                                description: A null or empty node selector term matches
-                                  no objects. The requirements of them are ANDed. The
-                                  TopologySelectorTerm type implements a subset of the
-                                  NodeSelectorTerm.
+                                description: |-
+                                  A null or empty node selector term matches no objects. The requirements of
+                                  them are ANDed.
+                                  The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                 properties:
                                   matchExpressions:
                                     description: A list of node selector requirements
                                       by node's labels.
                                     items:
-                                      description: A node selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
+                                      description: |-
+                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                        that relates the key and values.
                                       properties:
                                         key:
                                           description: The label key that the selector
                                             applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
+                                          description: |-
+                                            Represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                           type: string
                                         values:
-                                          description: An array of string values. If
-                                            the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values array
-                                            must be empty. If the operator is Gt or
-                                            Lt, the values array must have a single
-                                            element, which will be interpreted as an
-                                            integer. This array is replaced during a
-                                            strategic merge patch.
+                                          description: |-
+                                            An array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                            array must have a single element, which will be interpreted as an integer.
+                                            This array is replaced during a strategic merge patch.
                                           items:
                                             type: string
                                           type: array
@@ -1551,30 +1570,26 @@ spec:
                                     description: A list of node selector requirements
                                       by node's fields.
                                     items:
-                                      description: A node selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
+                                      description: |-
+                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                        that relates the key and values.
                                       properties:
                                         key:
                                           description: The label key that the selector
                                             applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
+                                          description: |-
+                                            Represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                           type: string
                                         values:
-                                          description: An array of string values. If
-                                            the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values array
-                                            must be empty. If the operator is Gt or
-                                            Lt, the values array must have a single
-                                            element, which will be interpreted as an
-                                            integer. This array is replaced during a
-                                            strategic merge patch.
+                                          description: |-
+                                            An array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                            array must have a single element, which will be interpreted as an integer.
+                                            This array is replaced during a strategic merge patch.
                                           items:
                                             type: string
                                           type: array
@@ -1596,16 +1611,15 @@ spec:
                         this pod in the same node, zone, etc. as some other pod(s)).
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to
-                            nodes that satisfy the affinity expressions specified by
-                            this field, but it may choose a node that violates one or
-                            more of the expressions. The node that is most preferred
-                            is the one with the greatest sum of weights, i.e. for each
-                            node that meets all of the scheduling requirements (resource
-                            request, requiredDuringScheduling affinity expressions,
-                            etc.), compute a sum by iterating through the elements of
-                            this field and adding "weight" to the sum if the node has
-                            pods which matches the corresponding podAffinityTerm; the
+                          description: |-
+                            The scheduler will prefer to schedule pods to nodes that satisfy
+                            the affinity expressions specified by this field, but it may choose
+                            a node that violates one or more of the expressions. The node that is
+                            most preferred is the one with the greatest sum of weights, i.e.
+                            for each node that meets all of the scheduling requirements (resource
+                            request, requiredDuringScheduling affinity expressions, etc.),
+                            compute a sum by iterating through the elements of this field and adding
+                            "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
                             node(s) with the highest sum are the most preferred.
                           items:
                             description: The weights of all of the matched WeightedPodAffinityTerm
@@ -1616,37 +1630,33 @@ spec:
                                   with the corresponding weight.
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods. If it's null, this PodAffinityTerm
-                                      matches with no Pods.
+                                    description: |-
+                                      A label query over a set of resources, in this case pods.
+                                      If it's null, this PodAffinityTerm matches with no Pods.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label
                                           selector requirements. The requirements are
                                           ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
                                           properties:
                                             key:
                                               description: key is the label key that
                                                 the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
                                                 merge patch.
                                               items:
                                                 type: string
@@ -1659,89 +1669,74 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: MatchLabelKeys is a set of pod label
-                                      keys to select which pods will be taken into consideration.
-                                      The keys are used to lookup values from the incoming
-                                      pod labels, those key-value labels are merged
-                                      with `LabelSelector` as `key in (value)` to select
-                                      the group of existing pods which pods will be
-                                      taken into consideration for the incoming pod's
-                                      pod (anti) affinity. Keys that don't exist in
-                                      the incoming pod labels will be ignored. The default
-                                      value is empty. The same key is forbidden to exist
-                                      in both MatchLabelKeys and LabelSelector. Also,
-                                      MatchLabelKeys cannot be set when LabelSelector
-                                      isn't set. This is an alpha field and requires
-                                      enabling MatchLabelKeysInPodAffinity feature gate.
+                                    description: |-
+                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                      Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                      This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   mismatchLabelKeys:
-                                    description: MismatchLabelKeys is a set of pod label
-                                      keys to select which pods will be taken into consideration.
-                                      The keys are used to lookup values from the incoming
-                                      pod labels, those key-value labels are merged
-                                      with `LabelSelector` as `key notin (value)` to
-                                      select the group of existing pods which pods will
-                                      be taken into consideration for the incoming pod's
-                                      pod (anti) affinity. Keys that don't exist in
-                                      the incoming pod labels will be ignored. The default
-                                      value is empty. The same key is forbidden to exist
-                                      in both MismatchLabelKeys and LabelSelector. Also,
-                                      MismatchLabelKeys cannot be set when LabelSelector
-                                      isn't set. This is an alpha field and requires
-                                      enabling MatchLabelKeysInPodAffinity feature gate.
+                                    description: |-
+                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                      Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                      This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces
-                                      that the term applies to. The term is applied
-                                      to the union of the namespaces selected by this
-                                      field and the ones listed in the namespaces field.
-                                      null selector and null or empty namespaces list
-                                      means "this pod's namespace". An empty selector
-                                      ({}) matches all namespaces.
+                                    description: |-
+                                      A label query over the set of namespaces that the term applies to.
+                                      The term is applied to the union of the namespaces selected by this field
+                                      and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                      An empty selector ({}) matches all namespaces.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label
                                           selector requirements. The requirements are
                                           ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
                                           properties:
                                             key:
                                               description: key is the label key that
                                                 the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
                                                 merge patch.
                                               items:
                                                 type: string
@@ -1754,40 +1749,37 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list
-                                      of namespace names that the term applies to. The
-                                      term is applied to the union of the namespaces
-                                      listed in this field and the ones selected by
-                                      namespaceSelector. null or empty namespaces list
-                                      and null namespaceSelector means "this pod's namespace".
+                                    description: |-
+                                      namespaces specifies a static list of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces listed in this field
+                                      and the ones selected by namespaceSelector.
+                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
+                                    description: |-
+                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                      selected pods is running.
+                                      Empty topologyKey is not allowed.
                                     type: string
                                 required:
                                   - topologyKey
                                 type: object
                               weight:
-                                description: weight associated with matching the corresponding
-                                  podAffinityTerm, in the range 1-100.
+                                description: |-
+                                  weight associated with matching the corresponding podAffinityTerm,
+                                  in the range 1-100.
                                 format: int32
                                 type: integer
                             required:
@@ -1796,53 +1788,51 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this
-                            field are not met at scheduling time, the pod will not be
-                            scheduled onto the node. If the affinity requirements specified
-                            by this field cease to be met at some point during pod execution
-                            (e.g. due to a pod label update), the system may or may
-                            not try to eventually evict the pod from its node. When
-                            there are multiple elements, the lists of nodes corresponding
-                            to each podAffinityTerm are intersected, i.e. all terms
-                            must be satisfied.
+                          description: |-
+                            If the affinity requirements specified by this field are not met at
+                            scheduling time, the pod will not be scheduled onto the node.
+                            If the affinity requirements specified by this field cease to be met
+                            at some point during pod execution (e.g. due to a pod label update), the
+                            system may or may not try to eventually evict the pod from its node.
+                            When there are multiple elements, the lists of nodes corresponding to each
+                            podAffinityTerm are intersected, i.e. all terms must be satisfied.
                           items:
-                            description: Defines a set of pods (namely those matching
-                              the labelSelector relative to the given namespace(s))
-                              that this pod should be co-located (affinity) or not co-located
-                              (anti-affinity) with, where co-located is defined as running
-                              on a node whose value of the label with key <topologyKey>
-                              matches that of any node on which a pod of the set of
-                              pods is running
+                            description: |-
+                              Defines a set of pods (namely those matching the labelSelector
+                              relative to the given namespace(s)) that this pod should be
+                              co-located (affinity) or not co-located (anti-affinity) with,
+                              where co-located is defined as running on a node whose value of
+                              the label with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
                             properties:
                               labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods. If it's null, this PodAffinityTerm
-                                  matches with no Pods.
+                                description: |-
+                                  A label query over a set of resources, in this case pods.
+                                  If it's null, this PodAffinityTerm matches with no Pods.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
                                       selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
                                       properties:
                                         key:
                                           description: key is the label key that the
                                             selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists and DoesNotExist.
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                           type: string
                                         values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the
-                                            operator is Exists or DoesNotExist, the
-                                            values array must be empty. This array is
-                                            replaced during a strategic merge patch.
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
                                           items:
                                             type: string
                                           type: array
@@ -1854,84 +1844,74 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value". The
-                                      requirements are ANDed.
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               matchLabelKeys:
-                                description: MatchLabelKeys is a set of pod label keys
-                                  to select which pods will be taken into consideration.
-                                  The keys are used to lookup values from the incoming
-                                  pod labels, those key-value labels are merged with
-                                  `LabelSelector` as `key in (value)` to select the
-                                  group of existing pods which pods will be taken into
-                                  consideration for the incoming pod's pod (anti) affinity.
-                                  Keys that don't exist in the incoming pod labels will
-                                  be ignored. The default value is empty. The same key
-                                  is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                  Also, MatchLabelKeys cannot be set when LabelSelector
-                                  isn't set. This is an alpha field and requires enabling
-                                  MatchLabelKeysInPodAffinity feature gate.
+                                description: |-
+                                  MatchLabelKeys is a set of pod label keys to select which pods will
+                                  be taken into consideration. The keys are used to lookup values from the
+                                  incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                  to select the group of existing pods which pods will be taken into consideration
+                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                  pod labels will be ignored. The default value is empty.
+                                  The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                  Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                  This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               mismatchLabelKeys:
-                                description: MismatchLabelKeys is a set of pod label
-                                  keys to select which pods will be taken into consideration.
-                                  The keys are used to lookup values from the incoming
-                                  pod labels, those key-value labels are merged with
-                                  `LabelSelector` as `key notin (value)` to select the
-                                  group of existing pods which pods will be taken into
-                                  consideration for the incoming pod's pod (anti) affinity.
-                                  Keys that don't exist in the incoming pod labels will
-                                  be ignored. The default value is empty. The same key
-                                  is forbidden to exist in both MismatchLabelKeys and
-                                  LabelSelector. Also, MismatchLabelKeys cannot be set
-                                  when LabelSelector isn't set. This is an alpha field
-                                  and requires enabling MatchLabelKeysInPodAffinity
-                                  feature gate.
+                                description: |-
+                                  MismatchLabelKeys is a set of pod label keys to select which pods will
+                                  be taken into consideration. The keys are used to lookup values from the
+                                  incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                  to select the group of existing pods which pods will be taken into consideration
+                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                  pod labels will be ignored. The default value is empty.
+                                  The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                  Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                  This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               namespaceSelector:
-                                description: A label query over the set of namespaces
-                                  that the term applies to. The term is applied to the
-                                  union of the namespaces selected by this field and
-                                  the ones listed in the namespaces field. null selector
-                                  and null or empty namespaces list means "this pod's
-                                  namespace". An empty selector ({}) matches all namespaces.
+                                description: |-
+                                  A label query over the set of namespaces that the term applies to.
+                                  The term is applied to the union of the namespaces selected by this field
+                                  and the ones listed in the namespaces field.
+                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                  An empty selector ({}) matches all namespaces.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
                                       selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
                                       properties:
                                         key:
                                           description: key is the label key that the
                                             selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists and DoesNotExist.
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                           type: string
                                         values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the
-                                            operator is Exists or DoesNotExist, the
-                                            values array must be empty. This array is
-                                            replaced during a strategic merge patch.
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
                                           items:
                                             type: string
                                           type: array
@@ -1943,32 +1923,28 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value". The
-                                      requirements are ANDed.
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaces:
-                                description: namespaces specifies a static list of namespace
-                                  names that the term applies to. The term is applied
-                                  to the union of the namespaces listed in this field
-                                  and the ones selected by namespaceSelector. null or
-                                  empty namespaces list and null namespaceSelector means
-                                  "this pod's namespace".
+                                description: |-
+                                  namespaces specifies a static list of namespace names that the term applies to.
+                                  The term is applied to the union of the namespaces listed in this field
+                                  and the ones selected by namespaceSelector.
+                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                 items:
                                   type: string
                                 type: array
                               topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods matching
-                                  the labelSelector in the specified namespaces, where
-                                  co-located is defined as running on a node whose value
-                                  of the label with key topologyKey matches that of
-                                  any node on which any of the selected pods is running.
+                                description: |-
+                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                  selected pods is running.
                                   Empty topologyKey is not allowed.
                                 type: string
                             required:
@@ -1982,16 +1958,15 @@ spec:
                         other pod(s)).
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to
-                            nodes that satisfy the anti-affinity expressions specified
-                            by this field, but it may choose a node that violates one
-                            or more of the expressions. The node that is most preferred
-                            is the one with the greatest sum of weights, i.e. for each
-                            node that meets all of the scheduling requirements (resource
-                            request, requiredDuringScheduling anti-affinity expressions,
-                            etc.), compute a sum by iterating through the elements of
-                            this field and adding "weight" to the sum if the node has
-                            pods which matches the corresponding podAffinityTerm; the
+                          description: |-
+                            The scheduler will prefer to schedule pods to nodes that satisfy
+                            the anti-affinity expressions specified by this field, but it may choose
+                            a node that violates one or more of the expressions. The node that is
+                            most preferred is the one with the greatest sum of weights, i.e.
+                            for each node that meets all of the scheduling requirements (resource
+                            request, requiredDuringScheduling anti-affinity expressions, etc.),
+                            compute a sum by iterating through the elements of this field and adding
+                            "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
                             node(s) with the highest sum are the most preferred.
                           items:
                             description: The weights of all of the matched WeightedPodAffinityTerm
@@ -2002,37 +1977,33 @@ spec:
                                   with the corresponding weight.
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods. If it's null, this PodAffinityTerm
-                                      matches with no Pods.
+                                    description: |-
+                                      A label query over a set of resources, in this case pods.
+                                      If it's null, this PodAffinityTerm matches with no Pods.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label
                                           selector requirements. The requirements are
                                           ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
                                           properties:
                                             key:
                                               description: key is the label key that
                                                 the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
                                                 merge patch.
                                               items:
                                                 type: string
@@ -2045,89 +2016,74 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: MatchLabelKeys is a set of pod label
-                                      keys to select which pods will be taken into consideration.
-                                      The keys are used to lookup values from the incoming
-                                      pod labels, those key-value labels are merged
-                                      with `LabelSelector` as `key in (value)` to select
-                                      the group of existing pods which pods will be
-                                      taken into consideration for the incoming pod's
-                                      pod (anti) affinity. Keys that don't exist in
-                                      the incoming pod labels will be ignored. The default
-                                      value is empty. The same key is forbidden to exist
-                                      in both MatchLabelKeys and LabelSelector. Also,
-                                      MatchLabelKeys cannot be set when LabelSelector
-                                      isn't set. This is an alpha field and requires
-                                      enabling MatchLabelKeysInPodAffinity feature gate.
+                                    description: |-
+                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                      Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                      This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   mismatchLabelKeys:
-                                    description: MismatchLabelKeys is a set of pod label
-                                      keys to select which pods will be taken into consideration.
-                                      The keys are used to lookup values from the incoming
-                                      pod labels, those key-value labels are merged
-                                      with `LabelSelector` as `key notin (value)` to
-                                      select the group of existing pods which pods will
-                                      be taken into consideration for the incoming pod's
-                                      pod (anti) affinity. Keys that don't exist in
-                                      the incoming pod labels will be ignored. The default
-                                      value is empty. The same key is forbidden to exist
-                                      in both MismatchLabelKeys and LabelSelector. Also,
-                                      MismatchLabelKeys cannot be set when LabelSelector
-                                      isn't set. This is an alpha field and requires
-                                      enabling MatchLabelKeysInPodAffinity feature gate.
+                                    description: |-
+                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                      Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                      This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces
-                                      that the term applies to. The term is applied
-                                      to the union of the namespaces selected by this
-                                      field and the ones listed in the namespaces field.
-                                      null selector and null or empty namespaces list
-                                      means "this pod's namespace". An empty selector
-                                      ({}) matches all namespaces.
+                                    description: |-
+                                      A label query over the set of namespaces that the term applies to.
+                                      The term is applied to the union of the namespaces selected by this field
+                                      and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                      An empty selector ({}) matches all namespaces.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label
                                           selector requirements. The requirements are
                                           ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
                                           properties:
                                             key:
                                               description: key is the label key that
                                                 the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
                                                 merge patch.
                                               items:
                                                 type: string
@@ -2140,40 +2096,37 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list
-                                      of namespace names that the term applies to. The
-                                      term is applied to the union of the namespaces
-                                      listed in this field and the ones selected by
-                                      namespaceSelector. null or empty namespaces list
-                                      and null namespaceSelector means "this pod's namespace".
+                                    description: |-
+                                      namespaces specifies a static list of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces listed in this field
+                                      and the ones selected by namespaceSelector.
+                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
+                                    description: |-
+                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                      selected pods is running.
+                                      Empty topologyKey is not allowed.
                                     type: string
                                 required:
                                   - topologyKey
                                 type: object
                               weight:
-                                description: weight associated with matching the corresponding
-                                  podAffinityTerm, in the range 1-100.
+                                description: |-
+                                  weight associated with matching the corresponding podAffinityTerm,
+                                  in the range 1-100.
                                 format: int32
                                 type: integer
                             required:
@@ -2182,53 +2135,51 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the anti-affinity requirements specified by
-                            this field are not met at scheduling time, the pod will
-                            not be scheduled onto the node. If the anti-affinity requirements
-                            specified by this field cease to be met at some point during
-                            pod execution (e.g. due to a pod label update), the system
-                            may or may not try to eventually evict the pod from its
-                            node. When there are multiple elements, the lists of nodes
-                            corresponding to each podAffinityTerm are intersected, i.e.
-                            all terms must be satisfied.
+                          description: |-
+                            If the anti-affinity requirements specified by this field are not met at
+                            scheduling time, the pod will not be scheduled onto the node.
+                            If the anti-affinity requirements specified by this field cease to be met
+                            at some point during pod execution (e.g. due to a pod label update), the
+                            system may or may not try to eventually evict the pod from its node.
+                            When there are multiple elements, the lists of nodes corresponding to each
+                            podAffinityTerm are intersected, i.e. all terms must be satisfied.
                           items:
-                            description: Defines a set of pods (namely those matching
-                              the labelSelector relative to the given namespace(s))
-                              that this pod should be co-located (affinity) or not co-located
-                              (anti-affinity) with, where co-located is defined as running
-                              on a node whose value of the label with key <topologyKey>
-                              matches that of any node on which a pod of the set of
-                              pods is running
+                            description: |-
+                              Defines a set of pods (namely those matching the labelSelector
+                              relative to the given namespace(s)) that this pod should be
+                              co-located (affinity) or not co-located (anti-affinity) with,
+                              where co-located is defined as running on a node whose value of
+                              the label with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
                             properties:
                               labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods. If it's null, this PodAffinityTerm
-                                  matches with no Pods.
+                                description: |-
+                                  A label query over a set of resources, in this case pods.
+                                  If it's null, this PodAffinityTerm matches with no Pods.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
                                       selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
                                       properties:
                                         key:
                                           description: key is the label key that the
                                             selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists and DoesNotExist.
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                           type: string
                                         values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the
-                                            operator is Exists or DoesNotExist, the
-                                            values array must be empty. This array is
-                                            replaced during a strategic merge patch.
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
                                           items:
                                             type: string
                                           type: array
@@ -2240,84 +2191,74 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value". The
-                                      requirements are ANDed.
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               matchLabelKeys:
-                                description: MatchLabelKeys is a set of pod label keys
-                                  to select which pods will be taken into consideration.
-                                  The keys are used to lookup values from the incoming
-                                  pod labels, those key-value labels are merged with
-                                  `LabelSelector` as `key in (value)` to select the
-                                  group of existing pods which pods will be taken into
-                                  consideration for the incoming pod's pod (anti) affinity.
-                                  Keys that don't exist in the incoming pod labels will
-                                  be ignored. The default value is empty. The same key
-                                  is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                  Also, MatchLabelKeys cannot be set when LabelSelector
-                                  isn't set. This is an alpha field and requires enabling
-                                  MatchLabelKeysInPodAffinity feature gate.
+                                description: |-
+                                  MatchLabelKeys is a set of pod label keys to select which pods will
+                                  be taken into consideration. The keys are used to lookup values from the
+                                  incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                  to select the group of existing pods which pods will be taken into consideration
+                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                  pod labels will be ignored. The default value is empty.
+                                  The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                  Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                  This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               mismatchLabelKeys:
-                                description: MismatchLabelKeys is a set of pod label
-                                  keys to select which pods will be taken into consideration.
-                                  The keys are used to lookup values from the incoming
-                                  pod labels, those key-value labels are merged with
-                                  `LabelSelector` as `key notin (value)` to select the
-                                  group of existing pods which pods will be taken into
-                                  consideration for the incoming pod's pod (anti) affinity.
-                                  Keys that don't exist in the incoming pod labels will
-                                  be ignored. The default value is empty. The same key
-                                  is forbidden to exist in both MismatchLabelKeys and
-                                  LabelSelector. Also, MismatchLabelKeys cannot be set
-                                  when LabelSelector isn't set. This is an alpha field
-                                  and requires enabling MatchLabelKeysInPodAffinity
-                                  feature gate.
+                                description: |-
+                                  MismatchLabelKeys is a set of pod label keys to select which pods will
+                                  be taken into consideration. The keys are used to lookup values from the
+                                  incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                  to select the group of existing pods which pods will be taken into consideration
+                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                  pod labels will be ignored. The default value is empty.
+                                  The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                  Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                  This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               namespaceSelector:
-                                description: A label query over the set of namespaces
-                                  that the term applies to. The term is applied to the
-                                  union of the namespaces selected by this field and
-                                  the ones listed in the namespaces field. null selector
-                                  and null or empty namespaces list means "this pod's
-                                  namespace". An empty selector ({}) matches all namespaces.
+                                description: |-
+                                  A label query over the set of namespaces that the term applies to.
+                                  The term is applied to the union of the namespaces selected by this field
+                                  and the ones listed in the namespaces field.
+                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                  An empty selector ({}) matches all namespaces.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
                                       selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
                                       properties:
                                         key:
                                           description: key is the label key that the
                                             selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists and DoesNotExist.
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                           type: string
                                         values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the
-                                            operator is Exists or DoesNotExist, the
-                                            values array must be empty. This array is
-                                            replaced during a strategic merge patch.
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
                                           items:
                                             type: string
                                           type: array
@@ -2329,32 +2270,28 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value". The
-                                      requirements are ANDed.
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaces:
-                                description: namespaces specifies a static list of namespace
-                                  names that the term applies to. The term is applied
-                                  to the union of the namespaces listed in this field
-                                  and the ones selected by namespaceSelector. null or
-                                  empty namespaces list and null namespaceSelector means
-                                  "this pod's namespace".
+                                description: |-
+                                  namespaces specifies a static list of namespace names that the term applies to.
+                                  The term is applied to the union of the namespaces listed in this field
+                                  and the ones selected by namespaceSelector.
+                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                 items:
                                   type: string
                                 type: array
                               topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods matching
-                                  the labelSelector in the specified namespaces, where
-                                  co-located is defined as running on a node whose value
-                                  of the label with key topologyKey matches that of
-                                  any node on which any of the selected pods is running.
+                                description: |-
+                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                  selected pods is running.
                                   Empty topologyKey is not allowed.
                                 type: string
                             required:
@@ -2370,35 +2307,34 @@ spec:
                     Collector binary
                   type: object
                 autoscaler:
-                  description: Autoscaler specifies the pod autoscaling configuration
-                    to use for the AmazonCloudWatchAgent workload.
+                  description: |-
+                    Autoscaler specifies the pod autoscaling configuration to use
+                    for the AmazonCloudWatchAgent workload.
                   properties:
                     behavior:
-                      description: HorizontalPodAutoscalerBehavior configures the scaling
-                        behavior of the target in both Up and Down directions (scaleUp
-                        and scaleDown fields respectively).
+                      description: |-
+                        HorizontalPodAutoscalerBehavior configures the scaling behavior of the target
+                        in both Up and Down directions (scaleUp and scaleDown fields respectively).
                       properties:
                         scaleDown:
-                          description: scaleDown is scaling policy for scaling Down.
-                            If not set, the default value is to allow to scale down
-                            to minReplicas pods, with a 300 second stabilization window
-                            (i.e., the highest recommendation for the last 300sec is
-                            used).
+                          description: |-
+                            scaleDown is scaling policy for scaling Down.
+                            If not set, the default value is to allow to scale down to minReplicas pods, with a
+                            300 second stabilization window (i.e., the highest recommendation for
+                            the last 300sec is used).
                           properties:
                             policies:
-                              description: policies is a list of potential scaling polices
-                                which can be used during scaling. At least one policy
-                                must be specified, otherwise the HPAScalingRules will
-                                be discarded as invalid
+                              description: |-
+                                policies is a list of potential scaling polices which can be used during scaling.
+                                At least one policy must be specified, otherwise the HPAScalingRules will be discarded as invalid
                               items:
                                 description: HPAScalingPolicy is a single policy which
                                   must hold true for a specified past interval.
                                 properties:
                                   periodSeconds:
-                                    description: periodSeconds specifies the window
-                                      of time for which the policy should hold true.
-                                      PeriodSeconds must be greater than zero and less
-                                      than or equal to 1800 (30 min).
+                                    description: |-
+                                      periodSeconds specifies the window of time for which the policy should hold true.
+                                      PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
                                     format: int32
                                     type: integer
                                   type:
@@ -2406,9 +2342,9 @@ spec:
                                       policy.
                                     type: string
                                   value:
-                                    description: value contains the amount of change
-                                      which is permitted by the policy. It must be greater
-                                      than zero
+                                    description: |-
+                                      value contains the amount of change which is permitted by the policy.
+                                      It must be greater than zero
                                     format: int32
                                     type: integer
                                 required:
@@ -2419,42 +2355,41 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             selectPolicy:
-                              description: selectPolicy is used to specify which policy
-                                should be used. If not set, the default value Max is
-                                used.
+                              description: |-
+                                selectPolicy is used to specify which policy should be used.
+                                If not set, the default value Max is used.
                               type: string
                             stabilizationWindowSeconds:
-                              description: 'stabilizationWindowSeconds is the number
-                              of seconds for which past recommendations should be
-                              considered while scaling up or scaling down. StabilizationWindowSeconds
-                              must be greater than or equal to zero and less than
-                              or equal to 3600 (one hour). If not set, use the default
-                              values: - For scale up: 0 (i.e. no stabilization is
-                              done). - For scale down: 300 (i.e. the stabilization
-                              window is 300 seconds long).'
+                              description: |-
+                                stabilizationWindowSeconds is the number of seconds for which past recommendations should be
+                                considered while scaling up or scaling down.
+                                StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour).
+                                If not set, use the default values:
+                                - For scale up: 0 (i.e. no stabilization is done).
+                                - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
                               format: int32
                               type: integer
                           type: object
                         scaleUp:
-                          description: 'scaleUp is scaling policy for scaling Up. If
-                          not set, the default value is the higher of: * increase
-                          no more than 4 pods per 60 seconds * double the number of
-                          pods per 60 seconds No stabilization is used.'
+                          description: |-
+                            scaleUp is scaling policy for scaling Up.
+                            If not set, the default value is the higher of:
+                              * increase no more than 4 pods per 60 seconds
+                              * double the number of pods per 60 seconds
+                            No stabilization is used.
                           properties:
                             policies:
-                              description: policies is a list of potential scaling polices
-                                which can be used during scaling. At least one policy
-                                must be specified, otherwise the HPAScalingRules will
-                                be discarded as invalid
+                              description: |-
+                                policies is a list of potential scaling polices which can be used during scaling.
+                                At least one policy must be specified, otherwise the HPAScalingRules will be discarded as invalid
                               items:
                                 description: HPAScalingPolicy is a single policy which
                                   must hold true for a specified past interval.
                                 properties:
                                   periodSeconds:
-                                    description: periodSeconds specifies the window
-                                      of time for which the policy should hold true.
-                                      PeriodSeconds must be greater than zero and less
-                                      than or equal to 1800 (30 min).
+                                    description: |-
+                                      periodSeconds specifies the window of time for which the policy should hold true.
+                                      PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
                                     format: int32
                                     type: integer
                                   type:
@@ -2462,9 +2397,9 @@ spec:
                                       policy.
                                     type: string
                                   value:
-                                    description: value contains the amount of change
-                                      which is permitted by the policy. It must be greater
-                                      than zero
+                                    description: |-
+                                      value contains the amount of change which is permitted by the policy.
+                                      It must be greater than zero
                                     format: int32
                                     type: integer
                                 required:
@@ -2475,19 +2410,18 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             selectPolicy:
-                              description: selectPolicy is used to specify which policy
-                                should be used. If not set, the default value Max is
-                                used.
+                              description: |-
+                                selectPolicy is used to specify which policy should be used.
+                                If not set, the default value Max is used.
                               type: string
                             stabilizationWindowSeconds:
-                              description: 'stabilizationWindowSeconds is the number
-                              of seconds for which past recommendations should be
-                              considered while scaling up or scaling down. StabilizationWindowSeconds
-                              must be greater than or equal to zero and less than
-                              or equal to 3600 (one hour). If not set, use the default
-                              values: - For scale up: 0 (i.e. no stabilization is
-                              done). - For scale down: 300 (i.e. the stabilization
-                              window is 300 seconds long).'
+                              description: |-
+                                stabilizationWindowSeconds is the number of seconds for which past recommendations should be
+                                considered while scaling up or scaling down.
+                                StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour).
+                                If not set, use the default values:
+                                - For scale up: 0 (i.e. no stabilization is done).
+                                - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
                               format: int32
                               type: integer
                           type: object
@@ -2498,22 +2432,22 @@ spec:
                       format: int32
                       type: integer
                     metrics:
-                      description: Metrics is meant to provide a customizable way to
-                        configure HPA metrics. currently the only supported custom metrics
-                        is type=Pod. Use TargetCPUUtilization or TargetMemoryUtilization
-                        instead if scaling on these common resource metrics.
+                      description: |-
+                        Metrics is meant to provide a customizable way to configure HPA metrics.
+                        currently the only supported custom metrics is type=Pod.
+                        Use TargetCPUUtilization or TargetMemoryUtilization instead if scaling on these common resource metrics.
                       items:
-                        description: MetricSpec defines a subset of metrics to be defined
-                          for the HPA's metric array more metric type can be supported
-                          as needed. See https://pkg.go.dev/k8s.io/api/autoscaling/v2#MetricSpec
-                          for reference.
+                        description: |-
+                          MetricSpec defines a subset of metrics to be defined for the HPA's metric array
+                          more metric type can be supported as needed.
+                          See https://pkg.go.dev/k8s.io/api/autoscaling/v2#MetricSpec for reference.
                         properties:
                           pods:
-                            description: PodsMetricSource indicates how to scale on
-                              a metric describing each pod in the current scale target
-                              (for example, transactions-processed-per-second). The
-                              values will be averaged together before being compared
-                              to the target value.
+                            description: |-
+                              PodsMetricSource indicates how to scale on a metric describing each pod in
+                              the current scale target (for example, transactions-processed-per-second).
+                              The values will be averaged together before being compared to the target
+                              value.
                             properties:
                               metric:
                                 description: metric identifies the target metric by
@@ -2523,40 +2457,34 @@ spec:
                                     description: name is the name of the given metric
                                     type: string
                                   selector:
-                                    description: selector is the string-encoded form
-                                      of a standard kubernetes label selector for the
-                                      given metric When set, it is passed as an additional
-                                      parameter to the metrics server for more specific
-                                      metrics scoping. When unset, just the metricName
-                                      will be used to gather metrics.
+                                    description: |-
+                                      selector is the string-encoded form of a standard kubernetes label selector for the given metric
+                                      When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
+                                      When unset, just the metricName will be used to gather metrics.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label
                                           selector requirements. The requirements are
                                           ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
                                           properties:
                                             key:
                                               description: key is the label key that
                                                 the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
                                                 merge patch.
                                               items:
                                                 type: string
@@ -2569,12 +2497,10 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -2586,21 +2512,20 @@ spec:
                                   given metric
                                 properties:
                                   averageUtilization:
-                                    description: averageUtilization is the target value
-                                      of the average of the resource metric across all
-                                      relevant pods, represented as a percentage of
+                                    description: |-
+                                      averageUtilization is the target value of the average of the
+                                      resource metric across all relevant pods, represented as a percentage of
                                       the requested value of the resource for the pods.
-                                      Currently only valid for Resource metric source
-                                      type
+                                      Currently only valid for Resource metric source type
                                     format: int32
                                     type: integer
                                   averageValue:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: averageValue is the target value of
-                                      the average of the metric across all relevant
-                                      pods (as a quantity)
+                                    description: |-
+                                      averageValue is the target value of the average of the
+                                      metric across all relevant pods (as a quantity)
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   type:
@@ -2636,9 +2561,9 @@ spec:
                       format: int32
                       type: integer
                     targetCPUUtilization:
-                      description: TargetCPUUtilization sets the target average CPU
-                        used across all replicas. If average CPU exceeds this value,
-                        the HPA will scale up. Defaults to 90 percent.
+                      description: |-
+                        TargetCPUUtilization sets the target average CPU used across all replicas.
+                        If average CPU exceeds this value, the HPA will scale up. Defaults to 90 percent.
                       format: int32
                       type: integer
                     targetMemoryUtilization:
@@ -2653,10 +2578,10 @@ spec:
                     for details.
                   type: string
                 configmaps:
-                  description: ConfigMaps is a list of ConfigMaps in the same namespace
-                    as the AmazonCloudWatchAgent object, which shall be mounted into
-                    the Collector Pods. Each ConfigMap will be added to the Collector's
-                    Deployments as a volume named `configmap-<configmap-name>`.
+                  description: |-
+                    ConfigMaps is a list of ConfigMaps in the same namespace as the AmazonCloudWatchAgent
+                    object, which shall be mounted into the Collector Pods.
+                    Each ConfigMap will be added to the Collector's Deployments as a volume named `configmap-<configmap-name>`.
                   items:
                     properties:
                       mountpath:
@@ -2671,9 +2596,9 @@ spec:
                     type: object
                   type: array
                 env:
-                  description: ENV vars to set on the OpenTelemetry Collector's Pods.
-                    These can then in certain cases be consumed in the config file for
-                    the Collector.
+                  description: |-
+                    ENV vars to set on the OpenTelemetry Collector's Pods. These can then in certain cases be
+                    consumed in the config file for the Collector.
                   items:
                     description: EnvVar represents an environment variable present in
                       a Container.
@@ -2682,15 +2607,16 @@ spec:
                         description: Name of the environment variable. Must be a C_IDENTIFIER.
                         type: string
                       value:
-                        description: 'Variable references $(VAR_NAME) are expanded using
-                        the previously defined environment variables in the container
-                        and any service environment variables. If a variable cannot
-                        be resolved, the reference in the input string will be unchanged.
-                        Double $$ are reduced to a single $, which allows for escaping
-                        the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the
-                        string literal "$(VAR_NAME)". Escaped references will never
-                        be expanded, regardless of whether the variable exists or
-                        not. Defaults to "".'
+                        description: |-
+                          Variable references $(VAR_NAME) are expanded
+                          using the previously defined environment variables in the container and
+                          any service environment variables. If a variable cannot be resolved,
+                          the reference in the input string will be unchanged. Double $$ are reduced
+                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                          "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                          Escaped references will never be expanded, regardless of whether the variable
+                          exists or not.
+                          Defaults to "".
                         type: string
                       valueFrom:
                         description: Source for the environment variable's value. Cannot
@@ -2703,8 +2629,10 @@ spec:
                                 description: The key to select.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                 type: string
                               optional:
                                 description: Specify whether the ConfigMap or its key
@@ -2715,10 +2643,9 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           fieldRef:
-                            description: 'Selects a field of the pod: supports metadata.name,
-                            metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                            spec.nodeName, spec.serviceAccountName, status.hostIP,
-                            status.podIP, status.podIPs.'
+                            description: |-
+                              Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                              spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                             properties:
                               apiVersion:
                                 description: Version of the schema the FieldPath is
@@ -2733,10 +2660,9 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           resourceFieldRef:
-                            description: 'Selects a resource of the container: only
-                            resources limits and requests (limits.cpu, limits.memory,
-                            limits.ephemeral-storage, requests.cpu, requests.memory
-                            and requests.ephemeral-storage) are currently supported.'
+                            description: |-
+                              Selects a resource of the container: only resources limits and requests
+                              (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                             properties:
                               containerName:
                                 description: 'Container name: required for volumes,
@@ -2765,8 +2691,10 @@ spec:
                                   be a valid secret key.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                 type: string
                               optional:
                                 description: Specify whether the Secret or its key must
@@ -2782,9 +2710,9 @@ spec:
                     type: object
                   type: array
                 envFrom:
-                  description: List of sources to populate environment variables on
-                    the OpenTelemetry Collector's Pods. These can then in certain cases
-                    be consumed in the config file for the Collector.
+                  description: |-
+                    List of sources to populate environment variables on the OpenTelemetry Collector's Pods.
+                    These can then in certain cases be consumed in the config file for the Collector.
                   items:
                     description: EnvFromSource represents the source of a set of ConfigMaps
                     properties:
@@ -2792,8 +2720,10 @@ spec:
                         description: The ConfigMap to select from
                         properties:
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?
                             type: string
                           optional:
                             description: Specify whether the ConfigMap must be defined
@@ -2808,8 +2738,10 @@ spec:
                         description: The Secret to select from
                         properties:
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?
                             type: string
                           optional:
                             description: Specify whether the Secret must be defined
@@ -2831,27 +2763,31 @@ spec:
                     for retrieving the container image (Always, Never, IfNotPresent)
                   type: string
                 ingress:
-                  description: 'Ingress is used to specify how OpenTelemetry Collector
-                  is exposed. This functionality is only available if one of the valid
-                  modes is set. Valid modes are: deployment, daemonset and statefulset.'
+                  description: |-
+                    Ingress is used to specify how OpenTelemetry Collector is exposed. This
+                    functionality is only available if one of the valid modes is set.
+                    Valid modes are: deployment, daemonset and statefulset.
                   properties:
                     annotations:
                       additionalProperties:
                         type: string
-                      description: 'Annotations to add to ingress. e.g. ''cert-manager.io/cluster-issuer:
-                      "letsencrypt"'''
+                      description: |-
+                        Annotations to add to ingress.
+                        e.g. 'cert-manager.io/cluster-issuer: "letsencrypt"'
                       type: object
                     hostname:
                       description: Hostname by which the ingress proxy can be reached.
                       type: string
                     ingressClassName:
-                      description: IngressClassName is the name of an IngressClass cluster
-                        resource. Ingress controller implementations use this field
-                        to know whether they should be serving this Ingress resource.
+                      description: |-
+                        IngressClassName is the name of an IngressClass cluster resource. Ingress
+                        controller implementations use this field to know whether they should be
+                        serving this Ingress resource.
                       type: string
                     route:
-                      description: Route is an OpenShift specific section that is only
-                        considered when type "route" is used.
+                      description: |-
+                        Route is an OpenShift specific section that is only considered when
+                        type "route" is used.
                       properties:
                         termination:
                           description: Termination indicates termination type. By default
@@ -2864,11 +2800,11 @@ spec:
                           type: string
                       type: object
                     ruleType:
-                      description: RuleType defines how Ingress exposes collector receivers.
-                        IngressRuleTypePath ("path") exposes each receiver port on a
-                        unique path on single domain defined in Hostname. IngressRuleTypeSubdomain
-                        ("subdomain") exposes each receiver port on a unique subdomain
-                        of Hostname. Default is IngressRuleTypePath ("path").
+                      description: |-
+                        RuleType defines how Ingress exposes collector receivers.
+                        IngressRuleTypePath ("path") exposes each receiver port on a unique path on single domain defined in Hostname.
+                        IngressRuleTypeSubdomain ("subdomain") exposes each receiver port on a unique subdomain of Hostname.
+                        Default is IngressRuleTypePath ("path").
                       enum:
                         - path
                         - subdomain
@@ -2880,74 +2816,74 @@ spec:
                           associated with an ingress.
                         properties:
                           hosts:
-                            description: hosts is a list of hosts included in the TLS
-                              certificate. The values in this list must match the name/s
-                              used in the tlsSecret. Defaults to the wildcard host setting
-                              for the loadbalancer controller fulfilling this Ingress,
-                              if left unspecified.
+                            description: |-
+                              hosts is a list of hosts included in the TLS certificate. The values in
+                              this list must match the name/s used in the tlsSecret. Defaults to the
+                              wildcard host setting for the loadbalancer controller fulfilling this
+                              Ingress, if left unspecified.
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           secretName:
-                            description: secretName is the name of the secret used to
-                              terminate TLS traffic on port 443. Field is left optional
-                              to allow TLS routing based on SNI hostname alone. If the
-                              SNI host in a listener conflicts with the "Host" header
-                              field used by an IngressRule, the SNI host is used for
-                              termination and value of the "Host" header is used for
-                              routing.
+                            description: |-
+                              secretName is the name of the secret used to terminate TLS traffic on
+                              port 443. Field is left optional to allow TLS routing based on SNI
+                              hostname alone. If the SNI host in a listener conflicts with the "Host"
+                              header field used by an IngressRule, the SNI host is used for termination
+                              and value of the "Host" header is used for routing.
                             type: string
                         type: object
                       type: array
                     type:
-                      description: 'Type default value is: "" Supported types are: ingress,
-                      route'
+                      description: |-
+                        Type default value is: ""
+                        Supported types are: ingress, route
                       enum:
                         - ingress
                         - route
                       type: string
                   type: object
                 initContainers:
-                  description: 'InitContainers allows injecting initContainers to the
-                  Collector''s pod definition. These init containers can be used to
-                  fetch secrets for injection into the configuration from external
-                  sources, run added checks, etc. Any errors during the execution
-                  of an initContainer will lead to a restart of the Pod. More info:
-                  https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                  description: |-
+                    InitContainers allows injecting initContainers to the Collector's pod definition.
+                    These init containers can be used to fetch secrets for injection into the
+                    configuration from external sources, run added checks, etc. Any errors during the execution of
+                    an initContainer will lead to a restart of the Pod. More info:
+                    https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
                   items:
                     description: A single application container that you want to run
                       within a pod.
                     properties:
                       args:
-                        description: 'Arguments to the entrypoint. The container image''s
-                        CMD is used if this is not provided. Variable references $(VAR_NAME)
-                        are expanded using the container''s environment. If a variable
-                        cannot be resolved, the reference in the input string will
-                        be unchanged. Double $$ are reduced to a single $, which allows
-                        for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                        produce the string literal "$(VAR_NAME)". Escaped references
-                        will never be expanded, regardless of whether the variable
-                        exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                        description: |-
+                          Arguments to the entrypoint.
+                          The container image's CMD is used if this is not provided.
+                          Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                          cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                          produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                          of whether the variable exists or not. Cannot be updated.
+                          More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                         items:
                           type: string
                         type: array
                       command:
-                        description: 'Entrypoint array. Not executed within a shell.
-                        The container image''s ENTRYPOINT is used if this is not provided.
-                        Variable references $(VAR_NAME) are expanded using the container''s
-                        environment. If a variable cannot be resolved, the reference
-                        in the input string will be unchanged. Double $$ are reduced
-                        to a single $, which allows for escaping the $(VAR_NAME) syntax:
-                        i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                        Escaped references will never be expanded, regardless of whether
-                        the variable exists or not. Cannot be updated. More info:
-                        https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                        description: |-
+                          Entrypoint array. Not executed within a shell.
+                          The container image's ENTRYPOINT is used if this is not provided.
+                          Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                          cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                          produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                          of whether the variable exists or not. Cannot be updated.
+                          More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                         items:
                           type: string
                         type: array
                       env:
-                        description: List of environment variables to set in the container.
+                        description: |-
+                          List of environment variables to set in the container.
                           Cannot be updated.
                         items:
                           description: EnvVar represents an environment variable present
@@ -2958,16 +2894,16 @@ spec:
                                 a C_IDENTIFIER.
                               type: string
                             value:
-                              description: 'Variable references $(VAR_NAME) are expanded
-                              using the previously defined environment variables in
-                              the container and any service environment variables.
-                              If a variable cannot be resolved, the reference in the
-                              input string will be unchanged. Double $$ are reduced
-                              to a single $, which allows for escaping the $(VAR_NAME)
-                              syntax: i.e. "$$(VAR_NAME)" will produce the string
-                              literal "$(VAR_NAME)". Escaped references will never
-                              be expanded, regardless of whether the variable exists
-                              or not. Defaults to "".'
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
                               type: string
                             valueFrom:
                               description: Source for the environment variable's value.
@@ -2980,10 +2916,10 @@ spec:
                                       description: The key to select.
                                       type: string
                                     name:
-                                      description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                     optional:
                                       description: Specify whether the ConfigMap or
@@ -2994,11 +2930,9 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: 'Selects a field of the pod: supports
-                                  metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                  `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                  spec.serviceAccountName, status.hostIP, status.podIP,
-                                  status.podIPs.'
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
                                       description: Version of the schema the FieldPath
@@ -3013,11 +2947,9 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: 'Selects a resource of the container:
-                                  only resources limits and requests (limits.cpu,
-                                  limits.memory, limits.ephemeral-storage, requests.cpu,
-                                  requests.memory and requests.ephemeral-storage)
-                                  are currently supported.'
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
                                       description: 'Container name: required for volumes,
@@ -3047,10 +2979,10 @@ spec:
                                         be a valid secret key.
                                       type: string
                                     name:
-                                      description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                     optional:
                                       description: Specify whether the Secret or its
@@ -3066,13 +2998,13 @@ spec:
                           type: object
                         type: array
                       envFrom:
-                        description: List of sources to populate environment variables
-                          in the container. The keys defined within a source must be
-                          a C_IDENTIFIER. All invalid keys will be reported as an event
-                          when the container is starting. When a key exists in multiple
-                          sources, the value associated with the last source will take
-                          precedence. Values defined by an Env with a duplicate key
-                          will take precedence. Cannot be updated.
+                        description: |-
+                          List of sources to populate environment variables in the container.
+                          The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                          will be reported as an event when the container is starting. When a key exists in multiple
+                          sources, the value associated with the last source will take precedence.
+                          Values defined by an Env with a duplicate key will take precedence.
+                          Cannot be updated.
                         items:
                           description: EnvFromSource represents the source of a set
                             of ConfigMaps
@@ -3081,9 +3013,10 @@ spec:
                               description: The ConfigMap to select from
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
                                   description: Specify whether the ConfigMap must be
@@ -3099,9 +3032,10 @@ spec:
                               description: The Secret to select from
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
                                   description: Specify whether the Secret must be defined
@@ -3111,40 +3045,42 @@ spec:
                           type: object
                         type: array
                       image:
-                        description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
-                        This field is optional to allow higher level config management
-                        to default or override container images in workload controllers
-                        like Deployments and StatefulSets.'
+                        description: |-
+                          Container image name.
+                          More info: https://kubernetes.io/docs/concepts/containers/images
+                          This field is optional to allow higher level config management to default or override
+                          container images in workload controllers like Deployments and StatefulSets.
                         type: string
                       imagePullPolicy:
-                        description: 'Image pull policy. One of Always, Never, IfNotPresent.
-                        Defaults to Always if :latest tag is specified, or IfNotPresent
-                        otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                        description: |-
+                          Image pull policy.
+                          One of Always, Never, IfNotPresent.
+                          Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                         type: string
                       lifecycle:
-                        description: Actions that the management system should take
-                          in response to container lifecycle events. Cannot be updated.
+                        description: |-
+                          Actions that the management system should take in response to container lifecycle events.
+                          Cannot be updated.
                         properties:
                           postStart:
-                            description: 'PostStart is called immediately after a container
-                            is created. If the handler fails, the container is terminated
-                            and restarted according to its restart policy. Other management
-                            of the container blocks until the hook completes. More
-                            info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                            description: |-
+                              PostStart is called immediately after a container is created. If the handler fails,
+                              the container is terminated and restarted according to its restart policy.
+                              Other management of the container blocks until the hook completes.
+                              More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                             properties:
                               exec:
                                 description: Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory for
-                                      the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions
-                                      ('|', etc) won't work. To use a shell, you need
-                                      to explicitly call out to that shell. Exit status
-                                      of 0 is treated as live/healthy and non-zero is
-                                      unhealthy.
+                                    description: |-
+                                      Command is the command line to execute inside the container, the working directory for the
+                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                      a shell, you need to explicitly call out to that shell.
+                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                     items:
                                       type: string
                                     type: array
@@ -3153,9 +3089,9 @@ spec:
                                 description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to
-                                      the pod IP. You probably want to set "Host" in
-                                      httpHeaders instead.
+                                    description: |-
+                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                      "Host" in httpHeaders instead.
                                     type: string
                                   httpHeaders:
                                     description: Custom headers to set in the request.
@@ -3165,9 +3101,9 @@ spec:
                                         to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name. This will
-                                            be canonicalized upon output, so case-variant
-                                            names will be understood as the same header.
+                                          description: |-
+                                            The header field name.
+                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                           type: string
                                         value:
                                           description: The header field value
@@ -3184,13 +3120,15 @@ spec:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    description: |-
+                                      Name or number of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
+                                    description: |-
+                                      Scheme to use for connecting to the host.
+                                      Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
@@ -3208,10 +3146,10 @@ spec:
                                   - seconds
                                 type: object
                               tcpSocket:
-                                description: Deprecated. TCPSocket is NOT supported
-                                  as a LifecycleHandler and kept for the backward compatibility.
-                                  There are no validation of this field and lifecycle
-                                  hooks will fail in runtime when tcp handler is specified.
+                                description: |-
+                                  Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                  for the backward compatibility. There are no validation of this field and
+                                  lifecycle hooks will fail in runtime when tcp handler is specified.
                                 properties:
                                   host:
                                     description: 'Optional: Host name to connect to,
@@ -3221,40 +3159,37 @@ spec:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    description: |-
+                                      Number or name of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                             type: object
                           preStop:
-                            description: 'PreStop is called immediately before a container
-                            is terminated due to an API request or management event
-                            such as liveness/startup probe failure, preemption, resource
-                            contention, etc. The handler is not called if the container
-                            crashes or exits. The Pod''s termination grace period
-                            countdown begins before the PreStop hook is executed.
-                            Regardless of the outcome of the handler, the container
-                            will eventually terminate within the Pod''s termination
-                            grace period (unless delayed by finalizers). Other management
-                            of the container blocks until the hook completes or until
-                            the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                            description: |-
+                              PreStop is called immediately before a container is terminated due to an
+                              API request or management event such as liveness/startup probe failure,
+                              preemption, resource contention, etc. The handler is not called if the
+                              container crashes or exits. The Pod's termination grace period countdown begins before the
+                              PreStop hook is executed. Regardless of the outcome of the handler, the
+                              container will eventually terminate within the Pod's termination grace
+                              period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                              or until the termination grace period is reached.
+                              More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                             properties:
                               exec:
                                 description: Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory for
-                                      the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions
-                                      ('|', etc) won't work. To use a shell, you need
-                                      to explicitly call out to that shell. Exit status
-                                      of 0 is treated as live/healthy and non-zero is
-                                      unhealthy.
+                                    description: |-
+                                      Command is the command line to execute inside the container, the working directory for the
+                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                      a shell, you need to explicitly call out to that shell.
+                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                     items:
                                       type: string
                                     type: array
@@ -3263,9 +3198,9 @@ spec:
                                 description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to
-                                      the pod IP. You probably want to set "Host" in
-                                      httpHeaders instead.
+                                    description: |-
+                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                      "Host" in httpHeaders instead.
                                     type: string
                                   httpHeaders:
                                     description: Custom headers to set in the request.
@@ -3275,9 +3210,9 @@ spec:
                                         to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name. This will
-                                            be canonicalized upon output, so case-variant
-                                            names will be understood as the same header.
+                                          description: |-
+                                            The header field name.
+                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                           type: string
                                         value:
                                           description: The header field value
@@ -3294,13 +3229,15 @@ spec:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    description: |-
+                                      Name or number of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
+                                    description: |-
+                                      Scheme to use for connecting to the host.
+                                      Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
@@ -3318,10 +3255,10 @@ spec:
                                   - seconds
                                 type: object
                               tcpSocket:
-                                description: Deprecated. TCPSocket is NOT supported
-                                  as a LifecycleHandler and kept for the backward compatibility.
-                                  There are no validation of this field and lifecycle
-                                  hooks will fail in runtime when tcp handler is specified.
+                                description: |-
+                                  Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                  for the backward compatibility. There are no validation of this field and
+                                  lifecycle hooks will fail in runtime when tcp handler is specified.
                                 properties:
                                   host:
                                     description: 'Optional: Host name to connect to,
@@ -3331,9 +3268,10 @@ spec:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    description: |-
+                                      Number or name of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
@@ -3341,30 +3279,30 @@ spec:
                             type: object
                         type: object
                       livenessProbe:
-                        description: 'Periodic probe of container liveness. Container
-                        will be restarted if the probe fails. Cannot be updated. More
-                        info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        description: |-
+                          Periodic probe of container liveness.
+                          Container will be restarted if the probe fails.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         properties:
                           exec:
                             description: Exec specifies the action to take.
                             properties:
                               command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for the
-                                  command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|', etc)
-                                  won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
+                                description: |-
+                                  Command is the command line to execute inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                  a shell, you need to explicitly call out to that shell.
+                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                 items:
                                   type: string
                                 type: array
                             type: object
                           failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
+                            description: |-
+                              Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                              Defaults to 3. Minimum value is 1.
                             format: int32
                             type: integer
                           grpc:
@@ -3376,10 +3314,12 @@ spec:
                                 format: int32
                                 type: integer
                               service:
-                                description: "Service is the name of the service to
-                                place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                \n If this is not specified, the default behavior
-                                is defined by gRPC."
+                                description: |-
+                                  Service is the name of the service to place in the gRPC HealthCheckRequest
+                                  (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                  
+                                  
+                                  If this is not specified, the default behavior is defined by gRPC.
                                 type: string
                             required:
                               - port
@@ -3388,9 +3328,9 @@ spec:
                             description: HTTPGet specifies the http request to perform.
                             properties:
                               host:
-                                description: Host name to connect to, defaults to the
-                                  pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
+                                description: |-
+                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                  "Host" in httpHeaders instead.
                                 type: string
                               httpHeaders:
                                 description: Custom headers to set in the request. HTTP
@@ -3400,9 +3340,9 @@ spec:
                                     to be used in HTTP probes
                                   properties:
                                     name:
-                                      description: The header field name. This will
-                                        be canonicalized upon output, so case-variant
-                                        names will be understood as the same header.
+                                      description: |-
+                                        The header field name.
+                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                       type: string
                                     value:
                                       description: The header field value
@@ -3419,33 +3359,35 @@ spec:
                                 anyOf:
                                   - type: integer
                                   - type: string
-                                description: Name or number of the port to access on
-                                  the container. Number must be in the range 1 to 65535.
+                                description: |-
+                                  Name or number of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
                                   Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                               scheme:
-                                description: Scheme to use for connecting to the host.
+                                description: |-
+                                  Scheme to use for connecting to the host.
                                   Defaults to HTTP.
                                 type: string
                             required:
                               - port
                             type: object
                           initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                            started before liveness probes are initiated. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            description: |-
+                              Number of seconds after the container has started before liveness probes are initiated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                             format: int32
                             type: integer
                           periodSeconds:
-                            description: How often (in seconds) to perform the probe.
+                            description: |-
+                              How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                             format: int32
                             type: integer
                           successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
+                            description: |-
+                              Minimum consecutive successes for the probe to be considered successful after having failed.
+                              Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                             format: int32
                             type: integer
                           tcpSocket:
@@ -3460,78 +3402,82 @@ spec:
                                 anyOf:
                                   - type: integer
                                   - type: string
-                                description: Number or name of the port to access on
-                                  the container. Number must be in the range 1 to 65535.
+                                description: |-
+                                  Number or name of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
                                   Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                             required:
                               - port
                             type: object
                           terminationGracePeriodSeconds:
-                            description: Optional duration in seconds the pod needs
-                              to terminate gracefully upon probe failure. The grace
-                              period is the duration in seconds after the processes
-                              running in the pod are sent a termination signal and the
-                              time when the processes are forcibly halted with a kill
-                              signal. Set this value longer than the expected cleanup
-                              time for your process. If this value is nil, the pod's
-                              terminationGracePeriodSeconds will be used. Otherwise,
-                              this value overrides the value provided by the pod spec.
-                              Value must be non-negative integer. The value zero indicates
-                              stop immediately via the kill signal (no opportunity to
-                              shut down). This is a beta field and requires enabling
-                              ProbeTerminationGracePeriod feature gate. Minimum value
-                              is 1. spec.terminationGracePeriodSeconds is used if unset.
+                            description: |-
+                              Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                              The grace period is the duration in seconds after the processes running in the pod are sent
+                              a termination signal and the time when the processes are forcibly halted with a kill signal.
+                              Set this value longer than the expected cleanup time for your process.
+                              If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                              value overrides the value provided by the pod spec.
+                              Value must be non-negative integer. The value zero indicates stop immediately via
+                              the kill signal (no opportunity to shut down).
+                              This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                              Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                             format: int64
                             type: integer
                           timeoutSeconds:
-                            description: 'Number of seconds after which the probe times
-                            out. Defaults to 1 second. Minimum value is 1. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            description: |-
+                              Number of seconds after which the probe times out.
+                              Defaults to 1 second. Minimum value is 1.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                             format: int32
                             type: integer
                         type: object
                       name:
-                        description: Name of the container specified as a DNS_LABEL.
+                        description: |-
+                          Name of the container specified as a DNS_LABEL.
                           Each container in a pod must have a unique name (DNS_LABEL).
                           Cannot be updated.
                         type: string
                       ports:
-                        description: List of ports to expose from the container. Not
-                          specifying a port here DOES NOT prevent that port from being
-                          exposed. Any port which is listening on the default "0.0.0.0"
-                          address inside a container will be accessible from the network.
-                          Modifying this array with strategic merge patch may corrupt
-                          the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                        description: |-
+                          List of ports to expose from the container. Not specifying a port here
+                          DOES NOT prevent that port from being exposed. Any port which is
+                          listening on the default "0.0.0.0" address inside a container will be
+                          accessible from the network.
+                          Modifying this array with strategic merge patch may corrupt the data.
+                          For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                           Cannot be updated.
                         items:
                           description: ContainerPort represents a network port in a
                             single container.
                           properties:
                             containerPort:
-                              description: Number of port to expose on the pod's IP
-                                address. This must be a valid port number, 0 < x < 65536.
+                              description: |-
+                                Number of port to expose on the pod's IP address.
+                                This must be a valid port number, 0 < x < 65536.
                               format: int32
                               type: integer
                             hostIP:
                               description: What host IP to bind the external port to.
                               type: string
                             hostPort:
-                              description: Number of port to expose on the host. If
-                                specified, this must be a valid port number, 0 < x <
-                                65536. If HostNetwork is specified, this must match
-                                ContainerPort. Most containers do not need this.
+                              description: |-
+                                Number of port to expose on the host.
+                                If specified, this must be a valid port number, 0 < x < 65536.
+                                If HostNetwork is specified, this must match ContainerPort.
+                                Most containers do not need this.
                               format: int32
                               type: integer
                             name:
-                              description: If specified, this must be an IANA_SVC_NAME
-                                and unique within the pod. Each named port in a pod
-                                must have a unique name. Name for the port that can
-                                be referred to by services.
+                              description: |-
+                                If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                named port in a pod must have a unique name. Name for the port that can be
+                                referred to by services.
                               type: string
                             protocol:
                               default: TCP
-                              description: Protocol for port. Must be UDP, TCP, or SCTP.
+                              description: |-
+                                Protocol for port. Must be UDP, TCP, or SCTP.
                                 Defaults to "TCP".
                               type: string
                           required:
@@ -3543,30 +3489,30 @@ spec:
                           - protocol
                         x-kubernetes-list-type: map
                       readinessProbe:
-                        description: 'Periodic probe of container service readiness.
-                        Container will be removed from service endpoints if the probe
-                        fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        description: |-
+                          Periodic probe of container service readiness.
+                          Container will be removed from service endpoints if the probe fails.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         properties:
                           exec:
                             description: Exec specifies the action to take.
                             properties:
                               command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for the
-                                  command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|', etc)
-                                  won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
+                                description: |-
+                                  Command is the command line to execute inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                  a shell, you need to explicitly call out to that shell.
+                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                 items:
                                   type: string
                                 type: array
                             type: object
                           failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
+                            description: |-
+                              Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                              Defaults to 3. Minimum value is 1.
                             format: int32
                             type: integer
                           grpc:
@@ -3578,10 +3524,12 @@ spec:
                                 format: int32
                                 type: integer
                               service:
-                                description: "Service is the name of the service to
-                                place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                \n If this is not specified, the default behavior
-                                is defined by gRPC."
+                                description: |-
+                                  Service is the name of the service to place in the gRPC HealthCheckRequest
+                                  (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                  
+                                  
+                                  If this is not specified, the default behavior is defined by gRPC.
                                 type: string
                             required:
                               - port
@@ -3590,9 +3538,9 @@ spec:
                             description: HTTPGet specifies the http request to perform.
                             properties:
                               host:
-                                description: Host name to connect to, defaults to the
-                                  pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
+                                description: |-
+                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                  "Host" in httpHeaders instead.
                                 type: string
                               httpHeaders:
                                 description: Custom headers to set in the request. HTTP
@@ -3602,9 +3550,9 @@ spec:
                                     to be used in HTTP probes
                                   properties:
                                     name:
-                                      description: The header field name. This will
-                                        be canonicalized upon output, so case-variant
-                                        names will be understood as the same header.
+                                      description: |-
+                                        The header field name.
+                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                       type: string
                                     value:
                                       description: The header field value
@@ -3621,33 +3569,35 @@ spec:
                                 anyOf:
                                   - type: integer
                                   - type: string
-                                description: Name or number of the port to access on
-                                  the container. Number must be in the range 1 to 65535.
+                                description: |-
+                                  Name or number of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
                                   Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                               scheme:
-                                description: Scheme to use for connecting to the host.
+                                description: |-
+                                  Scheme to use for connecting to the host.
                                   Defaults to HTTP.
                                 type: string
                             required:
                               - port
                             type: object
                           initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                            started before liveness probes are initiated. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            description: |-
+                              Number of seconds after the container has started before liveness probes are initiated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                             format: int32
                             type: integer
                           periodSeconds:
-                            description: How often (in seconds) to perform the probe.
+                            description: |-
+                              How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                             format: int32
                             type: integer
                           successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
+                            description: |-
+                              Minimum consecutive successes for the probe to be considered successful after having failed.
+                              Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                             format: int32
                             type: integer
                           tcpSocket:
@@ -3662,34 +3612,33 @@ spec:
                                 anyOf:
                                   - type: integer
                                   - type: string
-                                description: Number or name of the port to access on
-                                  the container. Number must be in the range 1 to 65535.
+                                description: |-
+                                  Number or name of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
                                   Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                             required:
                               - port
                             type: object
                           terminationGracePeriodSeconds:
-                            description: Optional duration in seconds the pod needs
-                              to terminate gracefully upon probe failure. The grace
-                              period is the duration in seconds after the processes
-                              running in the pod are sent a termination signal and the
-                              time when the processes are forcibly halted with a kill
-                              signal. Set this value longer than the expected cleanup
-                              time for your process. If this value is nil, the pod's
-                              terminationGracePeriodSeconds will be used. Otherwise,
-                              this value overrides the value provided by the pod spec.
-                              Value must be non-negative integer. The value zero indicates
-                              stop immediately via the kill signal (no opportunity to
-                              shut down). This is a beta field and requires enabling
-                              ProbeTerminationGracePeriod feature gate. Minimum value
-                              is 1. spec.terminationGracePeriodSeconds is used if unset.
+                            description: |-
+                              Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                              The grace period is the duration in seconds after the processes running in the pod are sent
+                              a termination signal and the time when the processes are forcibly halted with a kill signal.
+                              Set this value longer than the expected cleanup time for your process.
+                              If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                              value overrides the value provided by the pod spec.
+                              Value must be non-negative integer. The value zero indicates stop immediately via
+                              the kill signal (no opportunity to shut down).
+                              This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                              Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                             format: int64
                             type: integer
                           timeoutSeconds:
-                            description: 'Number of seconds after which the probe times
-                            out. Defaults to 1 second. Minimum value is 1. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            description: |-
+                              Number of seconds after which the probe times out.
+                              Defaults to 1 second. Minimum value is 1.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                             format: int32
                             type: integer
                         type: object
@@ -3700,12 +3649,14 @@ spec:
                             policy for the container.
                           properties:
                             resourceName:
-                              description: 'Name of the resource to which this resource
-                              resize policy applies. Supported values: cpu, memory.'
+                              description: |-
+                                Name of the resource to which this resource resize policy applies.
+                                Supported values: cpu, memory.
                               type: string
                             restartPolicy:
-                              description: Restart policy to apply when specified resource
-                                is resized. If not specified, it defaults to NotRequired.
+                              description: |-
+                                Restart policy to apply when specified resource is resized.
+                                If not specified, it defaults to NotRequired.
                               type: string
                           required:
                             - resourceName
@@ -3714,22 +3665,29 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                       resources:
-                        description: 'Compute Resources required by this container.
-                        Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        description: |-
+                          Compute Resources required by this container.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         properties:
                           claims:
-                            description: "Claims lists the names of resources, defined
-                            in spec.resourceClaims, that are used by this container.
-                            \n This is an alpha field and requires enabling the DynamicResourceAllocation
-                            feature gate. \n This field is immutable. It can only
-                            be set for containers."
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+                              
+                              
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+                              
+                              
+                              This field is immutable. It can only be set for containers.
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: Name must match the name of one entry
-                                    in pod.spec.resourceClaims of the Pod where this
-                                    field is used. It makes that resource available
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
                                     inside a container.
                                   type: string
                               required:
@@ -3746,8 +3704,9 @@ spec:
                                 - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -3756,52 +3715,52 @@ spec:
                                 - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of compute
-                            resources required. If Requests is omitted for a container,
-                            it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. Requests
-                            cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       restartPolicy:
-                        description: 'RestartPolicy defines the restart behavior of
-                        individual containers in a pod. This field may only be set
-                        for init containers, and the only allowed value is "Always".
-                        For non-init containers or when this field is not specified,
-                        the restart behavior is defined by the Pod''s restart policy
-                        and the container type. Setting the RestartPolicy as "Always"
-                        for the init container will have the following effect: this
-                        init container will be continually restarted on exit until
-                        all regular containers have terminated. Once all regular containers
-                        have completed, all init containers with restartPolicy "Always"
-                        will be shut down. This lifecycle differs from normal init
-                        containers and is often referred to as a "sidecar" container.
-                        Although this init container still starts in the init container
-                        sequence, it does not wait for the container to complete before
-                        proceeding to the next init container. Instead, the next init
-                        container starts immediately after this init container is
-                        started, or after any startupProbe has successfully completed.'
+                        description: |-
+                          RestartPolicy defines the restart behavior of individual containers in a pod.
+                          This field may only be set for init containers, and the only allowed value is "Always".
+                          For non-init containers or when this field is not specified,
+                          the restart behavior is defined by the Pod's restart policy and the container type.
+                          Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                          this init container will be continually restarted on
+                          exit until all regular containers have terminated. Once all regular
+                          containers have completed, all init containers with restartPolicy "Always"
+                          will be shut down. This lifecycle differs from normal init containers and
+                          is often referred to as a "sidecar" container. Although this init
+                          container still starts in the init container sequence, it does not wait
+                          for the container to complete before proceeding to the next init
+                          container. Instead, the next init container starts immediately after this
+                          init container is started, or after any startupProbe has successfully
+                          completed.
                         type: string
                       securityContext:
-                        description: 'SecurityContext defines the security options the
-                        container should be run with. If set, the fields of SecurityContext
-                        override the equivalent fields of PodSecurityContext. More
-                        info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                        description: |-
+                          SecurityContext defines the security options the container should be run with.
+                          If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                          More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                         properties:
                           allowPrivilegeEscalation:
-                            description: 'AllowPrivilegeEscalation controls whether
-                            a process can gain more privileges than its parent process.
-                            This bool directly controls if the no_new_privs flag will
-                            be set on the container process. AllowPrivilegeEscalation
-                            is true always when the container is: 1) run as Privileged
-                            2) has CAP_SYS_ADMIN Note that this field cannot be set
-                            when spec.os.name is windows.'
+                            description: |-
+                              AllowPrivilegeEscalation controls whether a process can gain more
+                              privileges than its parent process. This bool directly controls if
+                              the no_new_privs flag will be set on the container process.
+                              AllowPrivilegeEscalation is true always when the container is:
+                              1) run as Privileged
+                              2) has CAP_SYS_ADMIN
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: boolean
                           capabilities:
-                            description: The capabilities to add/drop when running containers.
-                              Defaults to the default set of capabilities granted by
-                              the container runtime. Note that this field cannot be
-                              set when spec.os.name is windows.
+                            description: |-
+                              The capabilities to add/drop when running containers.
+                              Defaults to the default set of capabilities granted by the container runtime.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               add:
                                 description: Added capabilities
@@ -3819,60 +3778,60 @@ spec:
                                 type: array
                             type: object
                           privileged:
-                            description: Run container in privileged mode. Processes
-                              in privileged containers are essentially equivalent to
-                              root on the host. Defaults to false. Note that this field
-                              cannot be set when spec.os.name is windows.
+                            description: |-
+                              Run container in privileged mode.
+                              Processes in privileged containers are essentially equivalent to root on the host.
+                              Defaults to false.
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: boolean
                           procMount:
-                            description: procMount denotes the type of proc mount to
-                              use for the containers. The default is DefaultProcMount
-                              which uses the container runtime defaults for readonly
-                              paths and masked paths. This requires the ProcMountType
-                              feature flag to be enabled. Note that this field cannot
-                              be set when spec.os.name is windows.
+                            description: |-
+                              procMount denotes the type of proc mount to use for the containers.
+                              The default is DefaultProcMount which uses the container runtime defaults for
+                              readonly paths and masked paths.
+                              This requires the ProcMountType feature flag to be enabled.
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
-                            description: Whether this container has a read-only root
-                              filesystem. Default is false. Note that this field cannot
-                              be set when spec.os.name is windows.
+                            description: |-
+                              Whether this container has a read-only root filesystem.
+                              Default is false.
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: boolean
                           runAsGroup:
-                            description: The GID to run the entrypoint of the container
-                              process. Uses runtime default if unset. May also be set
-                              in PodSecurityContext.  If set in both SecurityContext
-                              and PodSecurityContext, the value specified in SecurityContext
-                              takes precedence. Note that this field cannot be set when
-                              spec.os.name is windows.
+                            description: |-
+                              The GID to run the entrypoint of the container process.
+                              Uses runtime default if unset.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
                             format: int64
                             type: integer
                           runAsNonRoot:
-                            description: Indicates that the container must run as a
-                              non-root user. If true, the Kubelet will validate the
-                              image at runtime to ensure that it does not run as UID
-                              0 (root) and fail to start the container if it does. If
-                              unset or false, no such validation will be performed.
-                              May also be set in PodSecurityContext.  If set in both
-                              SecurityContext and PodSecurityContext, the value specified
-                              in SecurityContext takes precedence.
+                            description: |-
+                              Indicates that the container must run as a non-root user.
+                              If true, the Kubelet will validate the image at runtime to ensure that it
+                              does not run as UID 0 (root) and fail to start the container if it does.
+                              If unset or false, no such validation will be performed.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
                             type: boolean
                           runAsUser:
-                            description: The UID to run the entrypoint of the container
-                              process. Defaults to user specified in image metadata
-                              if unspecified. May also be set in PodSecurityContext.  If
-                              set in both SecurityContext and PodSecurityContext, the
-                              value specified in SecurityContext takes precedence. Note
-                              that this field cannot be set when spec.os.name is windows.
+                            description: |-
+                              The UID to run the entrypoint of the container process.
+                              Defaults to user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
                             format: int64
                             type: integer
                           seLinuxOptions:
-                            description: The SELinux context to be applied to the container.
-                              If unspecified, the container runtime will allocate a
-                              random SELinux context for each container.  May also be
-                              set in PodSecurityContext.  If set in both SecurityContext
-                              and PodSecurityContext, the value specified in SecurityContext
-                              takes precedence. Note that this field cannot be set when
-                              spec.os.name is windows.
+                            description: |-
+                              The SELinux context to be applied to the container.
+                              If unspecified, the container runtime will allocate a random SELinux context for each
+                              container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               level:
                                 description: Level is SELinux level label that applies
@@ -3892,98 +3851,93 @@ spec:
                                 type: string
                             type: object
                           seccompProfile:
-                            description: The seccomp options to use by this container.
-                              If seccomp options are provided at both the pod & container
-                              level, the container options override the pod options.
-                              Note that this field cannot be set when spec.os.name is
-                              windows.
+                            description: |-
+                              The seccomp options to use by this container. If seccomp options are
+                              provided at both the pod & container level, the container options
+                              override the pod options.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               localhostProfile:
-                                description: localhostProfile indicates a profile defined
-                                  in a file on the node should be used. The profile
-                                  must be preconfigured on the node to work. Must be
-                                  a descending path, relative to the kubelet's configured
-                                  seccomp profile location. Must be set if type is "Localhost".
-                                  Must NOT be set for any other type.
+                                description: |-
+                                  localhostProfile indicates a profile defined in a file on the node should be used.
+                                  The profile must be preconfigured on the node to work.
+                                  Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                  Must be set if type is "Localhost". Must NOT be set for any other type.
                                 type: string
                               type:
-                                description: "type indicates which kind of seccomp profile
-                                will be applied. Valid options are: \n Localhost -
-                                a profile defined in a file on the node should be
-                                used. RuntimeDefault - the container runtime default
-                                profile should be used. Unconfined - no profile should
-                                be applied."
+                                description: |-
+                                  type indicates which kind of seccomp profile will be applied.
+                                  Valid options are:
+                                  
+                                  
+                                  Localhost - a profile defined in a file on the node should be used.
+                                  RuntimeDefault - the container runtime default profile should be used.
+                                  Unconfined - no profile should be applied.
                                 type: string
                             required:
                               - type
                             type: object
                           windowsOptions:
-                            description: The Windows specific settings applied to all
-                              containers. If unspecified, the options from the PodSecurityContext
-                              will be used. If set in both SecurityContext and PodSecurityContext,
-                              the value specified in SecurityContext takes precedence.
-                              Note that this field cannot be set when spec.os.name is
-                              linux.
+                            description: |-
+                              The Windows specific settings applied to all containers.
+                              If unspecified, the options from the PodSecurityContext will be used.
+                              If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is linux.
                             properties:
                               gmsaCredentialSpec:
-                                description: GMSACredentialSpec is where the GMSA admission
-                                  webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                  inlines the contents of the GMSA credential spec named
-                                  by the GMSACredentialSpecName field.
+                                description: |-
+                                  GMSACredentialSpec is where the GMSA admission webhook
+                                  (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                  GMSA credential spec named by the GMSACredentialSpecName field.
                                 type: string
                               gmsaCredentialSpecName:
                                 description: GMSACredentialSpecName is the name of the
                                   GMSA credential spec to use.
                                 type: string
                               hostProcess:
-                                description: HostProcess determines if a container should
-                                  be run as a 'Host Process' container. All of a Pod's
-                                  containers must have the same effective HostProcess
-                                  value (it is not allowed to have a mix of HostProcess
-                                  containers and non-HostProcess containers). In addition,
-                                  if HostProcess is true then HostNetwork must also
-                                  be set to true.
+                                description: |-
+                                  HostProcess determines if a container should be run as a 'Host Process' container.
+                                  All of a Pod's containers must have the same effective HostProcess value
+                                  (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                  In addition, if HostProcess is true then HostNetwork must also be set to true.
                                 type: boolean
                               runAsUserName:
-                                description: The UserName in Windows to run the entrypoint
-                                  of the container process. Defaults to the user specified
-                                  in image metadata if unspecified. May also be set
-                                  in PodSecurityContext. If set in both SecurityContext
-                                  and PodSecurityContext, the value specified in SecurityContext
-                                  takes precedence.
+                                description: |-
+                                  The UserName in Windows to run the entrypoint of the container process.
+                                  Defaults to the user specified in image metadata if unspecified.
+                                  May also be set in PodSecurityContext. If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
                                 type: string
                             type: object
                         type: object
                       startupProbe:
-                        description: 'StartupProbe indicates that the Pod has successfully
-                        initialized. If specified, no other probes are executed until
-                        this completes successfully. If this probe fails, the Pod
-                        will be restarted, just as if the livenessProbe failed. This
-                        can be used to provide different probe parameters at the beginning
-                        of a Pod''s lifecycle, when it might take a long time to load
-                        data or warm a cache, than during steady-state operation.
-                        This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        description: |-
+                          StartupProbe indicates that the Pod has successfully initialized.
+                          If specified, no other probes are executed until this completes successfully.
+                          If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                          This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                          when it might take a long time to load data or warm a cache, than during steady-state operation.
+                          This cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         properties:
                           exec:
                             description: Exec specifies the action to take.
                             properties:
                               command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for the
-                                  command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|', etc)
-                                  won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
+                                description: |-
+                                  Command is the command line to execute inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                  a shell, you need to explicitly call out to that shell.
+                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                 items:
                                   type: string
                                 type: array
                             type: object
                           failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
+                            description: |-
+                              Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                              Defaults to 3. Minimum value is 1.
                             format: int32
                             type: integer
                           grpc:
@@ -3995,10 +3949,12 @@ spec:
                                 format: int32
                                 type: integer
                               service:
-                                description: "Service is the name of the service to
-                                place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                \n If this is not specified, the default behavior
-                                is defined by gRPC."
+                                description: |-
+                                  Service is the name of the service to place in the gRPC HealthCheckRequest
+                                  (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                  
+                                  
+                                  If this is not specified, the default behavior is defined by gRPC.
                                 type: string
                             required:
                               - port
@@ -4007,9 +3963,9 @@ spec:
                             description: HTTPGet specifies the http request to perform.
                             properties:
                               host:
-                                description: Host name to connect to, defaults to the
-                                  pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
+                                description: |-
+                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                  "Host" in httpHeaders instead.
                                 type: string
                               httpHeaders:
                                 description: Custom headers to set in the request. HTTP
@@ -4019,9 +3975,9 @@ spec:
                                     to be used in HTTP probes
                                   properties:
                                     name:
-                                      description: The header field name. This will
-                                        be canonicalized upon output, so case-variant
-                                        names will be understood as the same header.
+                                      description: |-
+                                        The header field name.
+                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                       type: string
                                     value:
                                       description: The header field value
@@ -4038,33 +3994,35 @@ spec:
                                 anyOf:
                                   - type: integer
                                   - type: string
-                                description: Name or number of the port to access on
-                                  the container. Number must be in the range 1 to 65535.
+                                description: |-
+                                  Name or number of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
                                   Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                               scheme:
-                                description: Scheme to use for connecting to the host.
+                                description: |-
+                                  Scheme to use for connecting to the host.
                                   Defaults to HTTP.
                                 type: string
                             required:
                               - port
                             type: object
                           initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                            started before liveness probes are initiated. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            description: |-
+                              Number of seconds after the container has started before liveness probes are initiated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                             format: int32
                             type: integer
                           periodSeconds:
-                            description: How often (in seconds) to perform the probe.
+                            description: |-
+                              How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                             format: int32
                             type: integer
                           successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
+                            description: |-
+                              Minimum consecutive successes for the probe to be considered successful after having failed.
+                              Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                             format: int32
                             type: integer
                           tcpSocket:
@@ -4079,77 +4037,76 @@ spec:
                                 anyOf:
                                   - type: integer
                                   - type: string
-                                description: Number or name of the port to access on
-                                  the container. Number must be in the range 1 to 65535.
+                                description: |-
+                                  Number or name of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
                                   Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                             required:
                               - port
                             type: object
                           terminationGracePeriodSeconds:
-                            description: Optional duration in seconds the pod needs
-                              to terminate gracefully upon probe failure. The grace
-                              period is the duration in seconds after the processes
-                              running in the pod are sent a termination signal and the
-                              time when the processes are forcibly halted with a kill
-                              signal. Set this value longer than the expected cleanup
-                              time for your process. If this value is nil, the pod's
-                              terminationGracePeriodSeconds will be used. Otherwise,
-                              this value overrides the value provided by the pod spec.
-                              Value must be non-negative integer. The value zero indicates
-                              stop immediately via the kill signal (no opportunity to
-                              shut down). This is a beta field and requires enabling
-                              ProbeTerminationGracePeriod feature gate. Minimum value
-                              is 1. spec.terminationGracePeriodSeconds is used if unset.
+                            description: |-
+                              Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                              The grace period is the duration in seconds after the processes running in the pod are sent
+                              a termination signal and the time when the processes are forcibly halted with a kill signal.
+                              Set this value longer than the expected cleanup time for your process.
+                              If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                              value overrides the value provided by the pod spec.
+                              Value must be non-negative integer. The value zero indicates stop immediately via
+                              the kill signal (no opportunity to shut down).
+                              This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                              Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                             format: int64
                             type: integer
                           timeoutSeconds:
-                            description: 'Number of seconds after which the probe times
-                            out. Defaults to 1 second. Minimum value is 1. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            description: |-
+                              Number of seconds after which the probe times out.
+                              Defaults to 1 second. Minimum value is 1.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                             format: int32
                             type: integer
                         type: object
                       stdin:
-                        description: Whether this container should allocate a buffer
-                          for stdin in the container runtime. If this is not set, reads
-                          from stdin in the container will always result in EOF. Default
-                          is false.
+                        description: |-
+                          Whether this container should allocate a buffer for stdin in the container runtime. If this
+                          is not set, reads from stdin in the container will always result in EOF.
+                          Default is false.
                         type: boolean
                       stdinOnce:
-                        description: Whether the container runtime should close the
-                          stdin channel after it has been opened by a single attach.
-                          When stdin is true the stdin stream will remain open across
-                          multiple attach sessions. If stdinOnce is set to true, stdin
-                          is opened on container start, is empty until the first client
-                          attaches to stdin, and then remains open and accepts data
-                          until the client disconnects, at which time stdin is closed
-                          and remains closed until the container is restarted. If this
-                          flag is false, a container processes that reads from stdin
-                          will never receive an EOF. Default is false
+                        description: |-
+                          Whether the container runtime should close the stdin channel after it has been opened by
+                          a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                          sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                          first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                          at which time stdin is closed and remains closed until the container is restarted. If this
+                          flag is false, a container processes that reads from stdin will never receive an EOF.
+                          Default is false
                         type: boolean
                       terminationMessagePath:
-                        description: 'Optional: Path at which the file to which the
-                        container''s termination message will be written is mounted
-                        into the container''s filesystem. Message written is intended
-                        to be brief final status, such as an assertion failure message.
-                        Will be truncated by the node if greater than 4096 bytes.
-                        The total message length across all containers will be limited
-                        to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
+                        description: |-
+                          Optional: Path at which the file to which the container's termination message
+                          will be written is mounted into the container's filesystem.
+                          Message written is intended to be brief final status, such as an assertion failure message.
+                          Will be truncated by the node if greater than 4096 bytes. The total message length across
+                          all containers will be limited to 12kb.
+                          Defaults to /dev/termination-log.
+                          Cannot be updated.
                         type: string
                       terminationMessagePolicy:
-                        description: Indicate how the termination message should be
-                          populated. File will use the contents of terminationMessagePath
-                          to populate the container status message on both success and
-                          failure. FallbackToLogsOnError will use the last chunk of
-                          container log output if the termination message file is empty
-                          and the container exited with an error. The log output is
-                          limited to 2048 bytes or 80 lines, whichever is smaller. Defaults
-                          to File. Cannot be updated.
+                        description: |-
+                          Indicate how the termination message should be populated. File will use the contents of
+                          terminationMessagePath to populate the container status message on both success and failure.
+                          FallbackToLogsOnError will use the last chunk of container log output if the termination
+                          message file is empty and the container exited with an error.
+                          The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                          Defaults to File.
+                          Cannot be updated.
                         type: string
                       tty:
-                        description: Whether this container should allocate a TTY for
-                          itself, also requires 'stdin' to be true. Default is false.
+                        description: |-
+                          Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                          Default is false.
                         type: boolean
                       volumeDevices:
                         description: volumeDevices is the list of block devices to be
@@ -4172,40 +4129,44 @@ spec:
                           type: object
                         type: array
                       volumeMounts:
-                        description: Pod volumes to mount into the container's filesystem.
+                        description: |-
+                          Pod volumes to mount into the container's filesystem.
                           Cannot be updated.
                         items:
                           description: VolumeMount describes a mounting of a Volume
                             within a container.
                           properties:
                             mountPath:
-                              description: Path within the container at which the volume
-                                should be mounted.  Must not contain ':'.
+                              description: |-
+                                Path within the container at which the volume should be mounted.  Must
+                                not contain ':'.
                               type: string
                             mountPropagation:
-                              description: mountPropagation determines how mounts are
-                                propagated from the host to container and the other
-                                way around. When not set, MountPropagationNone is used.
+                              description: |-
+                                mountPropagation determines how mounts are propagated from the host
+                                to container and the other way around.
+                                When not set, MountPropagationNone is used.
                                 This field is beta in 1.10.
                               type: string
                             name:
                               description: This must match the Name of a Volume.
                               type: string
                             readOnly:
-                              description: Mounted read-only if true, read-write otherwise
-                                (false or unspecified). Defaults to false.
+                              description: |-
+                                Mounted read-only if true, read-write otherwise (false or unspecified).
+                                Defaults to false.
                               type: boolean
                             subPath:
-                              description: Path within the volume from which the container's
-                                volume should be mounted. Defaults to "" (volume's root).
+                              description: |-
+                                Path within the volume from which the container's volume should be mounted.
+                                Defaults to "" (volume's root).
                               type: string
                             subPathExpr:
-                              description: Expanded path within the volume from which
-                                the container's volume should be mounted. Behaves similarly
-                                to SubPath but environment variable references $(VAR_NAME)
-                                are expanded using the container's environment. Defaults
-                                to "" (volume's root). SubPathExpr and SubPath are mutually
-                                exclusive.
+                              description: |-
+                                Expanded path within the volume from which the container's volume should be mounted.
+                                Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                Defaults to "" (volume's root).
+                                SubPathExpr and SubPath are mutually exclusive.
                               type: string
                           required:
                             - mountPath
@@ -4213,9 +4174,11 @@ spec:
                           type: object
                         type: array
                       workingDir:
-                        description: Container's working directory. If not specified,
-                          the container runtime's default will be used, which might
-                          be configured in the container image. Cannot be updated.
+                        description: |-
+                          Container's working directory.
+                          If not specified, the container runtime's default will be used, which
+                          might be configured in the container image.
+                          Cannot be updated.
                         type: string
                     required:
                       - name
@@ -4226,24 +4189,22 @@ spec:
                     to container lifecycle events. Cannot be updated.
                   properties:
                     postStart:
-                      description: 'PostStart is called immediately after a container
-                      is created. If the handler fails, the container is terminated
-                      and restarted according to its restart policy. Other management
-                      of the container blocks until the hook completes. More info:
-                      https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      description: |-
+                        PostStart is called immediately after a container is created. If the handler fails,
+                        the container is terminated and restarted according to its restart policy.
+                        Other management of the container blocks until the hook completes.
+                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                       properties:
                         exec:
                           description: Exec specifies the action to take.
                           properties:
                             command:
-                              description: Command is the command line to execute inside
-                                the container, the working directory for the command  is
-                                root ('/') in the container's filesystem. The command
-                                is simply exec'd, it is not run inside a shell, so traditional
-                                shell instructions ('|', etc) won't work. To use a shell,
-                                you need to explicitly call out to that shell. Exit
-                                status of 0 is treated as live/healthy and non-zero
-                                is unhealthy.
+                              description: |-
+                                Command is the command line to execute inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                a shell, you need to explicitly call out to that shell.
+                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                               items:
                                 type: string
                               type: array
@@ -4252,9 +4213,9 @@ spec:
                           description: HTTPGet specifies the http request to perform.
                           properties:
                             host:
-                              description: Host name to connect to, defaults to the
-                                pod IP. You probably want to set "Host" in httpHeaders
-                                instead.
+                              description: |-
+                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                "Host" in httpHeaders instead.
                               type: string
                             httpHeaders:
                               description: Custom headers to set in the request. HTTP
@@ -4264,9 +4225,9 @@ spec:
                                   be used in HTTP probes
                                 properties:
                                   name:
-                                    description: The header field name. This will be
-                                      canonicalized upon output, so case-variant names
-                                      will be understood as the same header.
+                                    description: |-
+                                      The header field name.
+                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                     type: string
                                   value:
                                     description: The header field value
@@ -4283,12 +4244,14 @@ spec:
                               anyOf:
                                 - type: integer
                                 - type: string
-                              description: Name or number of the port to access on the
-                                container. Number must be in the range 1 to 65535. Name
-                                must be an IANA_SVC_NAME.
+                              description: |-
+                                Name or number of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
-                              description: Scheme to use for connecting to the host.
+                              description: |-
+                                Scheme to use for connecting to the host.
                                 Defaults to HTTP.
                               type: string
                           required:
@@ -4306,10 +4269,10 @@ spec:
                             - seconds
                           type: object
                         tcpSocket:
-                          description: Deprecated. TCPSocket is NOT supported as a LifecycleHandler
-                            and kept for the backward compatibility. There are no validation
-                            of this field and lifecycle hooks will fail in runtime when
-                            tcp handler is specified.
+                          description: |-
+                            Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                            for the backward compatibility. There are no validation of this field and
+                            lifecycle hooks will fail in runtime when tcp handler is specified.
                           properties:
                             host:
                               description: 'Optional: Host name to connect to, defaults
@@ -4319,39 +4282,37 @@ spec:
                               anyOf:
                                 - type: integer
                                 - type: string
-                              description: Number or name of the port to access on the
-                                container. Number must be in the range 1 to 65535. Name
-                                must be an IANA_SVC_NAME.
+                              description: |-
+                                Number or name of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                             - port
                           type: object
                       type: object
                     preStop:
-                      description: 'PreStop is called immediately before a container
-                      is terminated due to an API request or management event such
-                      as liveness/startup probe failure, preemption, resource contention,
-                      etc. The handler is not called if the container crashes or exits.
-                      The Pod''s termination grace period countdown begins before
-                      the PreStop hook is executed. Regardless of the outcome of the
-                      handler, the container will eventually terminate within the
-                      Pod''s termination grace period (unless delayed by finalizers).
-                      Other management of the container blocks until the hook completes
-                      or until the termination grace period is reached. More info:
-                      https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      description: |-
+                        PreStop is called immediately before a container is terminated due to an
+                        API request or management event such as liveness/startup probe failure,
+                        preemption, resource contention, etc. The handler is not called if the
+                        container crashes or exits. The Pod's termination grace period countdown begins before the
+                        PreStop hook is executed. Regardless of the outcome of the handler, the
+                        container will eventually terminate within the Pod's termination grace
+                        period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                        or until the termination grace period is reached.
+                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                       properties:
                         exec:
                           description: Exec specifies the action to take.
                           properties:
                             command:
-                              description: Command is the command line to execute inside
-                                the container, the working directory for the command  is
-                                root ('/') in the container's filesystem. The command
-                                is simply exec'd, it is not run inside a shell, so traditional
-                                shell instructions ('|', etc) won't work. To use a shell,
-                                you need to explicitly call out to that shell. Exit
-                                status of 0 is treated as live/healthy and non-zero
-                                is unhealthy.
+                              description: |-
+                                Command is the command line to execute inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                a shell, you need to explicitly call out to that shell.
+                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                               items:
                                 type: string
                               type: array
@@ -4360,9 +4321,9 @@ spec:
                           description: HTTPGet specifies the http request to perform.
                           properties:
                             host:
-                              description: Host name to connect to, defaults to the
-                                pod IP. You probably want to set "Host" in httpHeaders
-                                instead.
+                              description: |-
+                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                "Host" in httpHeaders instead.
                               type: string
                             httpHeaders:
                               description: Custom headers to set in the request. HTTP
@@ -4372,9 +4333,9 @@ spec:
                                   be used in HTTP probes
                                 properties:
                                   name:
-                                    description: The header field name. This will be
-                                      canonicalized upon output, so case-variant names
-                                      will be understood as the same header.
+                                    description: |-
+                                      The header field name.
+                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                     type: string
                                   value:
                                     description: The header field value
@@ -4391,12 +4352,14 @@ spec:
                               anyOf:
                                 - type: integer
                                 - type: string
-                              description: Name or number of the port to access on the
-                                container. Number must be in the range 1 to 65535. Name
-                                must be an IANA_SVC_NAME.
+                              description: |-
+                                Name or number of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
-                              description: Scheme to use for connecting to the host.
+                              description: |-
+                                Scheme to use for connecting to the host.
                                 Defaults to HTTP.
                               type: string
                           required:
@@ -4414,10 +4377,10 @@ spec:
                             - seconds
                           type: object
                         tcpSocket:
-                          description: Deprecated. TCPSocket is NOT supported as a LifecycleHandler
-                            and kept for the backward compatibility. There are no validation
-                            of this field and lifecycle hooks will fail in runtime when
-                            tcp handler is specified.
+                          description: |-
+                            Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                            for the backward compatibility. There are no validation of this field and
+                            lifecycle hooks will fail in runtime when tcp handler is specified.
                           properties:
                             host:
                               description: 'Optional: Host name to connect to, defaults
@@ -4427,9 +4390,10 @@ spec:
                               anyOf:
                                 - type: integer
                                 - type: string
-                              description: Number or name of the port to access on the
-                                container. Number must be in the range 1 to 65535. Name
-                                must be an IANA_SVC_NAME.
+                              description: |-
+                                Number or name of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                             - port
@@ -4437,74 +4401,76 @@ spec:
                       type: object
                   type: object
                 livenessProbe:
-                  description: Liveness config for the OpenTelemetry Collector except
-                    the probe handler which is auto generated from the health extension
-                    of the collector. It is only effective when healthcheckextension
-                    is configured in the OpenTelemetry Collector pipeline.
+                  description: |-
+                    Liveness config for the OpenTelemetry Collector except the probe handler which is auto generated from the health extension of the collector.
+                    It is only effective when healthcheckextension is configured in the OpenTelemetry Collector pipeline.
                   properties:
                     failureThreshold:
-                      description: Minimum consecutive failures for the probe to be
-                        considered failed after having succeeded. Defaults to 3. Minimum
-                        value is 1.
+                      description: |-
+                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                        Defaults to 3. Minimum value is 1.
                       format: int32
                       type: integer
                     initialDelaySeconds:
-                      description: 'Number of seconds after the container has started
-                      before liveness probes are initiated. Defaults to 0 seconds.
-                      Minimum value is 0. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      description: |-
+                        Number of seconds after the container has started before liveness probes are initiated.
+                        Defaults to 0 seconds. Minimum value is 0.
+                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                       format: int32
                       type: integer
                     periodSeconds:
-                      description: How often (in seconds) to perform the probe. Default
-                        to 10 seconds. Minimum value is 1.
+                      description: |-
+                        How often (in seconds) to perform the probe.
+                        Default to 10 seconds. Minimum value is 1.
                       format: int32
                       type: integer
                     successThreshold:
-                      description: Minimum consecutive successes for the probe to be
-                        considered successful after having failed. Defaults to 1. Must
-                        be 1 for liveness and startup. Minimum value is 1.
+                      description: |-
+                        Minimum consecutive successes for the probe to be considered successful after having failed.
+                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                       format: int32
                       type: integer
                     terminationGracePeriodSeconds:
-                      description: Optional duration in seconds the pod needs to terminate
-                        gracefully upon probe failure. The grace period is the duration
-                        in seconds after the processes running in the pod are sent a
-                        termination signal and the time when the processes are forcibly
-                        halted with a kill signal. Set this value longer than the expected
-                        cleanup time for your process. If this value is nil, the pod's
-                        terminationGracePeriodSeconds will be used. Otherwise, this
-                        value overrides the value provided by the pod spec. Value must
-                        be non-negative integer. The value zero indicates stop immediately
-                        via the kill signal (no opportunity to shut down). This is a
-                        beta field and requires enabling ProbeTerminationGracePeriod
-                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
-                        is used if unset.
+                      description: |-
+                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                        The grace period is the duration in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly halted with a kill signal.
+                        Set this value longer than the expected cleanup time for your process.
+                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                        value overrides the value provided by the pod spec.
+                        Value must be non-negative integer. The value zero indicates stop immediately via
+                        the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                       format: int64
                       type: integer
                     timeoutSeconds:
-                      description: 'Number of seconds after which the probe times out.
-                      Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      description: |-
+                        Number of seconds after which the probe times out.
+                        Defaults to 1 second. Minimum value is 1.
+                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                       format: int32
                       type: integer
                   type: object
                 managementState:
                   default: managed
-                  description: ManagementState defines if the CR should be managed by
-                    the operator or not. Default is managed.
+                  description: |-
+                    ManagementState defines if the CR should be managed by the operator or not.
+                    Default is managed.
                   enum:
                     - managed
                     - unmanaged
                   type: string
                 maxReplicas:
-                  description: 'MaxReplicas sets an upper bound to the autoscaling feature.
-                  If MaxReplicas is set autoscaling is enabled. Deprecated: use "AmazonCloudWatchAgent.Spec.Autoscaler.MaxReplicas"
-                  instead.'
+                  description: |-
+                    MaxReplicas sets an upper bound to the autoscaling feature. If MaxReplicas is set autoscaling is enabled.
+                    Deprecated: use "AmazonCloudWatchAgent.Spec.Autoscaler.MaxReplicas" instead.
                   format: int32
                   type: integer
                 minReplicas:
-                  description: 'MinReplicas sets a lower bound to the autoscaling feature.  Set
-                  this if you are using autoscaling. It must be at least 1 Deprecated:
-                  use "AmazonCloudWatchAgent.Spec.Autoscaler.MinReplicas" instead.'
+                  description: |-
+                    MinReplicas sets a lower bound to the autoscaling feature.  Set this if you are using autoscaling. It must be at least 1
+                    Deprecated: use "AmazonCloudWatchAgent.Spec.Autoscaler.MinReplicas" instead.
                   format: int32
                   type: integer
                 mode:
@@ -4519,9 +4485,9 @@ spec:
                 nodeSelector:
                   additionalProperties:
                     type: string
-                  description: NodeSelector to schedule OpenTelemetry Collector pods.
-                    This is only relevant to daemonset, statefulset, and deployment
-                    mode
+                  description: |-
+                    NodeSelector to schedule OpenTelemetry Collector pods.
+                    This is only relevant to daemonset, statefulset, and deployment mode
                   type: object
                 observability:
                   description: ObservabilitySpec defines how telemetry data gets handled.
@@ -4530,104 +4496,121 @@ spec:
                       description: Metrics defines the metrics configuration for operands.
                       properties:
                         enableMetrics:
-                          description: EnableMetrics specifies if ServiceMonitor or
-                            PodMonitor(for sidecar mode) should be created for the service
-                            managed by the OpenTelemetry Operator. The operator.observability.prometheus
-                            feature gate must be enabled to use this feature.
+                          description: |-
+                            EnableMetrics specifies if ServiceMonitor or PodMonitor(for sidecar mode) should be created for the service managed by the OpenTelemetry Operator.
+                            The operator.observability.prometheus feature gate must be enabled to use this feature.
                           type: boolean
                       type: object
                   type: object
+                otelConfig:
+                  description: Config is the raw YAML to be used as the collector's
+                    configuration. Refer to the OpenTelemetry Collector documentation
+                    for details.
+                  type: string
                 podAnnotations:
                   additionalProperties:
                     type: string
-                  description: PodAnnotations is the set of annotations that will be
-                    attached to Collector and Target Allocator pods.
+                  description: |-
+                    PodAnnotations is the set of annotations that will be attached to
+                    Collector and Target Allocator pods.
                   type: object
                 podDisruptionBudget:
-                  description: PodDisruptionBudget specifies the pod disruption budget
-                    configuration to use for the AmazonCloudWatchAgent workload.
+                  description: |-
+                    PodDisruptionBudget specifies the pod disruption budget configuration to use
+                    for the AmazonCloudWatchAgent workload.
                   properties:
                     maxUnavailable:
                       anyOf:
                         - type: integer
                         - type: string
-                      description: An eviction is allowed if at most "maxUnavailable"
-                        pods selected by "selector" are unavailable after the eviction,
-                        i.e. even in absence of the evicted pod. For example, one can
-                        prevent all voluntary evictions by specifying 0. This is a mutually
-                        exclusive setting with "minAvailable".
+                      description: |-
+                        An eviction is allowed if at most "maxUnavailable" pods selected by
+                        "selector" are unavailable after the eviction, i.e. even in absence of
+                        the evicted pod. For example, one can prevent all voluntary evictions
+                        by specifying 0. This is a mutually exclusive setting with "minAvailable".
                       x-kubernetes-int-or-string: true
                     minAvailable:
                       anyOf:
                         - type: integer
                         - type: string
-                      description: An eviction is allowed if at least "minAvailable"
-                        pods selected by "selector" will still be available after the
-                        eviction, i.e. even in the absence of the evicted pod.  So for
-                        example you can prevent all voluntary evictions by specifying
-                        "100%".
+                      description: |-
+                        An eviction is allowed if at least "minAvailable" pods selected by
+                        "selector" will still be available after the eviction, i.e. even in the
+                        absence of the evicted pod.  So for example you can prevent all voluntary
+                        evictions by specifying "100%".
                       x-kubernetes-int-or-string: true
                   type: object
                 podSecurityContext:
-                  description: "PodSecurityContext configures the pod security context
-                  for the opentelemetry-collector pod, when running as a deployment,
-                  daemonset, or statefulset. \n In sidecar mode, the amazon-cloudwatch-agent-operator
-                  will ignore this setting."
+                  description: |-
+                    PodSecurityContext configures the pod security context for the
+                    amazon-cloudwatch-agent pod, when running as a deployment, daemonset,
+                    or statefulset.
+                    
+                    
+                    In sidecar mode, the amazon-cloudwatch-agent-operator will ignore this setting.
                   properties:
                     fsGroup:
-                      description: "A special supplemental group that applies to all
-                      containers in a pod. Some volume types allow the Kubelet to
-                      change the ownership of that volume to be owned by the pod:
-                      \n 1. The owning GID will be the FSGroup 2. The setgid bit is
-                      set (new files created in the volume will be owned by FSGroup)
-                      3. The permission bits are OR'd with rw-rw---- \n If unset,
-                      the Kubelet will not modify the ownership and permissions of
-                      any volume. Note that this field cannot be set when spec.os.name
-                      is windows."
+                      description: |-
+                        A special supplemental group that applies to all containers in a pod.
+                        Some volume types allow the Kubelet to change the ownership of that volume
+                        to be owned by the pod:
+                        
+                        
+                        1. The owning GID will be the FSGroup
+                        2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                        3. The permission bits are OR'd with rw-rw----
+                        
+                        
+                        If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                        Note that this field cannot be set when spec.os.name is windows.
                       format: int64
                       type: integer
                     fsGroupChangePolicy:
-                      description: 'fsGroupChangePolicy defines behavior of changing
-                      ownership and permission of the volume before being exposed
-                      inside Pod. This field will only apply to volume types which
-                      support fsGroup based ownership(and permissions). It will have
-                      no effect on ephemeral volume types such as: secret, configmaps
-                      and emptydir. Valid values are "OnRootMismatch" and "Always".
-                      If not specified, "Always" is used. Note that this field cannot
-                      be set when spec.os.name is windows.'
+                      description: |-
+                        fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                        before being exposed inside Pod. This field will only apply to
+                        volume types which support fsGroup based ownership(and permissions).
+                        It will have no effect on ephemeral volume types such as: secret, configmaps
+                        and emptydir.
+                        Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                        Note that this field cannot be set when spec.os.name is windows.
                       type: string
                     runAsGroup:
-                      description: The GID to run the entrypoint of the container process.
-                        Uses runtime default if unset. May also be set in SecurityContext.  If
-                        set in both SecurityContext and PodSecurityContext, the value
-                        specified in SecurityContext takes precedence for that container.
+                      description: |-
+                        The GID to run the entrypoint of the container process.
+                        Uses runtime default if unset.
+                        May also be set in SecurityContext.  If set in both SecurityContext and
+                        PodSecurityContext, the value specified in SecurityContext takes precedence
+                        for that container.
                         Note that this field cannot be set when spec.os.name is windows.
                       format: int64
                       type: integer
                     runAsNonRoot:
-                      description: Indicates that the container must run as a non-root
-                        user. If true, the Kubelet will validate the image at runtime
-                        to ensure that it does not run as UID 0 (root) and fail to start
-                        the container if it does. If unset or false, no such validation
-                        will be performed. May also be set in SecurityContext.  If set
-                        in both SecurityContext and PodSecurityContext, the value specified
-                        in SecurityContext takes precedence.
+                      description: |-
+                        Indicates that the container must run as a non-root user.
+                        If true, the Kubelet will validate the image at runtime to ensure that it
+                        does not run as UID 0 (root) and fail to start the container if it does.
+                        If unset or false, no such validation will be performed.
+                        May also be set in SecurityContext.  If set in both SecurityContext and
+                        PodSecurityContext, the value specified in SecurityContext takes precedence.
                       type: boolean
                     runAsUser:
-                      description: The UID to run the entrypoint of the container process.
+                      description: |-
+                        The UID to run the entrypoint of the container process.
                         Defaults to user specified in image metadata if unspecified.
-                        May also be set in SecurityContext.  If set in both SecurityContext
-                        and PodSecurityContext, the value specified in SecurityContext
-                        takes precedence for that container. Note that this field cannot
-                        be set when spec.os.name is windows.
+                        May also be set in SecurityContext.  If set in both SecurityContext and
+                        PodSecurityContext, the value specified in SecurityContext takes precedence
+                        for that container.
+                        Note that this field cannot be set when spec.os.name is windows.
                       format: int64
                       type: integer
                     seLinuxOptions:
-                      description: The SELinux context to be applied to all containers.
-                        If unspecified, the container runtime will allocate a random
-                        SELinux context for each container.  May also be set in SecurityContext.  If
-                        set in both SecurityContext and PodSecurityContext, the value
-                        specified in SecurityContext takes precedence for that container.
+                      description: |-
+                        The SELinux context to be applied to all containers.
+                        If unspecified, the container runtime will allocate a random SELinux context for each
+                        container.  May also be set in SecurityContext.  If set in
+                        both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence for that container.
                         Note that this field cannot be set when spec.os.name is windows.
                       properties:
                         level:
@@ -4648,47 +4631,48 @@ spec:
                           type: string
                       type: object
                     seccompProfile:
-                      description: The seccomp options to use by the containers in this
-                        pod. Note that this field cannot be set when spec.os.name is
-                        windows.
+                      description: |-
+                        The seccomp options to use by the containers in this pod.
+                        Note that this field cannot be set when spec.os.name is windows.
                       properties:
                         localhostProfile:
-                          description: localhostProfile indicates a profile defined
-                            in a file on the node should be used. The profile must be
-                            preconfigured on the node to work. Must be a descending
-                            path, relative to the kubelet's configured seccomp profile
-                            location. Must be set if type is "Localhost". Must NOT be
-                            set for any other type.
+                          description: |-
+                            localhostProfile indicates a profile defined in a file on the node should be used.
+                            The profile must be preconfigured on the node to work.
+                            Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                            Must be set if type is "Localhost". Must NOT be set for any other type.
                           type: string
                         type:
-                          description: "type indicates which kind of seccomp profile
-                          will be applied. Valid options are: \n Localhost - a profile
-                          defined in a file on the node should be used. RuntimeDefault
-                          - the container runtime default profile should be used.
-                          Unconfined - no profile should be applied."
+                          description: |-
+                            type indicates which kind of seccomp profile will be applied.
+                            Valid options are:
+                            
+                            
+                            Localhost - a profile defined in a file on the node should be used.
+                            RuntimeDefault - the container runtime default profile should be used.
+                            Unconfined - no profile should be applied.
                           type: string
                       required:
                         - type
                       type: object
                     supplementalGroups:
-                      description: A list of groups applied to the first process run
-                        in each container, in addition to the container's primary GID,
-                        the fsGroup (if specified), and group memberships defined in
-                        the container image for the uid of the container process. If
-                        unspecified, no additional groups are added to any container.
-                        Note that group memberships defined in the container image for
-                        the uid of the container process are still effective, even if
-                        they are not included in this list. Note that this field cannot
-                        be set when spec.os.name is windows.
+                      description: |-
+                        A list of groups applied to the first process run in each container, in addition
+                        to the container's primary GID, the fsGroup (if specified), and group memberships
+                        defined in the container image for the uid of the container process. If unspecified,
+                        no additional groups are added to any container. Note that group memberships
+                        defined in the container image for the uid of the container process are still effective,
+                        even if they are not included in this list.
+                        Note that this field cannot be set when spec.os.name is windows.
                       items:
                         format: int64
                         type: integer
                       type: array
                     sysctls:
-                      description: Sysctls hold a list of namespaced sysctls used for
-                        the pod. Pods with unsupported sysctls (by the container runtime)
-                        might fail to launch. Note that this field cannot be set when
-                        spec.os.name is windows.
+                      description: |-
+                        Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                        sysctls (by the container runtime) might fail to launch.
+                        Note that this field cannot be set when spec.os.name is windows.
                       items:
                         description: Sysctl defines a kernel parameter to be set
                         properties:
@@ -4704,80 +4688,86 @@ spec:
                         type: object
                       type: array
                     windowsOptions:
-                      description: The Windows specific settings applied to all containers.
-                        If unspecified, the options within a container's SecurityContext
-                        will be used. If set in both SecurityContext and PodSecurityContext,
-                        the value specified in SecurityContext takes precedence. Note
-                        that this field cannot be set when spec.os.name is linux.
+                      description: |-
+                        The Windows specific settings applied to all containers.
+                        If unspecified, the options within a container's SecurityContext will be used.
+                        If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        Note that this field cannot be set when spec.os.name is linux.
                       properties:
                         gmsaCredentialSpec:
-                          description: GMSACredentialSpec is where the GMSA admission
-                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                            inlines the contents of the GMSA credential spec named by
-                            the GMSACredentialSpecName field.
+                          description: |-
+                            GMSACredentialSpec is where the GMSA admission webhook
+                            (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                            GMSA credential spec named by the GMSACredentialSpecName field.
                           type: string
                         gmsaCredentialSpecName:
                           description: GMSACredentialSpecName is the name of the GMSA
                             credential spec to use.
                           type: string
                         hostProcess:
-                          description: HostProcess determines if a container should
-                            be run as a 'Host Process' container. All of a Pod's containers
-                            must have the same effective HostProcess value (it is not
-                            allowed to have a mix of HostProcess containers and non-HostProcess
-                            containers). In addition, if HostProcess is true then HostNetwork
-                            must also be set to true.
+                          description: |-
+                            HostProcess determines if a container should be run as a 'Host Process' container.
+                            All of a Pod's containers must have the same effective HostProcess value
+                            (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                            In addition, if HostProcess is true then HostNetwork must also be set to true.
                           type: boolean
                         runAsUserName:
-                          description: The UserName in Windows to run the entrypoint
-                            of the container process. Defaults to the user specified
-                            in image metadata if unspecified. May also be set in PodSecurityContext.
-                            If set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
+                          description: |-
+                            The UserName in Windows to run the entrypoint of the container process.
+                            Defaults to the user specified in image metadata if unspecified.
+                            May also be set in PodSecurityContext. If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
                           type: string
                       type: object
                   type: object
                 ports:
-                  description: Ports allows a set of ports to be exposed by the underlying
-                    v1.Service. By default, the operator will attempt to infer the required
-                    ports by parsing the .Spec.Config property but this property can
-                    be used to open additional ports that can't be inferred by the operator,
-                    like for custom receivers.
+                  description: |-
+                    Ports allows a set of ports to be exposed by the underlying v1.Service. By default, the operator
+                    will attempt to infer the required ports by parsing the .Spec.Config property but this property can be
+                    used to open additional ports that can't be inferred by the operator, like for custom receivers.
                   items:
                     description: ServicePort contains information on service's port.
                     properties:
                       appProtocol:
-                        description: "The application protocol for this port. This is
-                        used as a hint for implementations to offer richer behavior
-                        for protocols that they understand. This field follows standard
-                        Kubernetes label syntax. Valid values are either: \n * Un-prefixed
-                        protocol names - reserved for IANA standard service names
-                        (as per RFC-6335 and https://www.iana.org/assignments/service-names).
-                        \n * Kubernetes-defined prefixed names: * 'kubernetes.io/h2c'
-                        - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
-                        * 'kubernetes.io/ws'  - WebSocket over cleartext as described
-                        in https://www.rfc-editor.org/rfc/rfc6455 * 'kubernetes.io/wss'
-                        - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
-                        \n * Other protocols should use implementation-defined prefixed
-                        names such as mycompany.com/my-custom-protocol."
+                        description: |-
+                          The application protocol for this port.
+                          This is used as a hint for implementations to offer richer behavior for protocols that they understand.
+                          This field follows standard Kubernetes label syntax.
+                          Valid values are either:
+                          
+                          
+                          * Un-prefixed protocol names - reserved for IANA standard service names (as per
+                          RFC-6335 and https://www.iana.org/assignments/service-names).
+                          
+                          
+                          * Kubernetes-defined prefixed names:
+                            * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
+                            * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
+                            * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
+                          
+                          
+                          * Other protocols should use implementation-defined prefixed names such as
+                          mycompany.com/my-custom-protocol.
                         type: string
                       name:
-                        description: The name of this port within the service. This
-                          must be a DNS_LABEL. All ports within a ServiceSpec must have
-                          unique names. When considering the endpoints for a Service,
-                          this must match the 'name' field in the EndpointPort. Optional
-                          if only one ServicePort is defined on this service.
+                        description: |-
+                          The name of this port within the service. This must be a DNS_LABEL.
+                          All ports within a ServiceSpec must have unique names. When considering
+                          the endpoints for a Service, this must match the 'name' field in the
+                          EndpointPort.
+                          Optional if only one ServicePort is defined on this service.
                         type: string
                       nodePort:
-                        description: 'The port on each node on which this service is
-                        exposed when type is NodePort or LoadBalancer.  Usually assigned
-                        by the system. If a value is specified, in-range, and not
-                        in use it will be used, otherwise the operation will fail.  If
-                        not specified, a port will be allocated if this Service requires
-                        one.  If this field is specified when creating a Service which
-                        does not need it, creation will fail. This field will be wiped
-                        when updating a Service to no longer need it (e.g. changing
-                        type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                        description: |-
+                          The port on each node on which this service is exposed when type is
+                          NodePort or LoadBalancer.  Usually assigned by the system. If a value is
+                          specified, in-range, and not in use it will be used, otherwise the
+                          operation will fail.  If not specified, a port will be allocated if this
+                          Service requires one.  If this field is specified when creating a
+                          Service which does not need it, creation will fail. This field will be
+                          wiped when updating a Service to no longer need it (e.g. changing type
+                          from NodePort to ClusterIP).
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
                         format: int32
                         type: integer
                       port:
@@ -4786,21 +4776,23 @@ spec:
                         type: integer
                       protocol:
                         default: TCP
-                        description: The IP protocol for this port. Supports "TCP",
-                          "UDP", and "SCTP". Default is TCP.
+                        description: |-
+                          The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
+                          Default is TCP.
                         type: string
                       targetPort:
                         anyOf:
                           - type: integer
                           - type: string
-                        description: 'Number or name of the port to access on the pods
-                        targeted by the service. Number must be in the range 1 to
-                        65535. Name must be an IANA_SVC_NAME. If this is a string,
-                        it will be looked up as a named port in the target Pod''s
-                        container ports. If this is not specified, the value of the
-                        ''port'' field is used (an identity map). This field is ignored
-                        for services with clusterIP=None, and should be omitted or
-                        set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                        description: |-
+                          Number or name of the port to access on the pods targeted by the service.
+                          Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                          If this is a string, it will be looked up as a named port in the
+                          target Pod's container ports. If this is not specified, the value
+                          of the 'port' field is used (an identity map).
+                          This field is ignored for services with clusterIP=None, and should be
+                          omitted or set equal to the 'port' field.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
                         x-kubernetes-int-or-string: true
                     required:
                       - port
@@ -4808,8 +4800,10 @@ spec:
                   type: array
                   x-kubernetes-list-type: atomic
                 priorityClassName:
-                  description: If specified, indicates the pod's priority. If not specified,
-                    the pod priority will be default or zero if there is no default.
+                  description: |-
+                    If specified, indicates the pod's priority.
+                    If not specified, the pod priority will be default or zero if there is no
+                    default.
                   type: string
                 replicas:
                   description: Replicas is the number of pod instances for the underlying
@@ -4820,18 +4814,24 @@ spec:
                   description: Resources to set on the OpenTelemetry Collector pods.
                   properties:
                     claims:
-                      description: "Claims lists the names of resources, defined in
-                      spec.resourceClaims, that are used by this container. \n This
-                      is an alpha field and requires enabling the DynamicResourceAllocation
-                      feature gate. \n This field is immutable. It can only be set
-                      for containers."
+                      description: |-
+                        Claims lists the names of resources, defined in spec.resourceClaims,
+                        that are used by this container.
+                        
+                        
+                        This is an alpha field and requires enabling the
+                        DynamicResourceAllocation feature gate.
+                        
+                        
+                        This field is immutable. It can only be set for containers.
                       items:
                         description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                         properties:
                           name:
-                            description: Name must match the name of one entry in pod.spec.resourceClaims
-                              of the Pod where this field is used. It makes that resource
-                              available inside a container.
+                            description: |-
+                              Name must match the name of one entry in pod.spec.resourceClaims of
+                              the Pod where this field is used. It makes that resource available
+                              inside a container.
                             type: string
                         required:
                           - name
@@ -4847,8 +4847,9 @@ spec:
                           - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute resources
-                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      description: |-
+                        Limits describes the maximum amount of compute resources allowed.
+                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                       type: object
                     requests:
                       additionalProperties:
@@ -4857,33 +4858,42 @@ spec:
                           - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute
-                      resources required. If Requests is omitted for a container,
-                      it defaults to Limits if that is explicitly specified, otherwise
-                      to an implementation-defined value. Requests cannot exceed Limits.
-                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      description: |-
+                        Requests describes the minimum amount of compute resources required.
+                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                       type: object
                   type: object
                 securityContext:
-                  description: "SecurityContext configures the container security context
-                  for the opentelemetry-collector container. \n In deployment, daemonset,
-                  or statefulset mode, this controls the security context settings
-                  for the primary application container. \n In sidecar mode, this
-                  controls the security context for the injected sidecar container."
+                  description: |-
+                    SecurityContext configures the container security context for
+                    the amazon-cloudwatch-agent container.
+                    
+                    
+                    In deployment, daemonset, or statefulset mode, this controls
+                    the security context settings for the primary application
+                    container.
+                    
+                    
+                    In sidecar mode, this controls the security context for the
+                    injected sidecar container.
                   properties:
                     allowPrivilegeEscalation:
-                      description: 'AllowPrivilegeEscalation controls whether a process
-                      can gain more privileges than its parent process. This bool
-                      directly controls if the no_new_privs flag will be set on the
-                      container process. AllowPrivilegeEscalation is true always when
-                      the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
-                      Note that this field cannot be set when spec.os.name is windows.'
+                      description: |-
+                        AllowPrivilegeEscalation controls whether a process can gain more
+                        privileges than its parent process. This bool directly controls if
+                        the no_new_privs flag will be set on the container process.
+                        AllowPrivilegeEscalation is true always when the container is:
+                        1) run as Privileged
+                        2) has CAP_SYS_ADMIN
+                        Note that this field cannot be set when spec.os.name is windows.
                       type: boolean
                     capabilities:
-                      description: The capabilities to add/drop when running containers.
-                        Defaults to the default set of capabilities granted by the container
-                        runtime. Note that this field cannot be set when spec.os.name
-                        is windows.
+                      description: |-
+                        The capabilities to add/drop when running containers.
+                        Defaults to the default set of capabilities granted by the container runtime.
+                        Note that this field cannot be set when spec.os.name is windows.
                       properties:
                         add:
                           description: Added capabilities
@@ -4899,56 +4909,60 @@ spec:
                           type: array
                       type: object
                     privileged:
-                      description: Run container in privileged mode. Processes in privileged
-                        containers are essentially equivalent to root on the host. Defaults
-                        to false. Note that this field cannot be set when spec.os.name
-                        is windows.
+                      description: |-
+                        Run container in privileged mode.
+                        Processes in privileged containers are essentially equivalent to root on the host.
+                        Defaults to false.
+                        Note that this field cannot be set when spec.os.name is windows.
                       type: boolean
                     procMount:
-                      description: procMount denotes the type of proc mount to use for
-                        the containers. The default is DefaultProcMount which uses the
-                        container runtime defaults for readonly paths and masked paths.
+                      description: |-
+                        procMount denotes the type of proc mount to use for the containers.
+                        The default is DefaultProcMount which uses the container runtime defaults for
+                        readonly paths and masked paths.
                         This requires the ProcMountType feature flag to be enabled.
                         Note that this field cannot be set when spec.os.name is windows.
                       type: string
                     readOnlyRootFilesystem:
-                      description: Whether this container has a read-only root filesystem.
-                        Default is false. Note that this field cannot be set when spec.os.name
-                        is windows.
+                      description: |-
+                        Whether this container has a read-only root filesystem.
+                        Default is false.
+                        Note that this field cannot be set when spec.os.name is windows.
                       type: boolean
                     runAsGroup:
-                      description: The GID to run the entrypoint of the container process.
-                        Uses runtime default if unset. May also be set in PodSecurityContext.  If
-                        set in both SecurityContext and PodSecurityContext, the value
-                        specified in SecurityContext takes precedence. Note that this
-                        field cannot be set when spec.os.name is windows.
+                      description: |-
+                        The GID to run the entrypoint of the container process.
+                        Uses runtime default if unset.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        Note that this field cannot be set when spec.os.name is windows.
                       format: int64
                       type: integer
                     runAsNonRoot:
-                      description: Indicates that the container must run as a non-root
-                        user. If true, the Kubelet will validate the image at runtime
-                        to ensure that it does not run as UID 0 (root) and fail to start
-                        the container if it does. If unset or false, no such validation
-                        will be performed. May also be set in PodSecurityContext.  If
-                        set in both SecurityContext and PodSecurityContext, the value
-                        specified in SecurityContext takes precedence.
+                      description: |-
+                        Indicates that the container must run as a non-root user.
+                        If true, the Kubelet will validate the image at runtime to ensure that it
+                        does not run as UID 0 (root) and fail to start the container if it does.
+                        If unset or false, no such validation will be performed.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                        PodSecurityContext, the value specified in SecurityContext takes precedence.
                       type: boolean
                     runAsUser:
-                      description: The UID to run the entrypoint of the container process.
+                      description: |-
+                        The UID to run the entrypoint of the container process.
                         Defaults to user specified in image metadata if unspecified.
-                        May also be set in PodSecurityContext.  If set in both SecurityContext
-                        and PodSecurityContext, the value specified in SecurityContext
-                        takes precedence. Note that this field cannot be set when spec.os.name
-                        is windows.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        Note that this field cannot be set when spec.os.name is windows.
                       format: int64
                       type: integer
                     seLinuxOptions:
-                      description: The SELinux context to be applied to the container.
-                        If unspecified, the container runtime will allocate a random
-                        SELinux context for each container.  May also be set in PodSecurityContext.  If
-                        set in both SecurityContext and PodSecurityContext, the value
-                        specified in SecurityContext takes precedence. Note that this
-                        field cannot be set when spec.os.name is windows.
+                      description: |-
+                        The SELinux context to be applied to the container.
+                        If unspecified, the container runtime will allocate a random SELinux context for each
+                        container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        Note that this field cannot be set when spec.os.name is windows.
                       properties:
                         level:
                           description: Level is SELinux level label that applies to
@@ -4968,67 +4982,69 @@ spec:
                           type: string
                       type: object
                     seccompProfile:
-                      description: The seccomp options to use by this container. If
-                        seccomp options are provided at both the pod & container level,
-                        the container options override the pod options. Note that this
-                        field cannot be set when spec.os.name is windows.
+                      description: |-
+                        The seccomp options to use by this container. If seccomp options are
+                        provided at both the pod & container level, the container options
+                        override the pod options.
+                        Note that this field cannot be set when spec.os.name is windows.
                       properties:
                         localhostProfile:
-                          description: localhostProfile indicates a profile defined
-                            in a file on the node should be used. The profile must be
-                            preconfigured on the node to work. Must be a descending
-                            path, relative to the kubelet's configured seccomp profile
-                            location. Must be set if type is "Localhost". Must NOT be
-                            set for any other type.
+                          description: |-
+                            localhostProfile indicates a profile defined in a file on the node should be used.
+                            The profile must be preconfigured on the node to work.
+                            Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                            Must be set if type is "Localhost". Must NOT be set for any other type.
                           type: string
                         type:
-                          description: "type indicates which kind of seccomp profile
-                          will be applied. Valid options are: \n Localhost - a profile
-                          defined in a file on the node should be used. RuntimeDefault
-                          - the container runtime default profile should be used.
-                          Unconfined - no profile should be applied."
+                          description: |-
+                            type indicates which kind of seccomp profile will be applied.
+                            Valid options are:
+                            
+                            
+                            Localhost - a profile defined in a file on the node should be used.
+                            RuntimeDefault - the container runtime default profile should be used.
+                            Unconfined - no profile should be applied.
                           type: string
                       required:
                         - type
                       type: object
                     windowsOptions:
-                      description: The Windows specific settings applied to all containers.
-                        If unspecified, the options from the PodSecurityContext will
-                        be used. If set in both SecurityContext and PodSecurityContext,
-                        the value specified in SecurityContext takes precedence. Note
-                        that this field cannot be set when spec.os.name is linux.
+                      description: |-
+                        The Windows specific settings applied to all containers.
+                        If unspecified, the options from the PodSecurityContext will be used.
+                        If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        Note that this field cannot be set when spec.os.name is linux.
                       properties:
                         gmsaCredentialSpec:
-                          description: GMSACredentialSpec is where the GMSA admission
-                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                            inlines the contents of the GMSA credential spec named by
-                            the GMSACredentialSpecName field.
+                          description: |-
+                            GMSACredentialSpec is where the GMSA admission webhook
+                            (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                            GMSA credential spec named by the GMSACredentialSpecName field.
                           type: string
                         gmsaCredentialSpecName:
                           description: GMSACredentialSpecName is the name of the GMSA
                             credential spec to use.
                           type: string
                         hostProcess:
-                          description: HostProcess determines if a container should
-                            be run as a 'Host Process' container. All of a Pod's containers
-                            must have the same effective HostProcess value (it is not
-                            allowed to have a mix of HostProcess containers and non-HostProcess
-                            containers). In addition, if HostProcess is true then HostNetwork
-                            must also be set to true.
+                          description: |-
+                            HostProcess determines if a container should be run as a 'Host Process' container.
+                            All of a Pod's containers must have the same effective HostProcess value
+                            (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                            In addition, if HostProcess is true then HostNetwork must also be set to true.
                           type: boolean
                         runAsUserName:
-                          description: The UserName in Windows to run the entrypoint
-                            of the container process. Defaults to the user specified
-                            in image metadata if unspecified. May also be set in PodSecurityContext.
-                            If set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
+                          description: |-
+                            The UserName in Windows to run the entrypoint of the container process.
+                            Defaults to the user specified in image metadata if unspecified.
+                            May also be set in PodSecurityContext. If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
                           type: string
                       type: object
                   type: object
                 serviceAccount:
-                  description: ServiceAccount indicates the name of an existing service
-                    account to use with this instance. When set, the operator will not
-                    automatically create a ServiceAccount for the collector.
+                  description: |-
+                    ServiceAccount indicates the name of an existing service account to use with this instance. When set,
+                    the operator will not automatically create a ServiceAccount for the collector.
                   type: string
                 terminationGracePeriodSeconds:
                   description: Duration in seconds the pod needs to terminate gracefully
@@ -5036,50 +5052,50 @@ spec:
                   format: int64
                   type: integer
                 tolerations:
-                  description: Toleration to schedule OpenTelemetry Collector pods.
-                    This is only relevant to daemonset, statefulset, and deployment
-                    mode
+                  description: |-
+                    Toleration to schedule OpenTelemetry Collector pods.
+                    This is only relevant to daemonset, statefulset, and deployment mode
                   items:
-                    description: The pod this Toleration is attached to tolerates any
-                      taint that matches the triple <key,value,effect> using the matching
-                      operator <operator>.
+                    description: |-
+                      The pod this Toleration is attached to tolerates any taint that matches
+                      the triple <key,value,effect> using the matching operator <operator>.
                     properties:
                       effect:
-                        description: Effect indicates the taint effect to match. Empty
-                          means match all taint effects. When specified, allowed values
-                          are NoSchedule, PreferNoSchedule and NoExecute.
+                        description: |-
+                          Effect indicates the taint effect to match. Empty means match all taint effects.
+                          When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                         type: string
                       key:
-                        description: Key is the taint key that the toleration applies
-                          to. Empty means match all taint keys. If the key is empty,
-                          operator must be Exists; this combination means to match all
-                          values and all keys.
+                        description: |-
+                          Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                          If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                         type: string
                       operator:
-                        description: Operator represents a key's relationship to the
-                          value. Valid operators are Exists and Equal. Defaults to Equal.
-                          Exists is equivalent to wildcard for value, so that a pod
-                          can tolerate all taints of a particular category.
+                        description: |-
+                          Operator represents a key's relationship to the value.
+                          Valid operators are Exists and Equal. Defaults to Equal.
+                          Exists is equivalent to wildcard for value, so that a pod can
+                          tolerate all taints of a particular category.
                         type: string
                       tolerationSeconds:
-                        description: TolerationSeconds represents the period of time
-                          the toleration (which must be of effect NoExecute, otherwise
-                          this field is ignored) tolerates the taint. By default, it
-                          is not set, which means tolerate the taint forever (do not
-                          evict). Zero and negative values will be treated as 0 (evict
-                          immediately) by the system.
+                        description: |-
+                          TolerationSeconds represents the period of time the toleration (which must be
+                          of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                          it is not set, which means tolerate the taint forever (do not evict). Zero and
+                          negative values will be treated as 0 (evict immediately) by the system.
                         format: int64
                         type: integer
                       value:
-                        description: Value is the taint value the toleration matches
-                          to. If the operator is Exists, the value should be empty,
-                          otherwise just a regular string.
+                        description: |-
+                          Value is the taint value the toleration matches to.
+                          If the operator is Exists, the value should be empty, otherwise just a regular string.
                         type: string
                     type: object
                   type: array
                 topologySpreadConstraints:
-                  description: TopologySpreadConstraints embedded kubernetes pod configuration
-                    option, controls how pods are spread across your cluster among failure-domains
+                  description: |-
+                    TopologySpreadConstraints embedded kubernetes pod configuration option,
+                    controls how pods are spread across your cluster among failure-domains
                     such as regions, zones, nodes, and other user-defined topology domains
                     https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
                     This is only relevant to statefulset, and deployment mode
@@ -5088,33 +5104,34 @@ spec:
                       pods among the given topology.
                     properties:
                       labelSelector:
-                        description: LabelSelector is used to find matching pods. Pods
-                          that match this label selector are counted to determine the
-                          number of pods in their corresponding topology domain.
+                        description: |-
+                          LabelSelector is used to find matching pods.
+                          Pods that match this label selector are counted to determine the number of pods
+                          in their corresponding topology domain.
                         properties:
                           matchExpressions:
                             description: matchExpressions is a list of label selector
                               requirements. The requirements are ANDed.
                             items:
-                              description: A label selector requirement is a selector
-                                that contains values, a key, and an operator that relates
-                                the key and values.
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
                               properties:
                                 key:
                                   description: key is the label key that the selector
                                     applies to.
                                   type: string
                                 operator:
-                                  description: operator represents a key's relationship
-                                    to a set of values. Valid operators are In, NotIn,
-                                    Exists and DoesNotExist.
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                   type: string
                                 values:
-                                  description: values is an array of string values.
-                                    If the operator is In or NotIn, the values array
-                                    must be non-empty. If the operator is Exists or
-                                    DoesNotExist, the values array must be empty. This
-                                    array is replaced during a strategic merge patch.
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
                                   items:
                                     type: string
                                   type: array
@@ -5126,126 +5143,134 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
-                            description: matchLabels is a map of {key,value} pairs.
-                              A single {key,value} in the matchLabels map is equivalent
-                              to an element of matchExpressions, whose key field is
-                              "key", the operator is "In", and the values array contains
-                              only "value". The requirements are ANDed.
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
                       matchLabelKeys:
-                        description: "MatchLabelKeys is a set of pod label keys to select
-                        the pods over which spreading will be calculated. The keys
-                        are used to lookup values from the incoming pod labels, those
-                        key-value labels are ANDed with labelSelector to select the
-                        group of existing pods over which spreading will be calculated
-                        for the incoming pod. The same key is forbidden to exist in
-                        both MatchLabelKeys and LabelSelector. MatchLabelKeys cannot
-                        be set when LabelSelector isn't set. Keys that don't exist
-                        in the incoming pod labels will be ignored. A null or empty
-                        list means only match against labelSelector. \n This is a
-                        beta field and requires the MatchLabelKeysInPodTopologySpread
-                        feature gate to be enabled (enabled by default)."
+                        description: |-
+                          MatchLabelKeys is a set of pod label keys to select the pods over which
+                          spreading will be calculated. The keys are used to lookup values from the
+                          incoming pod labels, those key-value labels are ANDed with labelSelector
+                          to select the group of existing pods over which spreading will be calculated
+                          for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                          MatchLabelKeys cannot be set when LabelSelector isn't set.
+                          Keys that don't exist in the incoming pod labels will
+                          be ignored. A null or empty list means only match against labelSelector.
+                          
+                          
+                          This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: atomic
                       maxSkew:
-                        description: 'MaxSkew describes the degree to which pods may
-                        be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
-                        it is the maximum permitted difference between the number
-                        of matching pods in the target topology and the global minimum.
-                        The global minimum is the minimum number of matching pods
-                        in an eligible domain or zero if the number of eligible domains
-                        is less than MinDomains. For example, in a 3-zone cluster,
-                        MaxSkew is set to 1, and pods with the same labelSelector
-                        spread as 2/2/1: In this case, the global minimum is 1. |
-                        zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew
-                        is 1, incoming pod can only be scheduled to zone3 to become
-                        2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1)
-                        on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming
-                        pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
-                        it is used to give higher precedence to topologies that satisfy
-                        it. It''s a required field. Default value is 1 and 0 is not
-                        allowed.'
+                        description: |-
+                          MaxSkew describes the degree to which pods may be unevenly distributed.
+                          When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                          between the number of matching pods in the target topology and the global minimum.
+                          The global minimum is the minimum number of matching pods in an eligible domain
+                          or zero if the number of eligible domains is less than MinDomains.
+                          For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                          labelSelector spread as 2/2/1:
+                          In this case, the global minimum is 1.
+                          | zone1 | zone2 | zone3 |
+                          |  P P  |  P P  |   P   |
+                          - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                          scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                          violate MaxSkew(1).
+                          - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                          When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                          to topologies that satisfy it.
+                          It's a required field. Default value is 1 and 0 is not allowed.
                         format: int32
                         type: integer
                       minDomains:
-                        description: "MinDomains indicates a minimum number of eligible
-                        domains. When the number of eligible domains with matching
-                        topology keys is less than minDomains, Pod Topology Spread
-                        treats \"global minimum\" as 0, and then the calculation of
-                        Skew is performed. And when the number of eligible domains
-                        with matching topology keys equals or greater than minDomains,
-                        this value has no effect on scheduling. As a result, when
-                        the number of eligible domains is less than minDomains, scheduler
-                        won't schedule more than maxSkew Pods to those domains. If
-                        value is nil, the constraint behaves as if MinDomains is equal
-                        to 1. Valid values are integers greater than 0. When value
-                        is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For
-                        example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains
-                        is set to 5 and pods with the same labelSelector spread as
-                        2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  |
-                        The number of domains is less than 5(MinDomains), so \"global
-                        minimum\" is treated as 0. In this situation, new pod with
-                        the same labelSelector cannot be scheduled, because computed
-                        skew will be 3(3 - 0) if new Pod is scheduled to any of the
-                        three zones, it will violate MaxSkew. \n This is a beta field
-                        and requires the MinDomainsInPodTopologySpread feature gate
-                        to be enabled (enabled by default)."
+                        description: |-
+                          MinDomains indicates a minimum number of eligible domains.
+                          When the number of eligible domains with matching topology keys is less than minDomains,
+                          Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                          And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                          this value has no effect on scheduling.
+                          As a result, when the number of eligible domains is less than minDomains,
+                          scheduler won't schedule more than maxSkew Pods to those domains.
+                          If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                          Valid values are integers greater than 0.
+                          When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+                          
+                          
+                          For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                          labelSelector spread as 2/2/2:
+                          | zone1 | zone2 | zone3 |
+                          |  P P  |  P P  |  P P  |
+                          The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                          In this situation, new pod with the same labelSelector cannot be scheduled,
+                          because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                          it will violate MaxSkew.
+                          
+                          
+                          This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).
                         format: int32
                         type: integer
                       nodeAffinityPolicy:
-                        description: "NodeAffinityPolicy indicates how we will treat
-                        Pod's nodeAffinity/nodeSelector when calculating pod topology
-                        spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector
-                        are included in the calculations. - Ignore: nodeAffinity/nodeSelector
-                        are ignored. All nodes are included in the calculations. \n
-                        If this value is nil, the behavior is equivalent to the Honor
-                        policy. This is a beta-level feature default enabled by the
-                        NodeInclusionPolicyInPodTopologySpread feature flag."
+                        description: |-
+                          NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                          when calculating pod topology spread skew. Options are:
+                          - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                          - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+                          
+                          
+                          If this value is nil, the behavior is equivalent to the Honor policy.
+                          This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                         type: string
                       nodeTaintsPolicy:
-                        description: "NodeTaintsPolicy indicates how we will treat node
-                        taints when calculating pod topology spread skew. Options
-                        are: - Honor: nodes without taints, along with tainted nodes
-                        for which the incoming pod has a toleration, are included.
-                        - Ignore: node taints are ignored. All nodes are included.
-                        \n If this value is nil, the behavior is equivalent to the
-                        Ignore policy. This is a beta-level feature default enabled
-                        by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                        description: |-
+                          NodeTaintsPolicy indicates how we will treat node taints when calculating
+                          pod topology spread skew. Options are:
+                          - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                          has a toleration, are included.
+                          - Ignore: node taints are ignored. All nodes are included.
+                          
+                          
+                          If this value is nil, the behavior is equivalent to the Ignore policy.
+                          This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                         type: string
                       topologyKey:
-                        description: TopologyKey is the key of node labels. Nodes that
-                          have a label with this key and identical values are considered
-                          to be in the same topology. We consider each <key, value>
-                          as a "bucket", and try to put balanced number of pods into
-                          each bucket. We define a domain as a particular instance of
-                          a topology. Also, we define an eligible domain as a domain
-                          whose nodes meet the requirements of nodeAffinityPolicy and
-                          nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
-                          each Node is a domain of that topology. And, if TopologyKey
-                          is "topology.kubernetes.io/zone", each zone is a domain of
-                          that topology. It's a required field.
+                        description: |-
+                          TopologyKey is the key of node labels. Nodes that have a label with this key
+                          and identical values are considered to be in the same topology.
+                          We consider each <key, value> as a "bucket", and try to put balanced number
+                          of pods into each bucket.
+                          We define a domain as a particular instance of a topology.
+                          Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                          nodeAffinityPolicy and nodeTaintsPolicy.
+                          e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                          And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                          It's a required field.
                         type: string
                       whenUnsatisfiable:
-                        description: 'WhenUnsatisfiable indicates how to deal with a
-                        pod if it doesn''t satisfy the spread constraint. - DoNotSchedule
-                        (default) tells the scheduler not to schedule it. - ScheduleAnyway
-                        tells the scheduler to schedule the pod in any location, but
-                        giving higher precedence to topologies that would help reduce
-                        the skew. A constraint is considered "Unsatisfiable" for an
-                        incoming pod if and only if every possible node assignment
-                        for that pod would violate "MaxSkew" on some topology. For
-                        example, in a 3-zone cluster, MaxSkew is set to 1, and pods
-                        with the same labelSelector spread as 3/1/1: | zone1 | zone2
-                        | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is
-                        set to DoNotSchedule, incoming pod can only be scheduled to
-                        zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on
-                        zone2(zone3) satisfies MaxSkew(1). In other words, the cluster
-                        can still be imbalanced, but scheduler won''t make it *more*
-                        imbalanced. It''s a required field.'
+                        description: |-
+                          WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                          the spread constraint.
+                          - DoNotSchedule (default) tells the scheduler not to schedule it.
+                          - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                            but giving higher precedence to topologies that would help reduce the
+                            skew.
+                          A constraint is considered "Unsatisfiable" for an incoming pod
+                          if and only if every possible node assignment for that pod would violate
+                          "MaxSkew" on some topology.
+                          For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                          labelSelector spread as 3/1/1:
+                          | zone1 | zone2 | zone3 |
+                          | P P P |   P   |   P   |
+                          If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                          to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                          MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                          won't make it *more* imbalanced.
+                          It's a required field.
                         type: string
                     required:
                       - maxSkew
@@ -5254,61 +5279,62 @@ spec:
                     type: object
                   type: array
                 updateStrategy:
-                  description: UpdateStrategy represents the strategy the operator will
-                    take replacing existing DaemonSet pods with new pods https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/daemon-set-v1/#DaemonSetSpec
+                  description: |-
+                    UpdateStrategy represents the strategy the operator will take replacing existing DaemonSet pods with new pods
+                    https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/daemon-set-v1/#DaemonSetSpec
                     This is only applicable to Daemonset mode.
                   properties:
                     rollingUpdate:
-                      description: 'Rolling update config params. Present only if type
-                      = "RollingUpdate". --- TODO: Update this to follow our convention
-                      for oneOf, whatever we decide it to be. Same as Deployment `strategy.rollingUpdate`.
-                      See https://github.com/kubernetes/kubernetes/issues/35345'
+                      description: |-
+                        Rolling update config params. Present only if type = "RollingUpdate".
+                        ---
+                        TODO: Update this to follow our convention for oneOf, whatever we decide it
+                        to be. Same as Deployment `strategy.rollingUpdate`.
+                        See https://github.com/kubernetes/kubernetes/issues/35345
                       properties:
                         maxSurge:
                           anyOf:
                             - type: integer
                             - type: string
-                          description: 'The maximum number of nodes with an existing
-                          available DaemonSet pod that can have an updated DaemonSet
-                          pod during during an update. Value can be an absolute number
-                          (ex: 5) or a percentage of desired pods (ex: 10%). This
-                          can not be 0 if MaxUnavailable is 0. Absolute number is
-                          calculated from percentage by rounding up to a minimum of
-                          1. Default value is 0. Example: when this is set to 30%,
-                          at most 30% of the total number of nodes that should be
-                          running the daemon pod (i.e. status.desiredNumberScheduled)
-                          can have their a new pod created before the old pod is marked
-                          as deleted. The update starts by launching new pods on 30%
-                          of nodes. Once an updated pod is available (Ready for at
-                          least minReadySeconds) the old DaemonSet pod on that node
-                          is marked deleted. If the old pod becomes unavailable for
-                          any reason (Ready transitions to false, is evicted, or is
-                          drained) an updated pod is immediatedly created on that
-                          node without considering surge limits. Allowing surge implies
-                          the possibility that the resources consumed by the daemonset
-                          on any given node can double if the readiness check fails,
-                          and so resource intensive daemonsets should take into account
-                          that they may cause evictions during disruption.'
+                          description: |-
+                            The maximum number of nodes with an existing available DaemonSet pod that
+                            can have an updated DaemonSet pod during during an update.
+                            Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                            This can not be 0 if MaxUnavailable is 0.
+                            Absolute number is calculated from percentage by rounding up to a minimum of 1.
+                            Default value is 0.
+                            Example: when this is set to 30%, at most 30% of the total number of nodes
+                            that should be running the daemon pod (i.e. status.desiredNumberScheduled)
+                            can have their a new pod created before the old pod is marked as deleted.
+                            The update starts by launching new pods on 30% of nodes. Once an updated
+                            pod is available (Ready for at least minReadySeconds) the old DaemonSet pod
+                            on that node is marked deleted. If the old pod becomes unavailable for any
+                            reason (Ready transitions to false, is evicted, or is drained) an updated
+                            pod is immediatedly created on that node without considering surge limits.
+                            Allowing surge implies the possibility that the resources consumed by the
+                            daemonset on any given node can double if the readiness check fails, and
+                            so resource intensive daemonsets should take into account that they may
+                            cause evictions during disruption.
                           x-kubernetes-int-or-string: true
                         maxUnavailable:
                           anyOf:
                             - type: integer
                             - type: string
-                          description: 'The maximum number of DaemonSet pods that can
-                          be unavailable during the update. Value can be an absolute
-                          number (ex: 5) or a percentage of total number of DaemonSet
-                          pods at the start of the update (ex: 10%). Absolute number
-                          is calculated from percentage by rounding up. This cannot
-                          be 0 if MaxSurge is 0 Default value is 1. Example: when
-                          this is set to 30%, at most 30% of the total number of nodes
-                          that should be running the daemon pod (i.e. status.desiredNumberScheduled)
-                          can have their pods stopped for an update at any given time.
-                          The update starts by stopping at most 30% of those DaemonSet
-                          pods and then brings up new DaemonSet pods in their place.
-                          Once the new pods are available, it then proceeds onto other
-                          DaemonSet pods, thus ensuring that at least 70% of original
-                          number of DaemonSet pods are available at all times during
-                          the update.'
+                          description: |-
+                            The maximum number of DaemonSet pods that can be unavailable during the
+                            update. Value can be an absolute number (ex: 5) or a percentage of total
+                            number of DaemonSet pods at the start of the update (ex: 10%). Absolute
+                            number is calculated from percentage by rounding up.
+                            This cannot be 0 if MaxSurge is 0
+                            Default value is 1.
+                            Example: when this is set to 30%, at most 30% of the total number of nodes
+                            that should be running the daemon pod (i.e. status.desiredNumberScheduled)
+                            can have their pods stopped for an update at any given time. The update
+                            starts by stopping at most 30% of those DaemonSet pods and then brings
+                            up new DaemonSet pods in their place. Once the new pods are available,
+                            it then proceeds onto other DaemonSet pods, thus ensuring that at least
+                            70% of original number of DaemonSet pods are available at all times during
+                            the update.
                           x-kubernetes-int-or-string: true
                       type: object
                     type:
@@ -5331,19 +5357,24 @@ spec:
                       to a persistent volume
                     properties:
                       apiVersion:
-                        description: 'APIVersion defines the versioned schema of this
-                        representation of an object. Servers should convert recognized
-                        schemas to the latest internal value, and may reject unrecognized
-                        values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                        description: |-
+                          APIVersion defines the versioned schema of this representation of an object.
+                          Servers should convert recognized schemas to the latest internal value, and
+                          may reject unrecognized values.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
                         type: string
                       kind:
-                        description: 'Kind is a string value representing the REST resource
-                        this object represents. Servers may infer this from the endpoint
-                        the client submits requests to. Cannot be updated. In CamelCase.
-                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        description: |-
+                          Kind is a string value representing the REST resource this object represents.
+                          Servers may infer this from the endpoint the client submits requests to.
+                          Cannot be updated.
+                          In CamelCase.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                         type: string
                       metadata:
-                        description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                        description: |-
+                          Standard object's metadata.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                         properties:
                           annotations:
                             additionalProperties:
@@ -5363,33 +5394,33 @@ spec:
                             type: string
                         type: object
                       spec:
-                        description: 'spec defines the desired characteristics of a
-                        volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                        description: |-
+                          spec defines the desired characteristics of a volume requested by a pod author.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                         properties:
                           accessModes:
-                            description: 'accessModes contains the desired access modes
-                            the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                            description: |-
+                              accessModes contains the desired access modes the volume should have.
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                             items:
                               type: string
                             type: array
                           dataSource:
-                            description: 'dataSource field can be used to specify either:
-                            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                            * An existing PVC (PersistentVolumeClaim) If the provisioner
-                            or an external controller can support the specified data
-                            source, it will create a new volume based on the contents
-                            of the specified data source. When the AnyVolumeDataSource
-                            feature gate is enabled, dataSource contents will be copied
-                            to dataSourceRef, and dataSourceRef contents will be copied
-                            to dataSource when dataSourceRef.namespace is not specified.
-                            If the namespace is specified, then dataSourceRef will
-                            not be copied to dataSource.'
+                            description: |-
+                              dataSource field can be used to specify either:
+                              * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                              * An existing PVC (PersistentVolumeClaim)
+                              If the provisioner or an external controller can support the specified data source,
+                              it will create a new volume based on the contents of the specified data source.
+                              When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                              and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                              If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                             properties:
                               apiGroup:
-                                description: APIGroup is the group for the resource
-                                  being referenced. If APIGroup is not specified, the
-                                  specified Kind must be in the core API group. For
-                                  any other third-party types, APIGroup is required.
+                                description: |-
+                                  APIGroup is the group for the resource being referenced.
+                                  If APIGroup is not specified, the specified Kind must be in the core API group.
+                                  For any other third-party types, APIGroup is required.
                                 type: string
                               kind:
                                 description: Kind is the type of resource being referenced
@@ -5403,39 +5434,36 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           dataSourceRef:
-                            description: 'dataSourceRef specifies the object from which
-                            to populate the volume with data, if a non-empty volume
-                            is desired. This may be any object from a non-empty API
-                            group (non core object) or a PersistentVolumeClaim object.
-                            When this field is specified, volume binding will only
-                            succeed if the type of the specified object matches some
-                            installed volume populator or dynamic provisioner. This
-                            field will replace the functionality of the dataSource
-                            field and as such if both fields are non-empty, they must
-                            have the same value. For backwards compatibility, when
-                            namespace isn''t specified in dataSourceRef, both fields
-                            (dataSource and dataSourceRef) will be set to the same
-                            value automatically if one of them is empty and the other
-                            is non-empty. When namespace is specified in dataSourceRef,
-                            dataSource isn''t set to the same value and must be empty.
-                            There are three important differences between dataSource
-                            and dataSourceRef: * While dataSource only allows two
-                            specific types of objects, dataSourceRef allows any non-core
-                            object, as well as PersistentVolumeClaim objects. * While
-                            dataSource ignores disallowed values (dropping them),
-                            dataSourceRef preserves all values, and generates an error
-                            if a disallowed value is specified. * While dataSource
-                            only allows local objects, dataSourceRef allows objects
-                            in any namespaces. (Beta) Using this field requires the
-                            AnyVolumeDataSource feature gate to be enabled. (Alpha)
-                            Using the namespace field of dataSourceRef requires the
-                            CrossNamespaceVolumeDataSource feature gate to be enabled.'
+                            description: |-
+                              dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                              volume is desired. This may be any object from a non-empty API group (non
+                              core object) or a PersistentVolumeClaim object.
+                              When this field is specified, volume binding will only succeed if the type of
+                              the specified object matches some installed volume populator or dynamic
+                              provisioner.
+                              This field will replace the functionality of the dataSource field and as such
+                              if both fields are non-empty, they must have the same value. For backwards
+                              compatibility, when namespace isn't specified in dataSourceRef,
+                              both fields (dataSource and dataSourceRef) will be set to the same
+                              value automatically if one of them is empty and the other is non-empty.
+                              When namespace is specified in dataSourceRef,
+                              dataSource isn't set to the same value and must be empty.
+                              There are three important differences between dataSource and dataSourceRef:
+                              * While dataSource only allows two specific types of objects, dataSourceRef
+                                allows any non-core object, as well as PersistentVolumeClaim objects.
+                              * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                preserves all values, and generates an error if a disallowed value is
+                                specified.
+                              * While dataSource only allows local objects, dataSourceRef allows objects
+                                in any namespaces.
+                              (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                              (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                             properties:
                               apiGroup:
-                                description: APIGroup is the group for the resource
-                                  being referenced. If APIGroup is not specified, the
-                                  specified Kind must be in the core API group. For
-                                  any other third-party types, APIGroup is required.
+                                description: |-
+                                  APIGroup is the group for the resource being referenced.
+                                  If APIGroup is not specified, the specified Kind must be in the core API group.
+                                  For any other third-party types, APIGroup is required.
                                 type: string
                               kind:
                                 description: Kind is the type of resource being referenced
@@ -5444,26 +5472,22 @@ spec:
                                 description: Name is the name of resource being referenced
                                 type: string
                               namespace:
-                                description: Namespace is the namespace of resource
-                                  being referenced Note that when a namespace is specified,
-                                  a gateway.networking.k8s.io/ReferenceGrant object
-                                  is required in the referent namespace to allow that
-                                  namespace's owner to accept the reference. See the
-                                  ReferenceGrant documentation for details. (Alpha)
-                                  This field requires the CrossNamespaceVolumeDataSource
-                                  feature gate to be enabled.
+                                description: |-
+                                  Namespace is the namespace of resource being referenced
+                                  Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                  (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                 type: string
                             required:
                               - kind
                               - name
                             type: object
                           resources:
-                            description: 'resources represents the minimum resources
-                            the volume should have. If RecoverVolumeExpansionFailure
-                            feature is enabled users are allowed to specify resource
-                            requirements that are lower than previous value but must
-                            still be higher than capacity recorded in the status field
-                            of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                            description: |-
+                              resources represents the minimum resources the volume should have.
+                              If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                              that are lower than previous value but must still be higher than capacity recorded in the
+                              status field of the claim.
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                             properties:
                               limits:
                                 additionalProperties:
@@ -5472,8 +5496,9 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Limits describes the maximum amount of
-                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                               requests:
                                 additionalProperties:
@@ -5482,11 +5507,11 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Requests describes the minimum amount
-                                of compute resources required. If Requests is omitted
-                                for a container, it defaults to Limits if that is
-                                explicitly specified, otherwise to an implementation-defined
-                                value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                description: |-
+                                  Requests describes the minimum amount of compute resources required.
+                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                             type: object
                           selector:
@@ -5497,8 +5522,8 @@ spec:
                                 description: matchExpressions is a list of label selector
                                   requirements. The requirements are ANDed.
                                 items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
                                     relates the key and values.
                                   properties:
                                     key:
@@ -5506,17 +5531,16 @@ spec:
                                         applies to.
                                       type: string
                                     operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists and DoesNotExist.
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                       type: string
                                     values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists
-                                        or DoesNotExist, the values array must be empty.
-                                        This array is replaced during a strategic merge
-                                        patch.
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
                                       items:
                                         type: string
                                       type: array
@@ -5528,41 +5552,37 @@ spec:
                               matchLabels:
                                 additionalProperties:
                                   type: string
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field
-                                  is "key", the operator is "In", and the values array
-                                  contains only "value". The requirements are ANDed.
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                 type: object
                             type: object
                             x-kubernetes-map-type: atomic
                           storageClassName:
-                            description: 'storageClassName is the name of the StorageClass
-                            required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                            description: |-
+                              storageClassName is the name of the StorageClass required by the claim.
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                             type: string
                           volumeAttributesClassName:
-                            description: 'volumeAttributesClassName may be used to set
-                            the VolumeAttributesClass used by this claim. If specified,
-                            the CSI driver will create or update the volume with the
-                            attributes defined in the corresponding VolumeAttributesClass.
-                            This has a different purpose than storageClassName, it
-                            can be changed after the claim is created. An empty string
-                            value means that no VolumeAttributesClass will be applied
-                            to the claim but it''s not allowed to reset this field
-                            to empty string once it is set. If unspecified and the
-                            PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                            will be set by the persistentvolume controller if it exists.
-                            If the resource referred to by volumeAttributesClass does
-                            not exist, this PersistentVolumeClaim will be set to a
-                            Pending state, as reflected by the modifyVolumeStatus
-                            field, until such as a resource exists. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                            (Alpha) Using this field requires the VolumeAttributesClass
-                            feature gate to be enabled.'
+                            description: |-
+                              volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                              If specified, the CSI driver will create or update the volume with the attributes defined
+                              in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                              it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                              will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                              If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                              will be set by the persistentvolume controller if it exists.
+                              If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                              set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                              exists.
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                              (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
                             type: string
                           volumeMode:
-                            description: volumeMode defines what type of volume is required
-                              by the claim. Value of Filesystem is implied when not
-                              included in claim spec.
+                            description: |-
+                              volumeMode defines what type of volume is required by the claim.
+                              Value of Filesystem is implied when not included in claim spec.
                             type: string
                           volumeName:
                             description: volumeName is the binding reference to the
@@ -5570,56 +5590,59 @@ spec:
                             type: string
                         type: object
                       status:
-                        description: 'status represents the current information/status
-                        of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                        description: |-
+                          status represents the current information/status of a persistent volume claim.
+                          Read-only.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                         properties:
                           accessModes:
-                            description: 'accessModes contains the actual access modes
-                            the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                            description: |-
+                              accessModes contains the actual access modes the volume backing the PVC has.
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                             items:
                               type: string
                             type: array
                           allocatedResourceStatuses:
                             additionalProperties:
-                              description: When a controller receives persistentvolume
-                                claim update with ClaimResourceStatus for a resource
-                                that it does not recognizes, then it should ignore that
-                                update and let other controllers handle it.
+                              description: |-
+                                When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource
+                                that it does not recognizes, then it should ignore that update and let other controllers
+                                handle it.
                               type: string
                             description: "allocatedResourceStatuses stores status of
-                            resource being resized for the given PVC. Key names follow
-                            standard Kubernetes label syntax. Valid values are either:
-                            * Un-prefixed keys: - storage - the capacity of the volume.
-                            * Custom resources must use implementation-defined prefixed
-                            names such as \"example.com/my-custom-resource\" Apart
+                            resource being resized for the given PVC.\nKey names follow
+                            standard Kubernetes label syntax. Valid values are either:\n\t*
+                            Un-prefixed keys:\n\t\t- storage - the capacity of the
+                            volume.\n\t* Custom resources must use implementation-defined
+                            prefixed names such as \"example.com/my-custom-resource\"\nApart
                             from above values - keys that are unprefixed or have kubernetes.io
-                            prefix are considered reserved and hence may not be used.
-                            \n ClaimResourceStatus can be in any of following states:
-                            - ControllerResizeInProgress: State set when resize controller
-                            starts resizing the volume in control-plane. - ControllerResizeFailed:
-                            State set when resize has failed in resize controller
-                            with a terminal error. - NodeResizePending: State set
+                            prefix are considered\nreserved and hence may not be used.\n\n\nClaimResourceStatus
+                            can be in any of following states:\n\t- ControllerResizeInProgress:\n\t\tState
+                            set when resize controller starts resizing the volume
+                            in control-plane.\n\t- ControllerResizeFailed:\n\t\tState
+                            set when resize has failed in resize controller with a
+                            terminal error.\n\t- NodeResizePending:\n\t\tState set
                             when resize controller has finished resizing the volume
-                            but further resizing of volume is needed on the node.
-                            - NodeResizeInProgress: State set when kubelet starts
-                            resizing the volume. - NodeResizeFailed: State set when
-                            resizing has failed in kubelet with a terminal error.
-                            Transient errors don't set NodeResizeFailed. For example:
-                            if expanding a PVC for more capacity - this field can
-                            be one of the following states: - pvc.status.allocatedResourceStatus['storage']
-                            = \"ControllerResizeInProgress\" - pvc.status.allocatedResourceStatus['storage']
-                            = \"ControllerResizeFailed\" - pvc.status.allocatedResourceStatus['storage']
-                            = \"NodeResizePending\" - pvc.status.allocatedResourceStatus['storage']
-                            = \"NodeResizeInProgress\" - pvc.status.allocatedResourceStatus['storage']
-                            = \"NodeResizeFailed\" When this field is not set, it
+                            but further resizing of\n\t\tvolume is needed on the node.\n\t-
+                            NodeResizeInProgress:\n\t\tState set when kubelet starts
+                            resizing the volume.\n\t- NodeResizeFailed:\n\t\tState
+                            set when resizing has failed in kubelet with a terminal
+                            error. Transient errors don't set\n\t\tNodeResizeFailed.\nFor
+                            example: if expanding a PVC for more capacity - this field
+                            can be one of the following states:\n\t- pvc.status.allocatedResourceStatus['storage']
+                            = \"ControllerResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage']
+                            = \"ControllerResizeFailed\"\n     - pvc.status.allocatedResourceStatus['storage']
+                            = \"NodeResizePending\"\n     - pvc.status.allocatedResourceStatus['storage']
+                            = \"NodeResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage']
+                            = \"NodeResizeFailed\"\nWhen this field is not set, it
                             means that no resize operation is in progress for the
-                            given PVC. \n A controller that receives PVC update with
-                            previously unknown resourceName or ClaimResourceStatus
-                            should ignore the update for the purpose it was designed.
-                            For example - a controller that only is responsible for
-                            resizing capacity of the volume, should ignore PVC updates
-                            that change other valid resources associated with PVC.
-                            \n This is an alpha field and requires enabling RecoverVolumeExpansionFailure
+                            given PVC.\n\n\nA controller that receives PVC update
+                            with previously unknown resourceName or ClaimResourceStatus\nshould
+                            ignore the update for the purpose it was designed. For
+                            example - a controller that\nonly is responsible for resizing
+                            capacity of the volume, should ignore PVC updates that
+                            change other valid\nresources associated with PVC.\n\n\nThis
+                            is an alpha field and requires enabling RecoverVolumeExpansionFailure
                             feature."
                             type: object
                             x-kubernetes-map-type: granular
@@ -5631,29 +5654,29 @@ spec:
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                             description: "allocatedResources tracks the resources allocated
-                            to a PVC including its capacity. Key names follow standard
-                            Kubernetes label syntax. Valid values are either: * Un-prefixed
-                            keys: - storage - the capacity of the volume. * Custom
-                            resources must use implementation-defined prefixed names
-                            such as \"example.com/my-custom-resource\" Apart from
-                            above values - keys that are unprefixed or have kubernetes.io
-                            prefix are considered reserved and hence may not be used.
-                            \n Capacity reported here may be larger than the actual
-                            capacity when a volume expansion operation is requested.
-                            For storage quota, the larger value from allocatedResources
-                            and PVC.spec.resources is used. If allocatedResources
-                            is not set, PVC.spec.resources alone is used for quota
-                            calculation. If a volume expansion capacity request is
-                            lowered, allocatedResources is only lowered if there are
-                            no expansion operations in progress and if the actual
-                            volume capacity is equal or lower than the requested capacity.
-                            \n A controller that receives PVC update with previously
-                            unknown resourceName should ignore the update for the
-                            purpose it was designed. For example - a controller that
-                            only is responsible for resizing capacity of the volume,
-                            should ignore PVC updates that change other valid resources
-                            associated with PVC. \n This is an alpha field and requires
-                            enabling RecoverVolumeExpansionFailure feature."
+                            to a PVC including its capacity.\nKey names follow standard
+                            Kubernetes label syntax. Valid values are either:\n\t*
+                            Un-prefixed keys:\n\t\t- storage - the capacity of the
+                            volume.\n\t* Custom resources must use implementation-defined
+                            prefixed names such as \"example.com/my-custom-resource\"\nApart
+                            from above values - keys that are unprefixed or have kubernetes.io
+                            prefix are considered\nreserved and hence may not be used.\n\n\nCapacity
+                            reported here may be larger than the actual capacity when
+                            a volume expansion operation\nis requested.\nFor storage
+                            quota, the larger value from allocatedResources and PVC.spec.resources
+                            is used.\nIf allocatedResources is not set, PVC.spec.resources
+                            alone is used for quota calculation.\nIf a volume expansion
+                            capacity request is lowered, allocatedResources is only\nlowered
+                            if there are no expansion operations in progress and if
+                            the actual volume capacity\nis equal or lower than the
+                            requested capacity.\n\n\nA controller that receives PVC
+                            update with previously unknown resourceName\nshould ignore
+                            the update for the purpose it was designed. For example
+                            - a controller that\nonly is responsible for resizing
+                            capacity of the volume, should ignore PVC updates that
+                            change other valid\nresources associated with PVC.\n\n\nThis
+                            is an alpha field and requires enabling RecoverVolumeExpansionFailure
+                            feature."
                             type: object
                           capacity:
                             additionalProperties:
@@ -5666,8 +5689,8 @@ spec:
                               the underlying volume.
                             type: object
                           conditions:
-                            description: conditions is the current Condition of persistent
-                              volume claim. If underlying persistent volume is being
+                            description: |-
+                              conditions is the current Condition of persistent volume claim. If underlying persistent volume is being
                               resized then the Condition will be set to 'ResizeStarted'.
                             items:
                               description: PersistentVolumeClaimCondition contains details
@@ -5688,10 +5711,9 @@ spec:
                                     indicating details about last transition.
                                   type: string
                                 reason:
-                                  description: reason is a unique, this should be a
-                                    short, machine understandable string that gives
-                                    the reason for condition's last transition. If it
-                                    reports "ResizeStarted" that means the underlying
+                                  description: |-
+                                    reason is a unique, this should be a short, machine understandable string that gives the reason
+                                    for condition's last transition. If it reports "ResizeStarted" that means the underlying
                                     persistent volume is being resized.
                                   type: string
                                 status:
@@ -5706,32 +5728,30 @@ spec:
                               type: object
                             type: array
                           currentVolumeAttributesClassName:
-                            description: currentVolumeAttributesClassName is the current
-                              name of the VolumeAttributesClass the PVC is using. When
-                              unset, there is no VolumeAttributeClass applied to this
-                              PersistentVolumeClaim This is an alpha field and requires
-                              enabling VolumeAttributesClass feature.
+                            description: |-
+                              currentVolumeAttributesClassName is the current name of the VolumeAttributesClass the PVC is using.
+                              When unset, there is no VolumeAttributeClass applied to this PersistentVolumeClaim
+                              This is an alpha field and requires enabling VolumeAttributesClass feature.
                             type: string
                           modifyVolumeStatus:
-                            description: ModifyVolumeStatus represents the status object
-                              of ControllerModifyVolume operation. When this is unset,
-                              there is no ModifyVolume operation being attempted. This
-                              is an alpha field and requires enabling VolumeAttributesClass
-                              feature.
+                            description: |-
+                              ModifyVolumeStatus represents the status object of ControllerModifyVolume operation.
+                              When this is unset, there is no ModifyVolume operation being attempted.
+                              This is an alpha field and requires enabling VolumeAttributesClass feature.
                             properties:
                               status:
-                                description: 'status is the status of the ControllerModifyVolume
-                                operation. It can be in any of following states: -
-                                Pending Pending indicates that the PersistentVolumeClaim
+                                description: "status is the status of the ControllerModifyVolume
+                                operation. It can be in any of following states:\n
+                                - Pending\n   Pending indicates that the PersistentVolumeClaim
                                 cannot be modified due to unmet requirements, such
-                                as the specified VolumeAttributesClass not existing.
-                                - InProgress InProgress indicates that the volume
-                                is being modified. - Infeasible Infeasible indicates
+                                as\n   the specified VolumeAttributesClass not existing.\n
+                                - InProgress\n   InProgress indicates that the volume
+                                is being modified.\n - Infeasible\n  Infeasible indicates
                                 that the request has been rejected as invalid by the
-                                CSI driver. To resolve the error, a valid VolumeAttributesClass
-                                needs to be specified. Note: New statuses can be added
-                                in the future. Consumers should check for unknown
-                                statuses and fail appropriately.'
+                                CSI driver. To\n\t  resolve the error, a valid VolumeAttributesClass
+                                needs to be specified.\nNote: New statuses can be
+                                added in the future. Consumers should check for unknown
+                                statuses and fail appropriately."
                                 type: string
                               targetVolumeAttributesClassName:
                                 description: targetVolumeAttributesClassName is the
@@ -5756,32 +5776,36 @@ spec:
                       a container.
                     properties:
                       mountPath:
-                        description: Path within the container at which the volume should
-                          be mounted.  Must not contain ':'.
+                        description: |-
+                          Path within the container at which the volume should be mounted.  Must
+                          not contain ':'.
                         type: string
                       mountPropagation:
-                        description: mountPropagation determines how mounts are propagated
-                          from the host to container and the other way around. When
-                          not set, MountPropagationNone is used. This field is beta
-                          in 1.10.
+                        description: |-
+                          mountPropagation determines how mounts are propagated from the host
+                          to container and the other way around.
+                          When not set, MountPropagationNone is used.
+                          This field is beta in 1.10.
                         type: string
                       name:
                         description: This must match the Name of a Volume.
                         type: string
                       readOnly:
-                        description: Mounted read-only if true, read-write otherwise
-                          (false or unspecified). Defaults to false.
+                        description: |-
+                          Mounted read-only if true, read-write otherwise (false or unspecified).
+                          Defaults to false.
                         type: boolean
                       subPath:
-                        description: Path within the volume from which the container's
-                          volume should be mounted. Defaults to "" (volume's root).
+                        description: |-
+                          Path within the volume from which the container's volume should be mounted.
+                          Defaults to "" (volume's root).
                         type: string
                       subPathExpr:
-                        description: Expanded path within the volume from which the
-                          container's volume should be mounted. Behaves similarly to
-                          SubPath but environment variable references $(VAR_NAME) are
-                          expanded using the container's environment. Defaults to ""
-                          (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                        description: |-
+                          Expanded path within the volume from which the container's volume should be mounted.
+                          Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                          Defaults to "" (volume's root).
+                          SubPathExpr and SubPath are mutually exclusive.
                         type: string
                     required:
                       - mountPath
@@ -5797,34 +5821,36 @@ spec:
                       be accessed by any container in the pod.
                     properties:
                       awsElasticBlockStore:
-                        description: 'awsElasticBlockStore represents an AWS Disk resource
-                        that is attached to a kubelet''s host machine and then exposed
-                        to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                        description: |-
+                          awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                          kubelet's host machine and then exposed to the pod.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                         properties:
                           fsType:
-                            description: 'fsType is the filesystem type of the volume
-                            that you want to mount. Tip: Ensure that the filesystem
-                            type is supported by the host operating system. Examples:
-                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
+                            description: |-
+                              fsType is the filesystem type of the volume that you want to mount.
+                              Tip: Ensure that the filesystem type is supported by the host operating system.
+                              Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           partition:
-                            description: 'partition is the partition in the volume that
-                            you want to mount. If omitted, the default is to mount
-                            by volume name. Examples: For volume /dev/sda1, you specify
-                            the partition as "1". Similarly, the volume partition
-                            for /dev/sda is "0" (or you can leave the property empty).'
+                            description: |-
+                              partition is the partition in the volume that you want to mount.
+                              If omitted, the default is to mount by volume name.
+                              Examples: For volume /dev/sda1, you specify the partition as "1".
+                              Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                             format: int32
                             type: integer
                           readOnly:
-                            description: 'readOnly value true will force the readOnly
-                            setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                            description: |-
+                              readOnly value true will force the readOnly setting in VolumeMounts.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                             type: boolean
                           volumeID:
-                            description: 'volumeID is unique ID of the persistent disk
-                            resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                            description: |-
+                              volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                             type: string
                         required:
                           - volumeID
@@ -5846,10 +5872,10 @@ spec:
                               storage
                             type: string
                           fsType:
-                            description: fsType is Filesystem type to mount. Must be
-                              a filesystem type supported by the host operating system.
-                              Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                              if unspecified.
+                            description: |-
+                              fsType is Filesystem type to mount.
+                              Must be a filesystem type supported by the host operating system.
+                              Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                             type: string
                           kind:
                             description: 'kind expected values are Shared: multiple
@@ -5858,8 +5884,9 @@ spec:
                             disk (only in managed availability set). defaults to shared'
                             type: string
                           readOnly:
-                            description: readOnly Defaults to false (read/write). ReadOnly
-                              here will force the ReadOnly setting in VolumeMounts.
+                            description: |-
+                              readOnly Defaults to false (read/write). ReadOnly here will force
+                              the ReadOnly setting in VolumeMounts.
                             type: boolean
                         required:
                           - diskName
@@ -5870,8 +5897,9 @@ spec:
                           on the host and bind mount to the pod.
                         properties:
                           readOnly:
-                            description: readOnly defaults to false (read/write). ReadOnly
-                              here will force the ReadOnly setting in VolumeMounts.
+                            description: |-
+                              readOnly defaults to false (read/write). ReadOnly here will force
+                              the ReadOnly setting in VolumeMounts.
                             type: boolean
                           secretName:
                             description: secretName is the  name of secret that contains
@@ -5889,8 +5917,9 @@ spec:
                           shares a pod's lifetime
                         properties:
                           monitors:
-                            description: 'monitors is Required: Monitors is a collection
-                            of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                            description: |-
+                              monitors is Required: Monitors is a collection of Ceph monitors
+                              More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                             items:
                               type: string
                             type: array
@@ -5899,61 +5928,72 @@ spec:
                             rather than the full Ceph tree, default is /'
                             type: string
                           readOnly:
-                            description: 'readOnly is Optional: Defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                            description: |-
+                              readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                              the ReadOnly setting in VolumeMounts.
+                              More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                             type: boolean
                           secretFile:
-                            description: 'secretFile is Optional: SecretFile is the
-                            path to key ring for User, default is /etc/ceph/user.secret
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                            description: |-
+                              secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                              More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                             type: string
                           secretRef:
-                            description: 'secretRef is Optional: SecretRef is reference
-                            to the authentication secret for User, default is empty.
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                            description: |-
+                              secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                              More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                             properties:
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
                           user:
-                            description: 'user is optional: User is the rados user name,
-                            default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                            description: |-
+                              user is optional: User is the rados user name, default is admin
+                              More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                             type: string
                         required:
                           - monitors
                         type: object
                       cinder:
-                        description: 'cinder represents a cinder volume attached and
-                        mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                        description: |-
+                          cinder represents a cinder volume attached and mounted on kubelets host machine.
+                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                         properties:
                           fsType:
-                            description: 'fsType is the filesystem type to mount. Must
-                            be a filesystem type supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to
-                            be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                            description: |-
+                              fsType is the filesystem type to mount.
+                              Must be a filesystem type supported by the host operating system.
+                              Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                             type: string
                           readOnly:
-                            description: 'readOnly defaults to false (read/write). ReadOnly
-                            here will force the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                            description: |-
+                              readOnly defaults to false (read/write). ReadOnly here will force
+                              the ReadOnly setting in VolumeMounts.
+                              More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                             type: boolean
                           secretRef:
-                            description: 'secretRef is optional: points to a secret
-                            object containing parameters used to connect to OpenStack.'
+                            description: |-
+                              secretRef is optional: points to a secret object containing parameters used to connect
+                              to OpenStack.
                             properties:
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
                           volumeID:
-                            description: 'volumeID used to identify the volume in cinder.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                            description: |-
+                              volumeID used to identify the volume in cinder.
+                              More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                             type: string
                         required:
                           - volumeID
@@ -5963,27 +6003,25 @@ spec:
                           this volume
                         properties:
                           defaultMode:
-                            description: 'defaultMode is optional: mode bits used to
-                            set permissions on created files by default. Must be an
-                            octal value between 0000 and 0777 or a decimal value between
-                            0 and 511. YAML accepts both octal and decimal values,
-                            JSON requires decimal values for mode bits. Defaults to
-                            0644. Directories within the path are not affected by
-                            this setting. This might be in conflict with other options
-                            that affect the file mode, like fsGroup, and the result
-                            can be other mode bits set.'
+                            description: |-
+                              defaultMode is optional: mode bits used to set permissions on created files by default.
+                              Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                              Defaults to 0644.
+                              Directories within the path are not affected by this setting.
+                              This might be in conflict with other options that affect the file
+                              mode, like fsGroup, and the result can be other mode bits set.
                             format: int32
                             type: integer
                           items:
-                            description: items if unspecified, each key-value pair in
-                              the Data field of the referenced ConfigMap will be projected
-                              into the volume as a file whose name is the key and content
-                              is the value. If specified, the listed keys will be projected
-                              into the specified paths, and unlisted keys will not be
-                              present. If a key is specified which is not present in
-                              the ConfigMap, the volume setup will error unless it is
-                              marked optional. Paths must be relative and may not contain
-                              the '..' path or start with '..'.
+                            description: |-
+                              items if unspecified, each key-value pair in the Data field of the referenced
+                              ConfigMap will be projected into the volume as a file whose name is the
+                              key and content is the value. If specified, the listed keys will be
+                              projected into the specified paths, and unlisted keys will not be
+                              present. If a key is specified which is not present in the ConfigMap,
+                              the volume setup will error unless it is marked optional. Paths must be
+                              relative and may not contain the '..' path or start with '..'.
                             items:
                               description: Maps a string key to a path within a volume.
                               properties:
@@ -5991,22 +6029,21 @@ spec:
                                   description: key is the key to project.
                                   type: string
                                 mode:
-                                  description: 'mode is Optional: mode bits used to
-                                  set permissions on this file. Must be an octal value
-                                  between 0000 and 0777 or a decimal value between
-                                  0 and 511. YAML accepts both octal and decimal values,
-                                  JSON requires decimal values for mode bits. If not
-                                  specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that
-                                  affect the file mode, like fsGroup, and the result
-                                  can be other mode bits set.'
+                                  description: |-
+                                    mode is Optional: mode bits used to set permissions on this file.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    If not specified, the volume defaultMode will be used.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 path:
-                                  description: path is the relative path of the file
-                                    to map the key to. May not be an absolute path.
-                                    May not contain the path element '..'. May not start
-                                    with the string '..'.
+                                  description: |-
+                                    path is the relative path of the file to map the key to.
+                                    May not be an absolute path.
+                                    May not contain the path element '..'.
+                                    May not start with the string '..'.
                                   type: string
                               required:
                                 - key
@@ -6014,8 +6051,10 @@ spec:
                               type: object
                             type: array
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?
                             type: string
                           optional:
                             description: optional specify whether the ConfigMap or its
@@ -6029,41 +6068,43 @@ spec:
                           feature).
                         properties:
                           driver:
-                            description: driver is the name of the CSI driver that handles
-                              this volume. Consult with your admin for the correct name
-                              as registered in the cluster.
+                            description: |-
+                              driver is the name of the CSI driver that handles this volume.
+                              Consult with your admin for the correct name as registered in the cluster.
                             type: string
                           fsType:
-                            description: fsType to mount. Ex. "ext4", "xfs", "ntfs".
-                              If not provided, the empty value is passed to the associated
-                              CSI driver which will determine the default filesystem
-                              to apply.
+                            description: |-
+                              fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                              If not provided, the empty value is passed to the associated CSI driver
+                              which will determine the default filesystem to apply.
                             type: string
                           nodePublishSecretRef:
-                            description: nodePublishSecretRef is a reference to the
-                              secret object containing sensitive information to pass
-                              to the CSI driver to complete the CSI NodePublishVolume
-                              and NodeUnpublishVolume calls. This field is optional,
-                              and  may be empty if no secret is required. If the secret
-                              object contains more than one secret, all secret references
-                              are passed.
+                            description: |-
+                              nodePublishSecretRef is a reference to the secret object containing
+                              sensitive information to pass to the CSI driver to complete the CSI
+                              NodePublishVolume and NodeUnpublishVolume calls.
+                              This field is optional, and  may be empty if no secret is required. If the
+                              secret object contains more than one secret, all secret references are passed.
                             properties:
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
                           readOnly:
-                            description: readOnly specifies a read-only configuration
-                              for the volume. Defaults to false (read/write).
+                            description: |-
+                              readOnly specifies a read-only configuration for the volume.
+                              Defaults to false (read/write).
                             type: boolean
                           volumeAttributes:
                             additionalProperties:
                               type: string
-                            description: volumeAttributes stores driver-specific properties
-                              that are passed to the CSI driver. Consult your driver's
-                              documentation for supported values.
+                            description: |-
+                              volumeAttributes stores driver-specific properties that are passed to the CSI
+                              driver. Consult your driver's documentation for supported values.
                             type: object
                         required:
                           - driver
@@ -6073,16 +6114,15 @@ spec:
                           that should populate this volume
                         properties:
                           defaultMode:
-                            description: 'Optional: mode bits to use on created files
-                            by default. Must be a Optional: mode bits used to set
-                            permissions on created files by default. Must be an octal
-                            value between 0000 and 0777 or a decimal value between
-                            0 and 511. YAML accepts both octal and decimal values,
-                            JSON requires decimal values for mode bits. Defaults to
-                            0644. Directories within the path are not affected by
-                            this setting. This might be in conflict with other options
-                            that affect the file mode, like fsGroup, and the result
-                            can be other mode bits set.'
+                            description: |-
+                              Optional: mode bits to use on created files by default. Must be a
+                              Optional: mode bits used to set permissions on created files by default.
+                              Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                              Defaults to 0644.
+                              Directories within the path are not affected by this setting.
+                              This might be in conflict with other options that affect the file
+                              mode, like fsGroup, and the result can be other mode bits set.
                             format: int32
                             type: integer
                           items:
@@ -6109,15 +6149,13 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 mode:
-                                  description: 'Optional: mode bits used to set permissions
-                                  on this file, must be an octal value between 0000
-                                  and 0777 or a decimal value between 0 and 511. YAML
-                                  accepts both octal and decimal values, JSON requires
-                                  decimal values for mode bits. If not specified,
-                                  the volume defaultMode will be used. This might
-                                  be in conflict with other options that affect the
-                                  file mode, like fsGroup, and the result can be other
-                                  mode bits set.'
+                                  description: |-
+                                    Optional: mode bits used to set permissions on this file, must be an octal value
+                                    between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    If not specified, the volume defaultMode will be used.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 path:
@@ -6128,10 +6166,9 @@ spec:
                                   with ''..'''
                                   type: string
                                 resourceFieldRef:
-                                  description: 'Selects a resource of the container:
-                                  only resources limits and requests (limits.cpu,
-                                  limits.memory, requests.cpu and requests.memory)
-                                  are currently supported.'
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                   properties:
                                     containerName:
                                       description: 'Container name: required for volumes,
@@ -6158,73 +6195,94 @@ spec:
                             type: array
                         type: object
                       emptyDir:
-                        description: 'emptyDir represents a temporary directory that
-                        shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                        description: |-
+                          emptyDir represents a temporary directory that shares a pod's lifetime.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                         properties:
                           medium:
-                            description: 'medium represents what type of storage medium
-                            should back this directory. The default is "" which means
-                            to use the node''s default medium. Must be an empty string
-                            (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                            description: |-
+                              medium represents what type of storage medium should back this directory.
+                              The default is "" which means to use the node's default medium.
+                              Must be an empty string (default) or Memory.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                             type: string
                           sizeLimit:
                             anyOf:
                               - type: integer
                               - type: string
-                            description: 'sizeLimit is the total amount of local storage
-                            required for this EmptyDir volume. The size limit is also
-                            applicable for memory medium. The maximum usage on memory
-                            medium EmptyDir would be the minimum value between the
-                            SizeLimit specified here and the sum of memory limits
-                            of all containers in a pod. The default is nil which means
-                            that the limit is undefined. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                            description: |-
+                              sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                              The size limit is also applicable for memory medium.
+                              The maximum usage on memory medium EmptyDir would be the minimum value between
+                              the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                              The default is nil which means that the limit is undefined.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
                         type: object
                       ephemeral:
-                        description: "ephemeral represents a volume that is handled
-                        by a cluster storage driver. The volume's lifecycle is tied
-                        to the pod that defines it - it will be created before the
-                        pod starts, and deleted when the pod is removed. \n Use this
-                        if: a) the volume is only needed while the pod runs, b) features
-                        of normal volumes like restoring from snapshot or capacity
-                        tracking are needed, c) the storage driver is specified through
-                        a storage class, and d) the storage driver supports dynamic
-                        volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource
-                        for more information on the connection between this volume
-                        type and PersistentVolumeClaim). \n Use PersistentVolumeClaim
-                        or one of the vendor-specific APIs for volumes that persist
-                        for longer than the lifecycle of an individual pod. \n Use
-                        CSI for light-weight local ephemeral volumes if the CSI driver
-                        is meant to be used that way - see the documentation of the
-                        driver for more information. \n A pod can use both types of
-                        ephemeral volumes and persistent volumes at the same time."
+                        description: |-
+                          ephemeral represents a volume that is handled by a cluster storage driver.
+                          The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                          and deleted when the pod is removed.
+                          
+                          
+                          Use this if:
+                          a) the volume is only needed while the pod runs,
+                          b) features of normal volumes like restoring from snapshot or capacity
+                             tracking are needed,
+                          c) the storage driver is specified through a storage class, and
+                          d) the storage driver supports dynamic volume provisioning through
+                             a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                             information on the connection between this volume type
+                             and PersistentVolumeClaim).
+                          
+                          
+                          Use PersistentVolumeClaim or one of the vendor-specific
+                          APIs for volumes that persist for longer than the lifecycle
+                          of an individual pod.
+                          
+                          
+                          Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                          be used that way - see the documentation of the driver for
+                          more information.
+                          
+                          
+                          A pod can use both types of ephemeral volumes and
+                          persistent volumes at the same time.
                         properties:
                           volumeClaimTemplate:
-                            description: "Will be used to create a stand-alone PVC to
-                            provision the volume. The pod in which this EphemeralVolumeSource
-                            is embedded will be the owner of the PVC, i.e. the PVC
-                            will be deleted together with the pod.  The name of the
-                            PVC will be `<pod name>-<volume name>` where `<volume
-                            name>` is the name from the `PodSpec.Volumes` array entry.
-                            Pod validation will reject the pod if the concatenated
-                            name is not valid for a PVC (for example, too long). \n
-                            An existing PVC with that name that is not owned by the
-                            pod will *not* be used for the pod to avoid using an unrelated
-                            volume by mistake. Starting the pod is then blocked until
-                            the unrelated PVC is removed. If such a pre-created PVC
-                            is meant to be used by the pod, the PVC has to updated
-                            with an owner reference to the pod once the pod exists.
-                            Normally this should not be necessary, but it may be useful
-                            when manually reconstructing a broken cluster. \n This
-                            field is read-only and no changes will be made by Kubernetes
-                            to the PVC after it has been created. \n Required, must
-                            not be nil."
+                            description: |-
+                              Will be used to create a stand-alone PVC to provision the volume.
+                              The pod in which this EphemeralVolumeSource is embedded will be the
+                              owner of the PVC, i.e. the PVC will be deleted together with the
+                              pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                              `<volume name>` is the name from the `PodSpec.Volumes` array
+                              entry. Pod validation will reject the pod if the concatenated name
+                              is not valid for a PVC (for example, too long).
+                              
+                              
+                              An existing PVC with that name that is not owned by the pod
+                              will *not* be used for the pod to avoid using an unrelated
+                              volume by mistake. Starting the pod is then blocked until
+                              the unrelated PVC is removed. If such a pre-created PVC is
+                              meant to be used by the pod, the PVC has to updated with an
+                              owner reference to the pod once the pod exists. Normally
+                              this should not be necessary, but it may be useful when
+                              manually reconstructing a broken cluster.
+                              
+                              
+                              This field is read-only and no changes will be made by Kubernetes
+                              to the PVC after it has been created.
+                              
+                              
+                              Required, must not be nil.
                             properties:
                               metadata:
-                                description: May contain labels and annotations that
-                                  will be copied into the PVC when creating it. No other
-                                  fields are allowed and will be rejected during validation.
+                                description: |-
+                                  May contain labels and annotations that will be copied into the PVC
+                                  when creating it. No other fields are allowed and will be rejected during
+                                  validation.
                                 properties:
                                   annotations:
                                     additionalProperties:
@@ -6244,37 +6302,35 @@ spec:
                                     type: string
                                 type: object
                               spec:
-                                description: The specification for the PersistentVolumeClaim.
-                                  The entire content is copied unchanged into the PVC
-                                  that gets created from this template. The same fields
-                                  as in a PersistentVolumeClaim are also valid here.
+                                description: |-
+                                  The specification for the PersistentVolumeClaim. The entire content is
+                                  copied unchanged into the PVC that gets created from this
+                                  template. The same fields as in a PersistentVolumeClaim
+                                  are also valid here.
                                 properties:
                                   accessModes:
-                                    description: 'accessModes contains the desired access
-                                    modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                    description: |-
+                                      accessModes contains the desired access modes the volume should have.
+                                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                     items:
                                       type: string
                                     type: array
                                   dataSource:
-                                    description: 'dataSource field can be used to specify
-                                    either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                    * An existing PVC (PersistentVolumeClaim) If the
-                                    provisioner or an external controller can support
-                                    the specified data source, it will create a new
-                                    volume based on the contents of the specified
-                                    data source. When the AnyVolumeDataSource feature
-                                    gate is enabled, dataSource contents will be copied
-                                    to dataSourceRef, and dataSourceRef contents will
-                                    be copied to dataSource when dataSourceRef.namespace
-                                    is not specified. If the namespace is specified,
-                                    then dataSourceRef will not be copied to dataSource.'
+                                    description: |-
+                                      dataSource field can be used to specify either:
+                                      * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                      * An existing PVC (PersistentVolumeClaim)
+                                      If the provisioner or an external controller can support the specified data source,
+                                      it will create a new volume based on the contents of the specified data source.
+                                      When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                      and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                      If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                     properties:
                                       apiGroup:
-                                        description: APIGroup is the group for the resource
-                                          being referenced. If APIGroup is not specified,
-                                          the specified Kind must be in the core API
-                                          group. For any other third-party types, APIGroup
-                                          is required.
+                                        description: |-
+                                          APIGroup is the group for the resource being referenced.
+                                          If APIGroup is not specified, the specified Kind must be in the core API group.
+                                          For any other third-party types, APIGroup is required.
                                         type: string
                                       kind:
                                         description: Kind is the type of resource being
@@ -6290,45 +6346,36 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   dataSourceRef:
-                                    description: 'dataSourceRef specifies the object
-                                    from which to populate the volume with data, if
-                                    a non-empty volume is desired. This may be any
-                                    object from a non-empty API group (non core object)
-                                    or a PersistentVolumeClaim object. When this field
-                                    is specified, volume binding will only succeed
-                                    if the type of the specified object matches some
-                                    installed volume populator or dynamic provisioner.
-                                    This field will replace the functionality of the
-                                    dataSource field and as such if both fields are
-                                    non-empty, they must have the same value. For
-                                    backwards compatibility, when namespace isn''t
-                                    specified in dataSourceRef, both fields (dataSource
-                                    and dataSourceRef) will be set to the same value
-                                    automatically if one of them is empty and the
-                                    other is non-empty. When namespace is specified
-                                    in dataSourceRef, dataSource isn''t set to the
-                                    same value and must be empty. There are three
-                                    important differences between dataSource and dataSourceRef:
-                                    * While dataSource only allows two specific types
-                                    of objects, dataSourceRef allows any non-core
-                                    object, as well as PersistentVolumeClaim objects.
-                                    * While dataSource ignores disallowed values (dropping
-                                    them), dataSourceRef preserves all values, and
-                                    generates an error if a disallowed value is specified.
-                                    * While dataSource only allows local objects,
-                                    dataSourceRef allows objects in any namespaces.
-                                    (Beta) Using this field requires the AnyVolumeDataSource
-                                    feature gate to be enabled. (Alpha) Using the
-                                    namespace field of dataSourceRef requires the
-                                    CrossNamespaceVolumeDataSource feature gate to
-                                    be enabled.'
+                                    description: |-
+                                      dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                      volume is desired. This may be any object from a non-empty API group (non
+                                      core object) or a PersistentVolumeClaim object.
+                                      When this field is specified, volume binding will only succeed if the type of
+                                      the specified object matches some installed volume populator or dynamic
+                                      provisioner.
+                                      This field will replace the functionality of the dataSource field and as such
+                                      if both fields are non-empty, they must have the same value. For backwards
+                                      compatibility, when namespace isn't specified in dataSourceRef,
+                                      both fields (dataSource and dataSourceRef) will be set to the same
+                                      value automatically if one of them is empty and the other is non-empty.
+                                      When namespace is specified in dataSourceRef,
+                                      dataSource isn't set to the same value and must be empty.
+                                      There are three important differences between dataSource and dataSourceRef:
+                                      * While dataSource only allows two specific types of objects, dataSourceRef
+                                        allows any non-core object, as well as PersistentVolumeClaim objects.
+                                      * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                        preserves all values, and generates an error if a disallowed value is
+                                        specified.
+                                      * While dataSource only allows local objects, dataSourceRef allows objects
+                                        in any namespaces.
+                                      (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                      (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                     properties:
                                       apiGroup:
-                                        description: APIGroup is the group for the resource
-                                          being referenced. If APIGroup is not specified,
-                                          the specified Kind must be in the core API
-                                          group. For any other third-party types, APIGroup
-                                          is required.
+                                        description: |-
+                                          APIGroup is the group for the resource being referenced.
+                                          If APIGroup is not specified, the specified Kind must be in the core API group.
+                                          For any other third-party types, APIGroup is required.
                                         type: string
                                       kind:
                                         description: Kind is the type of resource being
@@ -6339,27 +6386,22 @@ spec:
                                           referenced
                                         type: string
                                       namespace:
-                                        description: Namespace is the namespace of resource
-                                          being referenced Note that when a namespace
-                                          is specified, a gateway.networking.k8s.io/ReferenceGrant
-                                          object is required in the referent namespace
-                                          to allow that namespace's owner to accept
-                                          the reference. See the ReferenceGrant documentation
-                                          for details. (Alpha) This field requires the
-                                          CrossNamespaceVolumeDataSource feature gate
-                                          to be enabled.
+                                        description: |-
+                                          Namespace is the namespace of resource being referenced
+                                          Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                          (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                         type: string
                                     required:
                                       - kind
                                       - name
                                     type: object
                                   resources:
-                                    description: 'resources represents the minimum resources
-                                    the volume should have. If RecoverVolumeExpansionFailure
-                                    feature is enabled users are allowed to specify
-                                    resource requirements that are lower than previous
-                                    value but must still be higher than capacity recorded
-                                    in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                    description: |-
+                                      resources represents the minimum resources the volume should have.
+                                      If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                      that are lower than previous value but must still be higher than capacity recorded in the
+                                      status field of the claim.
+                                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -6368,8 +6410,9 @@ spec:
                                             - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum amount
-                                        of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Limits describes the maximum amount of compute resources allowed.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -6378,12 +6421,11 @@ spec:
                                             - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum
-                                        amount of compute resources required. If Requests
-                                        is omitted for a container, it defaults to
-                                        Limits if that is explicitly specified, otherwise
-                                        to an implementation-defined value. Requests
-                                        cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Requests describes the minimum amount of compute resources required.
+                                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                     type: object
                                   selector:
@@ -6395,28 +6437,24 @@ spec:
                                           selector requirements. The requirements are
                                           ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
                                           properties:
                                             key:
                                               description: key is the label key that
                                                 the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
                                                 merge patch.
                                               items:
                                                 type: string
@@ -6429,46 +6467,37 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   storageClassName:
-                                    description: 'storageClassName is the name of the
-                                    StorageClass required by the claim. More info:
-                                    https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                    description: |-
+                                      storageClassName is the name of the StorageClass required by the claim.
+                                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                     type: string
                                   volumeAttributesClassName:
-                                    description: 'volumeAttributesClassName may be used
-                                    to set the VolumeAttributesClass used by this
-                                    claim. If specified, the CSI driver will create
-                                    or update the volume with the attributes defined
-                                    in the corresponding VolumeAttributesClass. This
-                                    has a different purpose than storageClassName,
-                                    it can be changed after the claim is created.
-                                    An empty string value means that no VolumeAttributesClass
-                                    will be applied to the claim but it''s not allowed
-                                    to reset this field to empty string once it is
-                                    set. If unspecified and the PersistentVolumeClaim
-                                    is unbound, the default VolumeAttributesClass
-                                    will be set by the persistentvolume controller
-                                    if it exists. If the resource referred to by volumeAttributesClass
-                                    does not exist, this PersistentVolumeClaim will
-                                    be set to a Pending state, as reflected by the
-                                    modifyVolumeStatus field, until such as a resource
-                                    exists. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                                    (Alpha) Using this field requires the VolumeAttributesClass
-                                    feature gate to be enabled.'
+                                    description: |-
+                                      volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                      If specified, the CSI driver will create or update the volume with the attributes defined
+                                      in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                      it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                                      will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                                      If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                                      will be set by the persistentvolume controller if it exists.
+                                      If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                      set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                      exists.
+                                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                                      (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
                                     type: string
                                   volumeMode:
-                                    description: volumeMode defines what type of volume
-                                      is required by the claim. Value of Filesystem
-                                      is implied when not included in claim spec.
+                                    description: |-
+                                      volumeMode defines what type of volume is required by the claim.
+                                      Value of Filesystem is implied when not included in claim spec.
                                     type: string
                                   volumeName:
                                     description: volumeName is the binding reference
@@ -6485,19 +6514,20 @@ spec:
                           pod.
                         properties:
                           fsType:
-                            description: 'fsType is the filesystem type to mount. Must
-                            be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified. TODO: how do we prevent errors in the
-                            filesystem from compromising the machine'
+                            description: |-
+                              fsType is the filesystem type to mount.
+                              Must be a filesystem type supported by the host operating system.
+                              Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           lun:
                             description: 'lun is Optional: FC target lun number'
                             format: int32
                             type: integer
                           readOnly:
-                            description: 'readOnly is Optional: Defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                            description: |-
+                              readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                              the ReadOnly setting in VolumeMounts.
                             type: boolean
                           targetWWNs:
                             description: 'targetWWNs is Optional: FC target worldwide
@@ -6506,26 +6536,27 @@ spec:
                               type: string
                             type: array
                           wwids:
-                            description: 'wwids Optional: FC volume world wide identifiers
-                            (wwids) Either wwids or combination of targetWWNs and
-                            lun must be set, but not both simultaneously.'
+                            description: |-
+                              wwids Optional: FC volume world wide identifiers (wwids)
+                              Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                             items:
                               type: string
                             type: array
                         type: object
                       flexVolume:
-                        description: flexVolume represents a generic volume resource
-                          that is provisioned/attached using an exec based plugin.
+                        description: |-
+                          flexVolume represents a generic volume resource that is
+                          provisioned/attached using an exec based plugin.
                         properties:
                           driver:
                             description: driver is the name of the driver to use for
                               this volume.
                             type: string
                           fsType:
-                            description: fsType is the filesystem type to mount. Must
-                              be a filesystem type supported by the host operating system.
-                              Ex. "ext4", "xfs", "ntfs". The default filesystem depends
-                              on FlexVolume script.
+                            description: |-
+                              fsType is the filesystem type to mount.
+                              Must be a filesystem type supported by the host operating system.
+                              Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                             type: string
                           options:
                             additionalProperties:
@@ -6534,20 +6565,23 @@ spec:
                             command options if any.'
                             type: object
                           readOnly:
-                            description: 'readOnly is Optional: defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                            description: |-
+                              readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                              the ReadOnly setting in VolumeMounts.
                             type: boolean
                           secretRef:
-                            description: 'secretRef is Optional: secretRef is reference
-                            to the secret object containing sensitive information
-                            to pass to the plugin scripts. This may be empty if no
-                            secret object is specified. If the secret object contains
-                            more than one secret, all secrets are passed to the plugin
-                            scripts.'
+                            description: |-
+                              secretRef is Optional: secretRef is reference to the secret object containing
+                              sensitive information to pass to the plugin scripts. This may be
+                              empty if no secret object is specified. If the secret object
+                              contains more than one secret, all secrets are passed to the plugin
+                              scripts.
                             properties:
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -6560,9 +6594,9 @@ spec:
                           service being running
                         properties:
                           datasetName:
-                            description: datasetName is Name of the dataset stored as
-                              metadata -> name on the dataset for Flocker should be
-                              considered as deprecated
+                            description: |-
+                              datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                              should be considered as deprecated
                             type: string
                           datasetUUID:
                             description: datasetUUID is the UUID of the dataset. This
@@ -6570,52 +6604,55 @@ spec:
                             type: string
                         type: object
                       gcePersistentDisk:
-                        description: 'gcePersistentDisk represents a GCE Disk resource
-                        that is attached to a kubelet''s host machine and then exposed
-                        to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        description: |-
+                          gcePersistentDisk represents a GCE Disk resource that is attached to a
+                          kubelet's host machine and then exposed to the pod.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                         properties:
                           fsType:
-                            description: 'fsType is filesystem type of the volume that
-                            you want to mount. Tip: Ensure that the filesystem type
-                            is supported by the host operating system. Examples: "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
+                            description: |-
+                              fsType is filesystem type of the volume that you want to mount.
+                              Tip: Ensure that the filesystem type is supported by the host operating system.
+                              Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           partition:
-                            description: 'partition is the partition in the volume that
-                            you want to mount. If omitted, the default is to mount
-                            by volume name. Examples: For volume /dev/sda1, you specify
-                            the partition as "1". Similarly, the volume partition
-                            for /dev/sda is "0" (or you can leave the property empty).
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            description: |-
+                              partition is the partition in the volume that you want to mount.
+                              If omitted, the default is to mount by volume name.
+                              Examples: For volume /dev/sda1, you specify the partition as "1".
+                              Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                             format: int32
                             type: integer
                           pdName:
-                            description: 'pdName is unique name of the PD resource in
-                            GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            description: |-
+                              pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                             type: string
                           readOnly:
-                            description: 'readOnly here will force the ReadOnly setting
-                            in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            description: |-
+                              readOnly here will force the ReadOnly setting in VolumeMounts.
+                              Defaults to false.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                             type: boolean
                         required:
                           - pdName
                         type: object
                       gitRepo:
-                        description: 'gitRepo represents a git repository at a particular
-                        revision. DEPRECATED: GitRepo is deprecated. To provision
-                        a container with a git repo, mount an EmptyDir into an InitContainer
-                        that clones the repo using git, then mount the EmptyDir into
-                        the Pod''s container.'
+                        description: |-
+                          gitRepo represents a git repository at a particular revision.
+                          DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                          EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                          into the Pod's container.
                         properties:
                           directory:
-                            description: directory is the target directory name. Must
-                              not contain or start with '..'.  If '.' is supplied, the
-                              volume directory will be the git repository.  Otherwise,
-                              if specified, the volume will contain the git repository
-                              in the subdirectory with the given name.
+                            description: |-
+                              directory is the target directory name.
+                              Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                              git repository.  Otherwise, if specified, the volume will contain the git repository in
+                              the subdirectory with the given name.
                             type: string
                           repository:
                             description: repository is the URL
@@ -6628,51 +6665,61 @@ spec:
                           - repository
                         type: object
                       glusterfs:
-                        description: 'glusterfs represents a Glusterfs mount on the
-                        host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                        description: |-
+                          glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                          More info: https://examples.k8s.io/volumes/glusterfs/README.md
                         properties:
                           endpoints:
-                            description: 'endpoints is the endpoint name that details
-                            Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                            description: |-
+                              endpoints is the endpoint name that details Glusterfs topology.
+                              More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                             type: string
                           path:
-                            description: 'path is the Glusterfs volume path. More info:
-                            https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                            description: |-
+                              path is the Glusterfs volume path.
+                              More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                             type: string
                           readOnly:
-                            description: 'readOnly here will force the Glusterfs volume
-                            to be mounted with read-only permissions. Defaults to
-                            false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                            description: |-
+                              readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                              Defaults to false.
+                              More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                             type: boolean
                         required:
                           - endpoints
                           - path
                         type: object
                       hostPath:
-                        description: 'hostPath represents a pre-existing file or directory
-                        on the host machine that is directly exposed to the container.
-                        This is generally used for system agents or other privileged
-                        things that are allowed to see the host machine. Most containers
-                        will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                        --- TODO(jonesdl) We need to restrict who can use host directory
-                        mounts and who can/can not mount host directories as read/write.'
+                        description: |-
+                          hostPath represents a pre-existing file or directory on the host
+                          machine that is directly exposed to the container. This is generally
+                          used for system agents or other privileged things that are allowed
+                          to see the host machine. Most containers will NOT need this.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                          ---
+                          TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
+                          mount host directories as read/write.
                         properties:
                           path:
-                            description: 'path of the directory on the host. If the
-                            path is a symlink, it will follow the link to the real
-                            path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                            description: |-
+                              path of the directory on the host.
+                              If the path is a symlink, it will follow the link to the real path.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                             type: string
                           type:
-                            description: 'type for HostPath Volume Defaults to "" More
-                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                            description: |-
+                              type for HostPath Volume
+                              Defaults to ""
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                             type: string
                         required:
                           - path
                         type: object
                       iscsi:
-                        description: 'iscsi represents an ISCSI Disk resource that is
-                        attached to a kubelet''s host machine and then exposed to
-                        the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                        description: |-
+                          iscsi represents an ISCSI Disk resource that is attached to a
+                          kubelet's host machine and then exposed to the pod.
+                          More info: https://examples.k8s.io/volumes/iscsi/README.md
                         properties:
                           chapAuthDiscovery:
                             description: chapAuthDiscovery defines whether support iSCSI
@@ -6683,56 +6730,59 @@ spec:
                               Session CHAP authentication
                             type: boolean
                           fsType:
-                            description: 'fsType is the filesystem type of the volume
-                            that you want to mount. Tip: Ensure that the filesystem
-                            type is supported by the host operating system. Examples:
-                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
+                            description: |-
+                              fsType is the filesystem type of the volume that you want to mount.
+                              Tip: Ensure that the filesystem type is supported by the host operating system.
+                              Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           initiatorName:
-                            description: initiatorName is the custom iSCSI Initiator
-                              Name. If initiatorName is specified with iscsiInterface
-                              simultaneously, new iSCSI interface <target portal>:<volume
-                              name> will be created for the connection.
+                            description: |-
+                              initiatorName is the custom iSCSI Initiator Name.
+                              If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                              <target portal>:<volume name> will be created for the connection.
                             type: string
                           iqn:
                             description: iqn is the target iSCSI Qualified Name.
                             type: string
                           iscsiInterface:
-                            description: iscsiInterface is the interface Name that uses
-                              an iSCSI transport. Defaults to 'default' (tcp).
+                            description: |-
+                              iscsiInterface is the interface Name that uses an iSCSI transport.
+                              Defaults to 'default' (tcp).
                             type: string
                           lun:
                             description: lun represents iSCSI Target Lun number.
                             format: int32
                             type: integer
                           portals:
-                            description: portals is the iSCSI Target Portal List. The
-                              portal is either an IP or ip_addr:port if the port is
-                              other than default (typically TCP ports 860 and 3260).
+                            description: |-
+                              portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                              is other than default (typically TCP ports 860 and 3260).
                             items:
                               type: string
                             type: array
                           readOnly:
-                            description: readOnly here will force the ReadOnly setting
-                              in VolumeMounts. Defaults to false.
+                            description: |-
+                              readOnly here will force the ReadOnly setting in VolumeMounts.
+                              Defaults to false.
                             type: boolean
                           secretRef:
                             description: secretRef is the CHAP Secret for iSCSI target
                               and initiator authentication
                             properties:
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
                           targetPortal:
-                            description: targetPortal is iSCSI Target Portal. The Portal
-                              is either an IP or ip_addr:port if the port is other than
-                              default (typically TCP ports 860 and 3260).
+                            description: |-
+                              targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                              is other than default (typically TCP ports 860 and 3260).
                             type: string
                         required:
                           - iqn
@@ -6740,43 +6790,51 @@ spec:
                           - targetPortal
                         type: object
                       name:
-                        description: 'name of the volume. Must be a DNS_LABEL and unique
-                        within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        description: |-
+                          name of the volume.
+                          Must be a DNS_LABEL and unique within the pod.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                         type: string
                       nfs:
-                        description: 'nfs represents an NFS mount on the host that shares
-                        a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        description: |-
+                          nfs represents an NFS mount on the host that shares a pod's lifetime
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                         properties:
                           path:
-                            description: 'path that is exported by the NFS server. More
-                            info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                            description: |-
+                              path that is exported by the NFS server.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                             type: string
                           readOnly:
-                            description: 'readOnly here will force the NFS export to
-                            be mounted with read-only permissions. Defaults to false.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                            description: |-
+                              readOnly here will force the NFS export to be mounted with read-only permissions.
+                              Defaults to false.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                             type: boolean
                           server:
-                            description: 'server is the hostname or IP address of the
-                            NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                            description: |-
+                              server is the hostname or IP address of the NFS server.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                             type: string
                         required:
                           - path
                           - server
                         type: object
                       persistentVolumeClaim:
-                        description: 'persistentVolumeClaimVolumeSource represents a
-                        reference to a PersistentVolumeClaim in the same namespace.
-                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                        description: |-
+                          persistentVolumeClaimVolumeSource represents a reference to a
+                          PersistentVolumeClaim in the same namespace.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                         properties:
                           claimName:
-                            description: 'claimName is the name of a PersistentVolumeClaim
-                            in the same namespace as the pod using this volume. More
-                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                            description: |-
+                              claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                             type: string
                           readOnly:
-                            description: readOnly Will force the ReadOnly setting in
-                              VolumeMounts. Default false.
+                            description: |-
+                              readOnly Will force the ReadOnly setting in VolumeMounts.
+                              Default false.
                             type: boolean
                         required:
                           - claimName
@@ -6786,10 +6844,10 @@ spec:
                           persistent disk attached and mounted on kubelets host machine
                         properties:
                           fsType:
-                            description: fsType is the filesystem type to mount. Must
-                              be a filesystem type supported by the host operating system.
-                              Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                              if unspecified.
+                            description: |-
+                              fsType is the filesystem type to mount.
+                              Must be a filesystem type supported by the host operating system.
+                              Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                             type: string
                           pdID:
                             description: pdID is the ID that identifies Photon Controller
@@ -6803,14 +6861,15 @@ spec:
                           and mounted on kubelets host machine
                         properties:
                           fsType:
-                            description: fSType represents the filesystem type to mount
-                              Must be a filesystem type supported by the host operating
-                              system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
-                              if unspecified.
+                            description: |-
+                              fSType represents the filesystem type to mount
+                              Must be a filesystem type supported by the host operating system.
+                              Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                             type: string
                           readOnly:
-                            description: readOnly defaults to false (read/write). ReadOnly
-                              here will force the ReadOnly setting in VolumeMounts.
+                            description: |-
+                              readOnly defaults to false (read/write). ReadOnly here will force
+                              the ReadOnly setting in VolumeMounts.
                             type: boolean
                           volumeID:
                             description: volumeID uniquely identifies a Portworx volume
@@ -6823,14 +6882,13 @@ spec:
                           configmaps, and downward API
                         properties:
                           defaultMode:
-                            description: defaultMode are the mode bits used to set permissions
-                              on created files by default. Must be an octal value between
-                              0000 and 0777 or a decimal value between 0 and 511. YAML
-                              accepts both octal and decimal values, JSON requires decimal
-                              values for mode bits. Directories within the path are
-                              not affected by this setting. This might be in conflict
-                              with other options that affect the file mode, like fsGroup,
-                              and the result can be other mode bits set.
+                            description: |-
+                              defaultMode are the mode bits used to set permissions on created files by default.
+                              Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                              Directories within the path are not affected by this setting.
+                              This might be in conflict with other options that affect the file
+                              mode, like fsGroup, and the result can be other mode bits set.
                             format: int32
                             type: integer
                           sources:
@@ -6840,54 +6898,54 @@ spec:
                                 other supported volume types
                               properties:
                                 clusterTrustBundle:
-                                  description: "ClusterTrustBundle allows a pod to access
-                                  the `.spec.trustBundle` field of ClusterTrustBundle
-                                  objects in an auto-updating file. \n Alpha, gated
-                                  by the ClusterTrustBundleProjection feature gate.
-                                  \n ClusterTrustBundle objects can either be selected
-                                  by name, or by the combination of signer name and
-                                  a label selector. \n Kubelet performs aggressive
-                                  normalization of the PEM contents written into the
-                                  pod filesystem.  Esoteric PEM features such as inter-block
-                                  comments and block headers are stripped.  Certificates
-                                  are deduplicated. The ordering of certificates within
-                                  the file is arbitrary, and Kubelet may change the
-                                  order over time."
+                                  description: |-
+                                    ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
+                                    of ClusterTrustBundle objects in an auto-updating file.
+                                    
+                                    
+                                    Alpha, gated by the ClusterTrustBundleProjection feature gate.
+                                    
+                                    
+                                    ClusterTrustBundle objects can either be selected by name, or by the
+                                    combination of signer name and a label selector.
+                                    
+                                    
+                                    Kubelet performs aggressive normalization of the PEM contents written
+                                    into the pod filesystem.  Esoteric PEM features such as inter-block
+                                    comments and block headers are stripped.  Certificates are deduplicated.
+                                    The ordering of certificates within the file is arbitrary, and Kubelet
+                                    may change the order over time.
                                   properties:
                                     labelSelector:
-                                      description: Select all ClusterTrustBundles that
-                                        match this label selector.  Only has effect
-                                        if signerName is set.  Mutually-exclusive with
-                                        name.  If unset, interpreted as "match nothing".  If
-                                        set but empty, interpreted as "match everything".
+                                      description: |-
+                                        Select all ClusterTrustBundles that match this label selector.  Only has
+                                        effect if signerName is set.  Mutually-exclusive with name.  If unset,
+                                        interpreted as "match nothing".  If set but empty, interpreted as "match
+                                        everything".
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list of
                                             label selector requirements. The requirements
                                             are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values, a
-                                              key, and an operator that relates the
-                                              key and values.
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
                                                 description: key is the label key that
                                                   the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's
-                                                  relationship to a set of values. Valid
-                                                  operators are In, NotIn, Exists and
-                                                  DoesNotExist.
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of string
-                                                  values. If the operator is In or NotIn,
-                                                  the values array must be non-empty.
-                                                  If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This
-                                                  array is replaced during a strategic
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
                                                   merge patch.
                                                 items:
                                                   type: string
@@ -6900,37 +6958,35 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator is
-                                            "In", and the values array contains only
-                                            "value". The requirements are ANDed.
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     name:
-                                      description: Select a single ClusterTrustBundle
-                                        by object name.  Mutually-exclusive with signerName
-                                        and labelSelector.
+                                      description: |-
+                                        Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                        with signerName and labelSelector.
                                       type: string
                                     optional:
-                                      description: If true, don't block pod startup
-                                        if the referenced ClusterTrustBundle(s) aren't
-                                        available.  If using name, then the named ClusterTrustBundle
-                                        is allowed not to exist.  If using signerName,
-                                        then the combination of signerName and labelSelector
-                                        is allowed to match zero ClusterTrustBundles.
+                                      description: |-
+                                        If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                        aren't available.  If using name, then the named ClusterTrustBundle is
+                                        allowed not to exist.  If using signerName, then the combination of
+                                        signerName and labelSelector is allowed to match zero
+                                        ClusterTrustBundles.
                                       type: boolean
                                     path:
                                       description: Relative path from the volume root
                                         to write the bundle.
                                       type: string
                                     signerName:
-                                      description: Select all ClusterTrustBundles that
-                                        match this signer name. Mutually-exclusive with
-                                        name.  The contents of all selected ClusterTrustBundles
-                                        will be unified and deduplicated.
+                                      description: |-
+                                        Select all ClusterTrustBundles that match this signer name.
+                                        Mutually-exclusive with name.  The contents of all selected
+                                        ClusterTrustBundles will be unified and deduplicated.
                                       type: string
                                   required:
                                     - path
@@ -6940,17 +6996,14 @@ spec:
                                     data to project
                                   properties:
                                     items:
-                                      description: items if unspecified, each key-value
-                                        pair in the Data field of the referenced ConfigMap
-                                        will be projected into the volume as a file
-                                        whose name is the key and content is the value.
-                                        If specified, the listed keys will be projected
-                                        into the specified paths, and unlisted keys
-                                        will not be present. If a key is specified which
-                                        is not present in the ConfigMap, the volume
-                                        setup will error unless it is marked optional.
-                                        Paths must be relative and may not contain the
-                                        '..' path or start with '..'.
+                                      description: |-
+                                        items if unspecified, each key-value pair in the Data field of the referenced
+                                        ConfigMap will be projected into the volume as a file whose name is the
+                                        key and content is the value. If specified, the listed keys will be
+                                        projected into the specified paths, and unlisted keys will not be
+                                        present. If a key is specified which is not present in the ConfigMap,
+                                        the volume setup will error unless it is marked optional. Paths must be
+                                        relative and may not contain the '..' path or start with '..'.
                                       items:
                                         description: Maps a string key to a path within
                                           a volume.
@@ -6959,25 +7012,21 @@ spec:
                                             description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'mode is Optional: mode bits
-                                            used to set permissions on this file.
-                                            Must be an octal value between 0000 and
-                                            0777 or a decimal value between 0 and
-                                            511. YAML accepts both octal and decimal
-                                            values, JSON requires decimal values for
-                                            mode bits. If not specified, the volume
-                                            defaultMode will be used. This might be
-                                            in conflict with other options that affect
-                                            the file mode, like fsGroup, and the result
-                                            can be other mode bits set.'
+                                            description: |-
+                                              mode is Optional: mode bits used to set permissions on this file.
+                                              Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                              If not specified, the volume defaultMode will be used.
+                                              This might be in conflict with other options that affect the file
+                                              mode, like fsGroup, and the result can be other mode bits set.
                                             format: int32
                                             type: integer
                                           path:
-                                            description: path is the relative path of
-                                              the file to map the key to. May not be
-                                              an absolute path. May not contain the
-                                              path element '..'. May not start with
-                                              the string '..'.
+                                            description: |-
+                                              path is the relative path of the file to map the key to.
+                                              May not be an absolute path.
+                                              May not contain the path element '..'.
+                                              May not start with the string '..'.
                                             type: string
                                         required:
                                           - key
@@ -6985,10 +7034,10 @@ spec:
                                         type: object
                                       type: array
                                     name:
-                                      description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                     optional:
                                       description: optional specify whether the ConfigMap
@@ -7027,17 +7076,13 @@ spec:
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           mode:
-                                            description: 'Optional: mode bits used to
-                                            set permissions on this file, must be
-                                            an octal value between 0000 and 0777 or
-                                            a decimal value between 0 and 511. YAML
-                                            accepts both octal and decimal values,
-                                            JSON requires decimal values for mode
-                                            bits. If not specified, the volume defaultMode
-                                            will be used. This might be in conflict
-                                            with other options that affect the file
-                                            mode, like fsGroup, and the result can
-                                            be other mode bits set.'
+                                            description: |-
+                                              Optional: mode bits used to set permissions on this file, must be an octal value
+                                              between 0000 and 0777 or a decimal value between 0 and 511.
+                                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                              If not specified, the volume defaultMode will be used.
+                                              This might be in conflict with other options that affect the file
+                                              mode, like fsGroup, and the result can be other mode bits set.
                                             format: int32
                                             type: integer
                                           path:
@@ -7049,10 +7094,9 @@ spec:
                                             with ''..'''
                                             type: string
                                           resourceFieldRef:
-                                            description: 'Selects a resource of the
-                                            container: only resources limits and requests
-                                            (limits.cpu, limits.memory, requests.cpu
-                                            and requests.memory) are currently supported.'
+                                            description: |-
+                                              Selects a resource of the container: only resources limits and requests
+                                              (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                             properties:
                                               containerName:
                                                 description: 'Container name: required
@@ -7085,17 +7129,14 @@ spec:
                                     to project
                                   properties:
                                     items:
-                                      description: items if unspecified, each key-value
-                                        pair in the Data field of the referenced Secret
-                                        will be projected into the volume as a file
-                                        whose name is the key and content is the value.
-                                        If specified, the listed keys will be projected
-                                        into the specified paths, and unlisted keys
-                                        will not be present. If a key is specified which
-                                        is not present in the Secret, the volume setup
-                                        will error unless it is marked optional. Paths
-                                        must be relative and may not contain the '..'
-                                        path or start with '..'.
+                                      description: |-
+                                        items if unspecified, each key-value pair in the Data field of the referenced
+                                        Secret will be projected into the volume as a file whose name is the
+                                        key and content is the value. If specified, the listed keys will be
+                                        projected into the specified paths, and unlisted keys will not be
+                                        present. If a key is specified which is not present in the Secret,
+                                        the volume setup will error unless it is marked optional. Paths must be
+                                        relative and may not contain the '..' path or start with '..'.
                                       items:
                                         description: Maps a string key to a path within
                                           a volume.
@@ -7104,25 +7145,21 @@ spec:
                                             description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'mode is Optional: mode bits
-                                            used to set permissions on this file.
-                                            Must be an octal value between 0000 and
-                                            0777 or a decimal value between 0 and
-                                            511. YAML accepts both octal and decimal
-                                            values, JSON requires decimal values for
-                                            mode bits. If not specified, the volume
-                                            defaultMode will be used. This might be
-                                            in conflict with other options that affect
-                                            the file mode, like fsGroup, and the result
-                                            can be other mode bits set.'
+                                            description: |-
+                                              mode is Optional: mode bits used to set permissions on this file.
+                                              Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                              If not specified, the volume defaultMode will be used.
+                                              This might be in conflict with other options that affect the file
+                                              mode, like fsGroup, and the result can be other mode bits set.
                                             format: int32
                                             type: integer
                                           path:
-                                            description: path is the relative path of
-                                              the file to map the key to. May not be
-                                              an absolute path. May not contain the
-                                              path element '..'. May not start with
-                                              the string '..'.
+                                            description: |-
+                                              path is the relative path of the file to map the key to.
+                                              May not be an absolute path.
+                                              May not contain the path element '..'.
+                                              May not start with the string '..'.
                                             type: string
                                         required:
                                           - key
@@ -7130,10 +7167,10 @@ spec:
                                         type: object
                                       type: array
                                     name:
-                                      description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                     optional:
                                       description: optional field specify whether the
@@ -7146,29 +7183,26 @@ spec:
                                     the serviceAccountToken data to project
                                   properties:
                                     audience:
-                                      description: audience is the intended audience
-                                        of the token. A recipient of a token must identify
-                                        itself with an identifier specified in the audience
-                                        of the token, and otherwise should reject the
-                                        token. The audience defaults to the identifier
-                                        of the apiserver.
+                                      description: |-
+                                        audience is the intended audience of the token. A recipient of a token
+                                        must identify itself with an identifier specified in the audience of the
+                                        token, and otherwise should reject the token. The audience defaults to the
+                                        identifier of the apiserver.
                                       type: string
                                     expirationSeconds:
-                                      description: expirationSeconds is the requested
-                                        duration of validity of the service account
-                                        token. As the token approaches expiration, the
-                                        kubelet volume plugin will proactively rotate
-                                        the service account token. The kubelet will
-                                        start trying to rotate the token if the token
-                                        is older than 80 percent of its time to live
-                                        or if the token is older than 24 hours.Defaults
-                                        to 1 hour and must be at least 10 minutes.
+                                      description: |-
+                                        expirationSeconds is the requested duration of validity of the service
+                                        account token. As the token approaches expiration, the kubelet volume
+                                        plugin will proactively rotate the service account token. The kubelet will
+                                        start trying to rotate the token if the token is older than 80 percent of
+                                        its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                        and must be at least 10 minutes.
                                       format: int64
                                       type: integer
                                     path:
-                                      description: path is the path relative to the
-                                        mount point of the file to project the token
-                                        into.
+                                      description: |-
+                                        path is the path relative to the mount point of the file to project the
+                                        token into.
                                       type: string
                                   required:
                                     - path
@@ -7181,28 +7215,30 @@ spec:
                           that shares a pod's lifetime
                         properties:
                           group:
-                            description: group to map volume access to Default is no
-                              group
+                            description: |-
+                              group to map volume access to
+                              Default is no group
                             type: string
                           readOnly:
-                            description: readOnly here will force the Quobyte volume
-                              to be mounted with read-only permissions. Defaults to
-                              false.
+                            description: |-
+                              readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                              Defaults to false.
                             type: boolean
                           registry:
-                            description: registry represents a single or multiple Quobyte
-                              Registry services specified as a string as host:port pair
-                              (multiple entries are separated with commas) which acts
-                              as the central registry for volumes
+                            description: |-
+                              registry represents a single or multiple Quobyte Registry services
+                              specified as a string as host:port pair (multiple entries are separated with commas)
+                              which acts as the central registry for volumes
                             type: string
                           tenant:
-                            description: tenant owning the given Quobyte volume in the
-                              Backend Used with dynamically provisioned Quobyte volumes,
-                              value is set by the plugin
+                            description: |-
+                              tenant owning the given Quobyte volume in the Backend
+                              Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                             type: string
                           user:
-                            description: user to map volume access to Defaults to serivceaccount
-                              user
+                            description: |-
+                              user to map volume access to
+                              Defaults to serivceaccount user
                             type: string
                           volume:
                             description: volume is a string that references an already
@@ -7213,54 +7249,68 @@ spec:
                           - volume
                         type: object
                       rbd:
-                        description: 'rbd represents a Rados Block Device mount on the
-                        host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                        description: |-
+                          rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                          More info: https://examples.k8s.io/volumes/rbd/README.md
                         properties:
                           fsType:
-                            description: 'fsType is the filesystem type of the volume
-                            that you want to mount. Tip: Ensure that the filesystem
-                            type is supported by the host operating system. Examples:
-                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
+                            description: |-
+                              fsType is the filesystem type of the volume that you want to mount.
+                              Tip: Ensure that the filesystem type is supported by the host operating system.
+                              Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           image:
-                            description: 'image is the rados image name. More info:
-                            https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            description: |-
+                              image is the rados image name.
+                              More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                             type: string
                           keyring:
-                            description: 'keyring is the path to key ring for RBDUser.
-                            Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            description: |-
+                              keyring is the path to key ring for RBDUser.
+                              Default is /etc/ceph/keyring.
+                              More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                             type: string
                           monitors:
-                            description: 'monitors is a collection of Ceph monitors.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            description: |-
+                              monitors is a collection of Ceph monitors.
+                              More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                             items:
                               type: string
                             type: array
                           pool:
-                            description: 'pool is the rados pool name. Default is rbd.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            description: |-
+                              pool is the rados pool name.
+                              Default is rbd.
+                              More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                             type: string
                           readOnly:
-                            description: 'readOnly here will force the ReadOnly setting
-                            in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            description: |-
+                              readOnly here will force the ReadOnly setting in VolumeMounts.
+                              Defaults to false.
+                              More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                             type: boolean
                           secretRef:
-                            description: 'secretRef is name of the authentication secret
-                            for RBDUser. If provided overrides keyring. Default is
-                            nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            description: |-
+                              secretRef is name of the authentication secret for RBDUser. If provided
+                              overrides keyring.
+                              Default is nil.
+                              More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                             properties:
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
                           user:
-                            description: 'user is the rados user name. Default is admin.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            description: |-
+                              user is the rados user name.
+                              Default is admin.
+                              More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                             type: string
                         required:
                           - image
@@ -7271,9 +7321,11 @@ spec:
                           attached and mounted on Kubernetes nodes.
                         properties:
                           fsType:
-                            description: fsType is the filesystem type to mount. Must
-                              be a filesystem type supported by the host operating system.
-                              Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+                            description: |-
+                              fsType is the filesystem type to mount.
+                              Must be a filesystem type supported by the host operating system.
+                              Ex. "ext4", "xfs", "ntfs".
+                              Default is "xfs".
                             type: string
                           gateway:
                             description: gateway is the host address of the ScaleIO
@@ -7284,17 +7336,20 @@ spec:
                               Protection Domain for the configured storage.
                             type: string
                           readOnly:
-                            description: readOnly Defaults to false (read/write). ReadOnly
-                              here will force the ReadOnly setting in VolumeMounts.
+                            description: |-
+                              readOnly Defaults to false (read/write). ReadOnly here will force
+                              the ReadOnly setting in VolumeMounts.
                             type: boolean
                           secretRef:
-                            description: secretRef references to the secret for ScaleIO
-                              user and other sensitive information. If this is not provided,
-                              Login operation will fail.
+                            description: |-
+                              secretRef references to the secret for ScaleIO user and other
+                              sensitive information. If this is not provided, Login operation will fail.
                             properties:
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -7303,8 +7358,8 @@ spec:
                               with Gateway, default false
                             type: boolean
                           storageMode:
-                            description: storageMode indicates whether the storage for
-                              a volume should be ThickProvisioned or ThinProvisioned.
+                            description: |-
+                              storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
                               Default is ThinProvisioned.
                             type: string
                           storagePool:
@@ -7316,9 +7371,9 @@ spec:
                               configured in ScaleIO.
                             type: string
                           volumeName:
-                            description: volumeName is the name of a volume already
-                              created in the ScaleIO system that is associated with
-                              this volume source.
+                            description: |-
+                              volumeName is the name of a volume already created in the ScaleIO system
+                              that is associated with this volume source.
                             type: string
                         required:
                           - gateway
@@ -7326,31 +7381,30 @@ spec:
                           - system
                         type: object
                       secret:
-                        description: 'secret represents a secret that should populate
-                        this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                        description: |-
+                          secret represents a secret that should populate this volume.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                         properties:
                           defaultMode:
-                            description: 'defaultMode is Optional: mode bits used to
-                            set permissions on created files by default. Must be an
-                            octal value between 0000 and 0777 or a decimal value between
-                            0 and 511. YAML accepts both octal and decimal values,
-                            JSON requires decimal values for mode bits. Defaults to
-                            0644. Directories within the path are not affected by
-                            this setting. This might be in conflict with other options
-                            that affect the file mode, like fsGroup, and the result
-                            can be other mode bits set.'
+                            description: |-
+                              defaultMode is Optional: mode bits used to set permissions on created files by default.
+                              Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                              YAML accepts both octal and decimal values, JSON requires decimal values
+                              for mode bits. Defaults to 0644.
+                              Directories within the path are not affected by this setting.
+                              This might be in conflict with other options that affect the file
+                              mode, like fsGroup, and the result can be other mode bits set.
                             format: int32
                             type: integer
                           items:
-                            description: items If unspecified, each key-value pair in
-                              the Data field of the referenced Secret will be projected
-                              into the volume as a file whose name is the key and content
-                              is the value. If specified, the listed keys will be projected
-                              into the specified paths, and unlisted keys will not be
-                              present. If a key is specified which is not present in
-                              the Secret, the volume setup will error unless it is marked
-                              optional. Paths must be relative and may not contain the
-                              '..' path or start with '..'.
+                            description: |-
+                              items If unspecified, each key-value pair in the Data field of the referenced
+                              Secret will be projected into the volume as a file whose name is the
+                              key and content is the value. If specified, the listed keys will be
+                              projected into the specified paths, and unlisted keys will not be
+                              present. If a key is specified which is not present in the Secret,
+                              the volume setup will error unless it is marked optional. Paths must be
+                              relative and may not contain the '..' path or start with '..'.
                             items:
                               description: Maps a string key to a path within a volume.
                               properties:
@@ -7358,22 +7412,21 @@ spec:
                                   description: key is the key to project.
                                   type: string
                                 mode:
-                                  description: 'mode is Optional: mode bits used to
-                                  set permissions on this file. Must be an octal value
-                                  between 0000 and 0777 or a decimal value between
-                                  0 and 511. YAML accepts both octal and decimal values,
-                                  JSON requires decimal values for mode bits. If not
-                                  specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that
-                                  affect the file mode, like fsGroup, and the result
-                                  can be other mode bits set.'
+                                  description: |-
+                                    mode is Optional: mode bits used to set permissions on this file.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    If not specified, the volume defaultMode will be used.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 path:
-                                  description: path is the relative path of the file
-                                    to map the key to. May not be an absolute path.
-                                    May not contain the path element '..'. May not start
-                                    with the string '..'.
+                                  description: |-
+                                    path is the relative path of the file to map the key to.
+                                    May not be an absolute path.
+                                    May not contain the path element '..'.
+                                    May not start with the string '..'.
                                   type: string
                               required:
                                 - key
@@ -7385,8 +7438,9 @@ spec:
                               its keys must be defined
                             type: boolean
                           secretName:
-                            description: 'secretName is the name of the secret in the
-                            pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                            description: |-
+                              secretName is the name of the secret in the pod's namespace to use.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                             type: string
                         type: object
                       storageos:
@@ -7394,40 +7448,42 @@ spec:
                           and mounted on Kubernetes nodes.
                         properties:
                           fsType:
-                            description: fsType is the filesystem type to mount. Must
-                              be a filesystem type supported by the host operating system.
-                              Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                              if unspecified.
+                            description: |-
+                              fsType is the filesystem type to mount.
+                              Must be a filesystem type supported by the host operating system.
+                              Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                             type: string
                           readOnly:
-                            description: readOnly defaults to false (read/write). ReadOnly
-                              here will force the ReadOnly setting in VolumeMounts.
+                            description: |-
+                              readOnly defaults to false (read/write). ReadOnly here will force
+                              the ReadOnly setting in VolumeMounts.
                             type: boolean
                           secretRef:
-                            description: secretRef specifies the secret to use for obtaining
-                              the StorageOS API credentials.  If not specified, default
-                              values will be attempted.
+                            description: |-
+                              secretRef specifies the secret to use for obtaining the StorageOS API
+                              credentials.  If not specified, default values will be attempted.
                             properties:
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
                           volumeName:
-                            description: volumeName is the human-readable name of the
-                              StorageOS volume.  Volume names are only unique within
-                              a namespace.
+                            description: |-
+                              volumeName is the human-readable name of the StorageOS volume.  Volume
+                              names are only unique within a namespace.
                             type: string
                           volumeNamespace:
-                            description: volumeNamespace specifies the scope of the
-                              volume within StorageOS.  If no namespace is specified
-                              then the Pod's namespace will be used.  This allows the
-                              Kubernetes name scoping to be mirrored within StorageOS
-                              for tighter integration. Set VolumeName to any name to
-                              override the default behaviour. Set to "default" if you
-                              are not using namespaces within StorageOS. Namespaces
-                              that do not pre-exist within StorageOS will be created.
+                            description: |-
+                              volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                              namespace is specified then the Pod's namespace will be used.  This allows the
+                              Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                              Set VolumeName to any name to override the default behaviour.
+                              Set to "default" if you are not using namespaces within StorageOS.
+                              Namespaces that do not pre-exist within StorageOS will be created.
                             type: string
                         type: object
                       vsphereVolume:
@@ -7435,10 +7491,10 @@ spec:
                           and mounted on kubelets host machine
                         properties:
                           fsType:
-                            description: fsType is filesystem type to mount. Must be
-                              a filesystem type supported by the host operating system.
-                              Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                              if unspecified.
+                            description: |-
+                              fsType is filesystem type to mount.
+                              Must be a filesystem type supported by the host operating system.
+                              Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                             type: string
                           storagePolicyID:
                             description: storagePolicyID is the storage Policy Based
@@ -7461,9 +7517,10 @@ spec:
                   type: array
                   x-kubernetes-list-type: atomic
                 workingDir:
-                  description: WorkingDir represents Container's working directory.
-                    If not specified, the container runtime's default will be used,
-                    which might be configured in the container image. Cannot be updated.
+                  description: |-
+                    WorkingDir represents Container's working directory. If not specified,
+                    the container runtime's default will be used, which might
+                    be configured in the container image. Cannot be updated.
                   type: string
               type: object
             status:
@@ -7475,16 +7532,17 @@ spec:
                     Collector.
                   type: string
                 messages:
-                  description: 'Messages about actions performed by the operator on
-                  this resource. Deprecated: use Kubernetes events instead.'
+                  description: |-
+                    Messages about actions performed by the operator on this resource.
+                    Deprecated: use Kubernetes events instead.
                   items:
                     type: string
                   type: array
                   x-kubernetes-list-type: atomic
                 replicas:
-                  description: 'Replicas is currently not being set and might be removed
-                  in the next version. Deprecated: use "AmazonCloudWatchAgent.Status.Scale.Replicas"
-                  instead.'
+                  description: |-
+                    Replicas is currently not being set and might be removed in the next version.
+                    Deprecated: use "AmazonCloudWatchAgent.Status.Scale.Replicas" instead.
                   format: int32
                   type: integer
                 scale:
@@ -7492,19 +7550,21 @@ spec:
                     status.
                   properties:
                     replicas:
-                      description: The total number non-terminated pods targeted by
-                        this AmazonCloudWatchAgent's deployment or statefulSet.
+                      description: |-
+                        The total number non-terminated pods targeted by this
+                        AmazonCloudWatchAgent's deployment or statefulSet.
                       format: int32
                       type: integer
                     selector:
-                      description: The selector used to match the AmazonCloudWatchAgent's
+                      description: |-
+                        The selector used to match the AmazonCloudWatchAgent's
                         deployment or statefulSet pods.
                       type: string
                     statusReplicas:
-                      description: StatusReplicas is the number of pods targeted by
-                        this AmazonCloudWatchAgent's with a Ready Condition / Total
-                        number of non-terminated pods targeted by this AmazonCloudWatchAgent's
-                        (their labels match the selector). Deployment, Daemonset, StatefulSet.
+                      description: |-
+                        StatusReplicas is the number of pods targeted by this AmazonCloudWatchAgent's with a Ready Condition /
+                        Total number of non-terminated pods targeted by this AmazonCloudWatchAgent's (their labels match the selector).
+                        Deployment, Daemonset, StatefulSet.
                       type: string
                   type: object
                 version:

--- a/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
@@ -44,6 +44,25 @@ Helper function to modify customer supplied agent config if ContainerInsights or
 {{- end }}
 
 {{/*
+Helper function to modify cloudwatch-agent YAML config
+*/}}
+{{- define "cloudwatch-agent.modify-yaml-config" -}}
+{{- $configCopy := deepCopy .OtelConfig }}
+
+{{- range $name, $component := $configCopy }}
+{{- if $component -}}
+  {{- range $key, $value := $component }}
+    {{- if (and (quote $value | empty) (not (hasKey $component $key))) }}
+      {{- $component = set $component $key (dict) }}
+    {{- end -}}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{- $configCopy | toYaml | quote }}
+{{- end }}
+
+{{/*
 Name for cloudwatch-agent
 */}}
 {{- define "cloudwatch-agent.name" -}}

--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml
@@ -46,7 +46,7 @@ spec:
   config: {{ include "cloudwatch-agent.modify-config" (merge (dict "Config" .Values.agent.defaultConfig) . ) }}
   {{- end }}
   {{- if .Values.agent.otelConfig }}
-  otelConfig: {{ .Values.agent.otelConfig | toYaml | quote }}
+  otelConfig: {{ include "cloudwatch-agent.modify-yaml-config" (merge (dict "OtelConfig" .Values.agent.otelConfig) . ) }}
   {{- end }}
   {{- with .Values.agent.resources }}
   resources: {{- toYaml . | nindent 4}}

--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml
@@ -45,6 +45,9 @@ spec:
   {{- else }}
   config: {{ include "cloudwatch-agent.modify-config" (merge (dict "Config" .Values.agent.defaultConfig) . ) }}
   {{- end }}
+  {{- if .Values.agent.otelConfig }}
+  otelConfig: {{ .Values.agent.otelConfig | toYaml | quote }}
+  {{- end }}
   {{- with .Values.agent.resources }}
   resources: {{- toYaml . | nindent 4}}
   {{- end }}

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -586,6 +586,7 @@ agent:
   serviceAccount:
     name: # override agent service account name
   config: # optional config that can be provided to override the defaultConfig
+  otelConfig: # optional YAML config that can be provided to combine with the config/defaultConfig
   defaultConfig:
     {
       "logs": {


### PR DESCRIPTION
*Description of changes:*
1. Update amazoncloudwatchagent CRD to support otelConfig field
2. Add support for otelConfig in the Linux cloudwatch agent custom resource

Tested as part of https://github.com/aws/amazon-cloudwatch-agent-operator/pull/241
Additional testing for supporting empty config in agent YAML config - verified the agent pod starts up for the following YAML configs
```
    receivers:
      otlp:
        protocols:
          grpc:
          http:
      awsxray:
    processors:
      batch/traces:
      batch/metrics:
    exporters:
      awsxray:
      awsemf:
    service:
      pipelines:
        traces:
          receivers: [ otlp,awsxray ]
          processors: [ batch/traces ]
          exporters: [ awsxray ]
        metrics:
          receivers: [ otlp ]
          processors: [ batch/metrics ]
          exporters: [ awsemf ]

----------------------------------------------
    extensions:
      health_check:
    receivers:
      otlp:
        protocols:
          grpc:
            endpoint: 0.0.0.0:4317
          http:
            endpoint: 0.0.0.0:4318
      awsxray:
        endpoint: 0.0.0.0:2000
        transport: udp
    processors:
      batch/traces:
        timeout: 1s
        send_batch_size: 50
      batch/metrics:
        timeout: 60s
    exporters:
      awsxray:
      awsemf:

    service:
      pipelines:
        traces:
          receivers: [otlp,awsxray]
          processors: [batch/traces]
          exporters: [awsxray]
        metrics:
          receivers: [otlp]
          processors: [batch/metrics]
          exporters: [awsemf]

      extensions: [health_check]
````


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

