### PR TITLE
Forcing YAML conversion for otelConfig field

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
@@ -48,6 +48,7 @@ Helper function to modify cloudwatch-agent YAML config
 */}}
 {{- define "cloudwatch-agent.modify-yaml-config" -}}
 {{- $configCopy := deepCopy .OtelConfig }}
+{{- $configCopy := fromYaml $configCopy }}
 
 {{- range $name, $component := $configCopy }}
 {{- if $component -}}


### PR DESCRIPTION

*Description of changes:*
1. Add a YAML parser while reading string YAML for otelConfig field for amazoncloudwatchagent. 
2. The toYAML function converts the string to a YAML as long as the string is correctly indented. **_Malformed strings will cause an error_**

*Testing*
```
helm upgrade --install  --debug --namespace amazon-cloudwatch amazon-cloudwatch-operator ./ --create-namespace --set region={regionName} --set clusterName={clusterName} --set agent.otelConfig='
extensions:
  health_check:
receivers:
  otlp:
exporters:
  awsemf:
service:
  pipelines:
    metrics/test:
      receivers: [otlp]
      exporters: [awsemf]
  extensions: [health_check]'
```

Cloudwatch Agent config-map
```

Data
====
cwagentotelconfig.yaml:
----
exporters:
  awsemf: null
extensions:
  health_check: null
receivers:
  otlp: null
service:
  extensions:
  - health_check
  pipelines:
    metrics/test:
      exporters:
      - awsemf
      receivers:
      - otlp
 ```

Negative testing
```
helm upgrade --install  --debug --namespace amazon-cloudwatch amazon-cloudwatch-operator ./ --create-namespace --set region=us-west-2 --set clusterName=my-dev-cluster --set agent.otelConfig='
extensions:
          health_check:
        receivers:
  otlp:
        exporters:
  awsemf:
service:
  pipelines:
    metrics/test:
      receivers: [otlp]
      exporters: [awsemf]
  extensions: [health_check]'
.
.
.
.
.

helm.go:84: [debug] template: amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml:49:17: executing "amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml" at <include "cloudwatch-agent.modify-yaml-config" (merge (dict "OtelConfig" .Values.agent.otelConfig) .)>: error calling include: template: amazon-cloudwatch-observability/templates/_helpers.tpl:55:28: executing "cloudwatch-agent.modify-yaml-config" at <$component>: range can't iterate over error converting YAML to JSON: yaml: line 3: found character that cannot start any token
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

