### PR TITLE
disabled ec2_instance_id flag to retrieve behind entity flag in aws filter plugin for fluent bit application logs

### DIFF
--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -122,6 +122,7 @@ containerLogs:
             Name                aws
             Match               application.*
             az                  false
+            ec2_instance_id     false
             Enable_Entity       true
           
           [FILTER]


### PR DESCRIPTION
*Issue #, if available:*
After recent fluent-bit changes, to retrieve instance id behind enable entity flag, we need to disable the default ec2_instance_id flag to avoid additional ec2_instance_id in fluent-bit application logs.
*Description of changes:*
Updated fluent-bit config to disable the ec2_instance_id on aws plugin

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

