### PR TITLE
Remove keyUsages in favor of usages in cert manager template

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/certmanager.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/certmanager.yaml
@@ -84,12 +84,6 @@ spec:
     - digital signature
     - key encipherment
     - cert sign
-  keyUsages:
-    critical: true
-    usages:
-      - digitalSignature
-      - keyEncipherment
-      - certSign
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -108,12 +102,6 @@ spec:
     - digital signature
     - key encipherment
     - cert sign
-  keyUsages:
-    critical: true
-    usages:
-      - digitalSignature
-      - keyEncipherment
-      - certSign
 {{- if not .Values.agent.certManager.issuerRef }}
 ---
 apiVersion: cert-manager.io/v1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
keyUsages is not present in the `certificates.cert-manager.io` crd. This causes issues with helm installation:

```
Error from server: failed to create typed patch object (amazon-cloudwatch/amazon-cloudwatch-observability-agent-server-cert; cert-manager.io/v1, Kind=Certificate): .spec.keyUsages: field not declared in schema
Error from server: failed to create typed patch object (amazon-cloudwatch/amazon-cloudwatch-observability-agent-client-cert; cert-manager.io/v1, Kind=Certificate): .spec.keyUsages: field not declared in schema
```

Issue from cert-manager: https://github.com/cert-manager/cert-manager/issues/2407#issuecomment-559579095


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

