### PR TITLE
added latest fluent-bit config for application logs files to support sending entity

### DIFF
--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -121,6 +121,8 @@ containerLogs:
           [FILTER]
             Name                aws
             Match               application.*
+            az                  false
+            Enable_Entity       true
           
           [FILTER]
             Name                kubernetes
@@ -146,6 +148,7 @@ containerLogs:
             log_stream_prefix   ${HOST_NAME}-
             auto_create_group   true
             extra_user_agent    container-insights
+            add_entity          true
         dataplane-log.conf: |
           [INPUT]
             Name                systemd


### PR DESCRIPTION
*Issue #, if available:*
Update Fluent-bit config for application logs to support sending entity

*Description of changes:*
Added the required config

Testing:

tested with fluent-bit public image `public.ecr.aws/aws-observability/aws-for-fluent-bit:2.32.3`

Application Log group Insights for petclinic-app pod

<img width="1341" alt="Screenshot 2024-10-24 at 2 40 05 PM" src="https://github.com/user-attachments/assets/122eb630-ada8-4676-8a2c-b213a6267471">

Application Log message of petclinic-app pod
```
{
    "time": "2024-10-24T18:34:48.603721294Z",
    "stream": "stdout",
    "_p": "F",
    "log": "2024-10-24 18:34:48.603  INFO 1 --- [           main] com.amazon.sampleapp.FrontendService     : Started FrontendService in 4.79 seconds (JVM running for 9.874)",
    "kubernetes": {
        "pod_name": "petclinic-pod-j7z6f",
        "namespace_name": "default",
        "pod_id": "eed3a07a-4bf0-42c4-8654-400f8917a439",
        "host": "ip-192-168-54-165.ec2.internal",
        "container_name": "petclinic-container",
        "docker_id": "a7021bcb6f7e680ee4e70c043d0f86d1a9580626b812376bda13461ff347047e",
        "container_hash": "957688854012.dkr.ecr.us-east-1.amazonaws.com/petclinic-appsignal@sha256:e97a8f75060c61f24f9fcfb7affe3ce1d82008364d370fbfbcb6b00ec268e586",
        "container_image": "957688854012.dkr.ecr.us-east-1.amazonaws.com/petclinic-appsignal:latest"
    }
}
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

