### PR TITLE
Add agent server port for vending entity to fluent bit

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/certmanager.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/certmanager.yaml
@@ -63,6 +63,57 @@ spec:
     kind: Issuer
     name: "agent-ca"
   secretName: "amazon-cloudwatch-observability-agent-cert"
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    {{- include "amazon-cloudwatch-observability.labels" . | nindent 4 }}
+  name: "amazon-cloudwatch-observability-agent-server-cert"
+  namespace: {{ .Release.Namespace }}
+spec:
+  commonName: "agent-server"
+  dnsNames:
+    - "cloudwatch-agent"
+    - "cloudwatch-agent.amazon-cloudwatch.svc"
+  issuerRef:
+    kind: Issuer
+    name: "agent-ca"
+  secretName: "amazon-cloudwatch-observability-agent-server-cert"
+  usages:
+    - digital signature
+    - key encipherment
+    - cert sign
+  keyUsages:
+    critical: true
+    usages:
+      - digitalSignature
+      - keyEncipherment
+      - certSign
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    {{- include "amazon-cloudwatch-observability.labels" . | nindent 4 }}
+  name: "amazon-cloudwatch-observability-agent-client-cert"
+  namespace: {{ .Release.Namespace }}
+spec:
+  commonName: "agent-client"
+  issuerRef:
+    kind: Issuer
+    name: "agent-ca"
+  secretName:  "amazon-cloudwatch-observability-agent-client-cert"
+  usages:
+    - digital signature
+    - key encipherment
+    - cert sign
+  keyUsages:
+    critical: true
+    usages:
+      - digitalSignature
+      - keyEncipherment
+      - certSign
 {{- if not .Values.agent.certManager.issuerRef }}
 ---
 apiVersion: cert-manager.io/v1
@@ -86,6 +137,22 @@ metadata:
   labels:
     {{- include "amazon-cloudwatch-observability.labels" . | nindent 4 }}
   name: "amazon-cloudwatch-observability-agent-cert"
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    {{- include "amazon-cloudwatch-observability.labels" . | nindent 4 }}
+  name: "amazon-cloudwatch-observability-agent-server-cert"
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    {{- include "amazon-cloudwatch-observability.labels" . | nindent 4 }}
+  name:  "amazon-cloudwatch-observability-agent-client-cert"
   namespace: {{ .Release.Namespace }}
 {{- end }}
 

--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-daemonset.yaml
@@ -1,8 +1,11 @@
 {{- if .Values.agent.enabled }}
 {{- if and (.Values.agent.autoGenerateCert.enabled) (not .Values.agent.certManager.enabled) -}}
 {{- $altNames := list ( printf "%s-service" (include "dcgm-exporter.name" .) ) ( printf "%s-service" (include "neuron-monitor.name" .) ) ( printf "%s-service.%s.svc" (include "dcgm-exporter.name" .) .Release.Namespace ) ( printf "%s-service.%s.svc" (include "neuron-monitor.name" .) .Release.Namespace ) -}}
+{{- $agentAltNames := list ( printf "%s" (include "cloudwatch-agent.name" .) ) ( printf "%s.%s.svc" (include "cloudwatch-agent.name" .) .Release.Namespace ) -}}
 {{- $ca := genCA ("agent-ca")  ( .Values.agent.autoGenerateCert.expiryDays | int ) -}}
 {{- $cert := genSignedCert ("agent") nil $altNames ( .Values.admissionWebhooks.autoGenerateCert.expiryDays | int ) $ca -}}
