### PR TITLE
[TA] TLS Cert Generation for Multiple Target Allocator Services

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/certmanager.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/certmanager.yaml
@@ -55,6 +55,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   dnsNames:
+    {{- range $i, $customAgent := .Values.agents }}
+    - {{( printf "%s-target-allocator-service" $customAgent.name )}}
+    {{- end }}
     - "dcgm-exporter-service"
     - "dcgm-exporter-service.amazon-cloudwatch.svc"
     - "neuron-monitor-service"

--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
@@ -1,6 +1,9 @@
 {{- if .Values.agent.enabled }}
 {{- if and (.Values.agent.autoGenerateCert.enabled) (not .Values.agent.certManager.enabled) -}}
 {{- $altNames := list ( printf "%s-service" (include "dcgm-exporter.name" .) ) ( printf "%s-service" (include "neuron-monitor.name" .) ) ( printf "%s-service.%s.svc" (include "dcgm-exporter.name" .) .Release.Namespace ) ( printf "%s-service.%s.svc" (include "neuron-monitor.name" .) .Release.Namespace ) -}}
+{{- range $i, $customAgent := .Values.agents }}
+{{ $altNames = append $altNames ( printf "%s-target-allocator-service" $customAgent.name )}}
+{{- end }}
 {{- $ca := genCA ("agent-ca")  ( .Values.agent.autoGenerateCert.expiryDays | int ) -}}
 {{- $cert := genSignedCert ("agent") nil $altNames ( .Values.admissionWebhooks.autoGenerateCert.expiryDays | int ) $ca -}}
 apiVersion: v1


### PR DESCRIPTION
*Issue #, if available:*
Currently, we cannot support TLS for target allocator because TLS certs are not accepting TA service as a valid dns. This PR dynamically generates the TA service dns' for each agent that uses TA.
*Description of changes:*
* Updated Cert Manager to generate TA dns.
* Updated key generation to generate TA dns.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