+{{- $serverCert := genSignedCert ("agent-server") nil $agentAltNames ( .Values.admissionWebhooks.autoGenerateCert.expiryDays | int ) $ca -}}
+{{- $clientCert := genSignedCert ("agent-client") nil nil ( .Values.admissionWebhooks.autoGenerateCert.expiryDays | int ) $ca -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -14,6 +17,30 @@ data:
   ca.crt: {{ $ca.Cert | b64enc }}
   tls.crt: {{ $cert.Cert | b64enc }}
   tls.key: {{ $cert.Key | b64enc }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+      {{- include "amazon-cloudwatch-observability.labels" . | nindent 4}}
+  name: "amazon-cloudwatch-observability-agent-server-cert"
+  namespace: {{ .Release.Namespace }}
+data:
+  ca.crt: {{ $ca.Cert | b64enc }}
+  tls.crt: {{ $serverCert.Cert | b64enc }}
+  tls.key: {{ $serverCert.Key | b64enc }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+      {{- include "amazon-cloudwatch-observability.labels" . | nindent 4}}
+  name: "amazon-cloudwatch-observability-agent-client-cert"
+  namespace: {{ .Release.Namespace }}
+data:
+  ca.crt: {{ $ca.Cert | b64enc }}
+  tls.crt: {{ $clientCert.Cert | b64enc }}
+  tls.key: {{ $clientCert.Key | b64enc }}
 ---
 {{- end -}}
 
@@ -69,6 +96,12 @@ spec:
   - mountPath: /etc/amazon-cloudwatch-observability-agent-cert
     name: agenttls
     readOnly: true
+  - mountPath: /etc/amazon-cloudwatch-observability-agent-client-cert
+    name: agentclienttls
+    readOnly: true
+  - mountPath: /etc/amazon-cloudwatch-observability-agent-server-cert
+    name: agentservertls
+    readOnly: true
   - mountPath: /var/lib/kubelet/pod-resources
     name: kubelet-podresources
   volumes:
@@ -100,6 +133,20 @@ spec:
       items:
         - key: ca.crt
           path: tls-ca.crt
+  - name: agentclienttls
+    secret:
+      secretName: amazon-cloudwatch-observability-agent-client-cert
+      items:
+        - key: ca.crt
+          path: tls-ca.crt
+  - name: agentservertls
+    secret:
+      secretName: amazon-cloudwatch-observability-agent-server-cert
+      items:
+        - key: tls.crt
+          path: server.crt
+        - key: tls.key
+          path: server.key
   env:
   - name: K8S_NODE_NAME
     valueFrom:

--- a/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
@@ -68,6 +68,12 @@ spec:
         - name: dmesg
           mountPath: /var/log/dmesg
           readOnly: true
+        - mountPath: /etc/amazon-cloudwatch-observability-agent-client-cert
+          name: agentclienttls
+          readOnly: true
+        - mountPath: /etc/amazon-cloudwatch-observability-agent-server-cert
+          name: agentservertls
+          readOnly: true
       terminationGracePeriodSeconds: 10
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
@@ -90,6 +96,20 @@ spec:
       - name: dmesg
         hostPath:
           path: /var/log/dmesg
+      - name: agentclienttls
+        secret:
+          secretName: amazon-cloudwatch-observability-agent-client-cert
+          items:
+            - key: tls.crt
+              path: client.crt
+            - key: tls.key
+              path: client.key
+      - name: agentservertls
+        secret:
+          secretName: amazon-cloudwatch-observability-agent-server-cert
+          items:
+            - key: ca.crt
+              path: tls-ca.crt
       serviceAccountName: {{ template "cloudwatch-agent.serviceAccountName" . }}
       affinity:
         nodeAffinity:

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -121,6 +121,8 @@ containerLogs:
           [FILTER]
             Name                aws
             Match               application.*
+            az                  false
+            Enable_Entity       true
           
           [FILTER]
             Name                kubernetes
@@ -146,6 +148,7 @@ containerLogs:
             log_stream_prefix   ${HOST_NAME}-
             auto_create_group   true
             extra_user_agent    container-insights
+            add_entity          true
         dataplane-log.conf: |
           [INPUT]
             Name                systemd

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -119,6 +119,10 @@ containerLogs:
             Read_from_Head      ${READ_FROM_HEAD}
           
           [FILTER]
+            Name                aws
+            Match               application.*
+          
+          [FILTER]
             Name                kubernetes
             Match               application.*
             Kube_URL            https://kubernetes.default.svc:443
@@ -132,6 +136,7 @@ containerLogs:
             Use_Kubelet         On
             Kubelet_Port        10250
             Buffer_Size         0
+            Use_Pod_Association On
           
           [OUTPUT]
             Name                cloudwatch_logs

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -32,7 +32,7 @@ containerLogs:
   fluentBit:
     image:
       repository: aws-for-fluent-bit
-      tag: 2.32.2.20240627
+      tag: 2.32.4
       tagWindows: 2.31.12-windowsservercore
       repositoryDomainMap:
         public: public.ecr.aws/aws-observability

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -122,6 +122,7 @@ containerLogs:
             Name                aws
             Match               application.*
             az                  false
+            ec2_instance_id     false
             Enable_Entity       true
           
           [FILTER]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Adds certificates for agent server port that exposes service name per instrumented pod 
- Adds fluent bit configuration to retrieve service name from the agent server port to populate entity to CW Logs


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

