### PR TITLE
Add slack bot

### DIFF
--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -82,7 +82,16 @@ jobs:
           cmd: yq '${{ matrix.container_images.tag }}' charts/amazon-cloudwatch-observability/values.yaml
 
       - name: "Scan for vulnerabilities"
+        id: scan
         uses: crazy-max/ghaction-container-scan@v3
         with:
           image: ${{ steps.registry.outputs.result }}/${{ steps.repository.outputs.result }}:${{ steps.tag.outputs.result }}
           severity_threshold: HIGH
+      - name: "Send slack message"
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            status: "${{ steps.scan.outputs.json }}"
+            option: "false"

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -89,6 +89,7 @@ jobs:
           severity_threshold: HIGH
           annotations: true
       - run: cat ${{ steps.scan.outputs.json }}
+        if: success() || failure()
       # from https://stackoverflow.com/questions/61919141/read-json-file-in-github-actions
       - run: echo "SCAN_RESULT=$(jq -r '.[] | "**\(.ArtifactName)**:\n" + ( .Results // empty | .[] | select(.Vulnerabilities != null) | .Vulnerabilities[] | "- \(.VulnerabilityID)" ) | @text' ${{ steps.scan.outputs.json }})" >> $GITHUB_ENV
         if: success() || failure()

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -91,7 +91,11 @@ jobs:
       - run: cat ${{ steps.scan.outputs.json }}
         if: success() || failure()
       # from https://stackoverflow.com/questions/61919141/read-json-file-in-github-actions
-      - run: echo "SCAN_RESULT=$(jq -rs '"**\(.ArtifactName)**:\n", ( .Results | .[] | select(.Vulnerabilities != null) | .Vulnerabilities[] | "- \(.VulnerabilityID)" ) | @text' ${{ steps.scan.outputs.json }})" >> $GITHUB_ENV
+      - run: |
+          SCAN_RESULT=$(jq -rs '"**\(.ArtifactName)**:\n", ( .Results | .[] | select(.Vulnerabilities != null) | .Vulnerabilities[] | "- \(.VulnerabilityID)" ) | @text' ${{ steps.scan.outputs.json }})
+          echo "SCAN_RESULT<<EOF" >> $GITHUB_ENV
+          echo "$SCAN_RESULT" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
         if: success() || failure()
       - if: success() || failure()
         run: |

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -91,7 +91,7 @@ jobs:
       - run: cat ${{ steps.scan.outputs.json }}
         if: success() || failure()
       # from https://stackoverflow.com/questions/61919141/read-json-file-in-github-actions
-      - run: echo "SCAN_RESULT=$(jq -r '.[] | "**\(.ArtifactName)**:\n" + ( .Results // empty | .[] | select(.Vulnerabilities != null) | .Vulnerabilities[] | "- \(.VulnerabilityID)" ) | @text' ${{ steps.scan.outputs.json }})" >> $GITHUB_ENV
+      - run: echo "SCAN_RESULT=$(jq -r '"**\(.ArtifactName)**:\n", ( .Results | .[] | select(.Vulnerabilities != null) | .Vulnerabilities[] | "- \(.VulnerabilityID)" ) | @text' ${{ steps.scan.outputs.json }})" >> $GITHUB_ENV
         if: success() || failure()
       - if: success() || failure()
         run: |

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -89,7 +89,7 @@ jobs:
           severity_threshold: HIGH
           annotations: true
       # from https://stackoverflow.com/questions/61919141/read-json-file-in-github-actions
-      - run: echo "SCAN_RESULT=$(jq -cRs  . ${{ steps.scan.outputs.json }})" >> $GITHUB_ENV
+      - run: echo "SCAN_RESULT=$(jq -s  . ${{ steps.scan.outputs.json }})" >> $GITHUB_ENV
         if: success() || failure()
       - if: success() || failure()
         run: |
@@ -101,4 +101,5 @@ jobs:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: webhook-trigger
           payload: |
-            results: '${{ env.SCAN_RESULT }}'
+            results: >-
+             ${{ env.SCAN_RESULT }}

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -82,16 +82,8 @@ jobs:
           cmd: yq '${{ matrix.container_images.tag }}' charts/amazon-cloudwatch-observability/values.yaml
 
       - name: "Scan for vulnerabilities"
-        id: scan
         uses: crazy-max/ghaction-container-scan@v3
         with:
           image: ${{ steps.registry.outputs.result }}/${{ steps.repository.outputs.result }}:${{ steps.tag.outputs.result }}
           severity_threshold: HIGH
-      - name: "Send slack message"
-        uses: slackapi/slack-github-action@v2.0.0
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          webhook-type: webhook-trigger
-          payload: |
-            status: "${{ steps.scan.outputs.json }}"
-            option: "false"
+          annotations: true

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -88,6 +88,7 @@ jobs:
           image: ${{ steps.registry.outputs.result }}/${{ steps.repository.outputs.result }}:${{ steps.tag.outputs.result }}
           severity_threshold: HIGH
           annotations: true
+      - run: echo $(jq -r . ${{ steps.scan.outputs.json }})
       # from https://stackoverflow.com/questions/61919141/read-json-file-in-github-actions
       - run: echo "SCAN_RESULT=$(jq -r '.[] | "**\(.ArtifactName)**:\n" + ( .Results // empty | .[] | select(.Vulnerabilities != null) | .Vulnerabilities[] | "- \(.VulnerabilityID)" ) | @text' ${{ steps.scan.outputs.json }})" >> $GITHUB_ENV
         if: success() || failure()

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -88,9 +88,17 @@ jobs:
           image: ${{ steps.registry.outputs.result }}/${{ steps.repository.outputs.result }}:${{ steps.tag.outputs.result }}
           severity_threshold: HIGH
           annotations: true
-      -
-        name: Upload SARIF file
-        if: ${{ steps.scan.outputs.sarif != '' }}
-        uses: github/codeql-action/upload-sarif@v2
+      # from https://stackoverflow.com/questions/61919141/read-json-file-in-github-actions
+      - run: echo "SCAN_RESULT=$(jq -cR . < ${{ steps.scan.outputs.json }})" >> $GITHUB_ENV
+        if: success() || failure()
+      - if: success() || failure()
+        run: |
+          echo '${{ env.SCAN_RESULT }}'
+      - name: Send a saved artifact to a Slack workflow
+        if: success() || failure()
+        uses: slackapi/slack-github-action@v2.0.0
         with:
-          sarif_file: ${{ steps.scan.outputs.sarif }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            results: '${{ env.SCAN_RESULT }}'

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -92,7 +92,7 @@ jobs:
         if: success() || failure()
       # from https://stackoverflow.com/questions/61919141/read-json-file-in-github-actions
       - run: |
-          SCAN_RESULT=$(jq -rs '"**\(.ArtifactName)**:\n", ( .Results | .[] | select(.Vulnerabilities != null) | .Vulnerabilities[] | "- \(.VulnerabilityID)" ) | @text' ${{ steps.scan.outputs.json }})
+          SCAN_RESULT=$(SCAN_RESULT=$(jq -r '"**\(.ArtifactName)**:\n", ( .Results | .[] | select(.Vulnerabilities != null) | .Vulnerabilities[] | "- \(.VulnerabilityID)" ) | @text' ${{ steps.scan.outputs.json }})
           echo "SCAN_RESULT<<EOF" >> $GITHUB_ENV
           echo "$SCAN_RESULT" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -91,7 +91,7 @@ jobs:
       # from https://stackoverflow.com/questions/61919141/read-json-file-in-github-actions
       - run: |
           echo 'SCAN_RESULT<<EOF' >> $GITHUB_ENV
-          cat $${{ steps.scan.outputs.json }} >> $GITHUB_ENV
+          cat ${{ steps.scan.outputs.json }} >> $GITHUB_ENV
           echo 'EOF' >> $SCAN_RESULT
       - run: |
           echo '${{ fromJson(env.SCAN_RESULT).version }}'

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -105,12 +105,7 @@ jobs:
         uses: slackapi/slack-github-action@v2.0.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
+          webhook-type: webhook-trigger
           payload: |
-            text: "Image Security Status"
-            blocks:
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: |
-                    ${{ env.SCAN_RESULT }}
+            results: >-
+             ${{ env.SCAN_RESULT }}

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -108,4 +108,4 @@ jobs:
           webhook-type: webhook-trigger
           payload: |
             results: >-
-             ${{ env.SCAN_RESULT }}
+               ${{ env.SCAN_RESULT }}

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -92,7 +92,7 @@ jobs:
         if: success() || failure()
       # from https://stackoverflow.com/questions/61919141/read-json-file-in-github-actions
       - run: |
-          SCAN_RESULT=$(jq -r '{results: ("\(.ArtifactName):\n" + (.Results | .[] | select(.Vulnerabilities != null) | .Vulnerabilities | map(.VulnerabilityID) | join(", ")))}' ${{ steps.scan.outputs.json }})
+          SCAN_RESULT=$(jq -cr '"\(.ArtifactName): " + (.Results | .[] | select(.Vulnerabilities != null) | .Vulnerabilities | map(.VulnerabilityID) | join(", "))' ${{ steps.scan.outputs.json }})
           echo "SCAN_RESULT<<EOF" >> $GITHUB_ENV
           echo "$SCAN_RESULT" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -101,7 +101,7 @@ jobs:
         run: |
           echo '${{ env.SCAN_RESULT }}'
       - name: Send a saved artifact to a Slack workflow
-        if: success() || failure() || ${{ env.SCAN_RESULT != '' }} 
+        if: (success() || failure()) && ${{ env.SCAN_RESULT != '' }} 
         run: |
           curl -X POST "${{ secrets.SLACK_WEBHOOK_URL }}" \
             -H "Content-Type: application/json" \

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -88,17 +88,9 @@ jobs:
           image: ${{ steps.registry.outputs.result }}/${{ steps.repository.outputs.result }}:${{ steps.tag.outputs.result }}
           severity_threshold: HIGH
           annotations: true
-      # from https://stackoverflow.com/questions/61919141/read-json-file-in-github-actions
-      - run: echo "SCAN_RESULT=$(jq -c . < ${{ steps.scan.outputs.json }})" >> $GITHUB_ENV
-        if: success() || failure()
-      - if: success() || failure()
-        run: |
-          echo '${{ env.SCAN_RESULT }}'
-      - name: Send a saved artifact to a Slack workflow
-        if: success() || failure()
-        uses: slackapi/slack-github-action@v2.0.0
+      -
+        name: Upload SARIF file
+        if: ${{ steps.scan.outputs.sarif != '' }}
+        uses: github/codeql-action/upload-sarif@v2
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          webhook-type: webhook-trigger
-          payload: |
-            results: '${{ env.SCAN_RESULT }}'
+          sarif_file: ${{ steps.scan.outputs.sarif }}

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -99,10 +99,11 @@ jobs:
           content="${content//$'\r'/'%0D'}"
           # end of optional handling for multi line json
           echo "::set-output name=content::$content"
+          echo "$content"
       - name: Send a saved artifact to a Slack workflow
         uses: slackapi/slack-github-action@v2.0.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: webhook-trigger
           payload: |
-            results: "${{ steps.set_var.outputs.content }}"
+            results: "${{ fromJson(steps.set_var.outputs.content) }}"

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -89,7 +89,7 @@ jobs:
           severity_threshold: HIGH
           annotations: true
       - name: Send a saved artifact to a Slack workflow
-        uses: slackapi/slack-github-action@v3
+        uses: slackapi/slack-github-action@v2.0.0
         with:
           payload-file-path: ${{ steps.scan.outputs.json }}
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -92,9 +92,10 @@ jobs:
       - run: |
           echo 'SCAN_RESULT<<EOF' >> $GITHUB_ENV
           cat ${{ steps.scan.outputs.json }} >> $GITHUB_ENV
-          echo 'EOF' >> $SCAN_RESULT
+          echo '\nEOF' >> $GITHUB_ENV
       - run: |
-          echo '${{ fromJson(env.SCAN_RESULT).version }}'
+          echo '${{ fromJson(env.SCAN_RESULT) }}'
+          echo '${{ env.SCAN_RESULT }}'
       - name: Send a saved artifact to a Slack workflow
         uses: slackapi/slack-github-action@v2.0.0
         with:

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -92,7 +92,7 @@ jobs:
         if: success() || failure()
       # from https://stackoverflow.com/questions/61919141/read-json-file-in-github-actions
       - run: |
-          SCAN_RESULT=$(jq -r '"**\(.ArtifactName)**:", ( .Results | .[] | select(.Vulnerabilities != null) | .Vulnerabilities[] | "- \(.VulnerabilityID)" ) | @text' ${{ steps.scan.outputs.json }})
+          SCAN_RESULT=$(jq -r '"\(.ArtifactName):", ( .Results | .[] | select(.Vulnerabilities != null) | .Vulnerabilities[] | "* \(.VulnerabilityID)" ) | @text' ${{ steps.scan.outputs.json }})
           echo "SCAN_RESULT<<EOF" >> $GITHUB_ENV
           echo "$SCAN_RESULT" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -91,7 +91,7 @@ jobs:
       - run: cat ${{ steps.scan.outputs.json }}
         if: success() || failure()
       # from https://stackoverflow.com/questions/61919141/read-json-file-in-github-actions
-      - run: echo "SCAN_RESULT=$(jq -r '"**\(.ArtifactName)**:\n", ( .Results | .[] | select(.Vulnerabilities != null) | .Vulnerabilities[] | "- \(.VulnerabilityID)" ) | @text' ${{ steps.scan.outputs.json }})" >> $GITHUB_ENV
+      - run: echo "SCAN_RESULT=$(jq -rs '"**\(.ArtifactName)**:\n", ( .Results | .[] | select(.Vulnerabilities != null) | .Vulnerabilities[] | "- \(.VulnerabilityID)" ) | @text' ${{ steps.scan.outputs.json }})" >> $GITHUB_ENV
         if: success() || failure()
       - if: success() || failure()
         run: |

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -102,10 +102,7 @@ jobs:
           echo '${{ env.SCAN_RESULT }}'
       - name: Send a saved artifact to a Slack workflow
         if: success() || failure()
-        uses: slackapi/slack-github-action@v2.0.0
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          webhook-type: webhook-trigger
-          payload: |
-            results: |
-               ${{ env.SCAN_RESULT }}
+        run: |
+          curl -X POST "${{ secrets.SLACK_WEBHOOK_URL }}" \
+            -H "Content-Type: application/json" \
+            -d '{"results": "${{ env.SCAN_RESULT }}"}'

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -89,7 +89,7 @@ jobs:
           severity_threshold: HIGH
           annotations: true
       # from https://stackoverflow.com/questions/61919141/read-json-file-in-github-actions
-      - run: echo "SCAN_RESULT=$(jq -sc  . ${{ steps.scan.outputs.json }})" >> $GITHUB_ENV
+      - run: echo "SCAN_RESULT=$(jq -r '.[] | "**\(.ArtifactName)**:\n" + (.Results[] | select(.Vulnerabilities != null) | .Vulnerabilities[] | "- \(.VulnerabilityID)\n" ) | @text' ${{ steps.scan.outputs.json }})" >> $GITHUB_ENV
         if: success() || failure()
       - if: success() || failure()
         run: |

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -90,7 +90,9 @@ jobs:
           annotations: true
       # from https://stackoverflow.com/questions/61919141/read-json-file-in-github-actions
       - run: echo "SCAN_RESULT=$(jq -c . < ${{ steps.scan.outputs.json }})" >> $GITHUB_ENV
-      - run: |
+        if: success() || failure()
+      - if: success() || failure()
+        run: |
           echo '${{ env.SCAN_RESULT }}'
       - name: Send a saved artifact to a Slack workflow
         if: success() || failure()

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -89,21 +89,16 @@ jobs:
           severity_threshold: HIGH
           annotations: true
       # from https://stackoverflow.com/questions/61919141/read-json-file-in-github-actions
-      - name: "Read json file"
-        id: set_var
-        run: |
-          content=`cat ${{ steps.scan.outputs.json }}`
-          # the following lines are only required for multi line json
-          content="${content//'%'/'%25'}"
-          content="${content//$'\n'/'%0A'}"
-          content="${content//$'\r'/'%0D'}"
-          # end of optional handling for multi line json
-          echo "::set-output name=content::$content"
-          echo "$content"
+      - run: |
+          echo 'SCAN_RESULT<<EOF' >> $GITHUB_ENV
+          cat $${{ steps.scan.outputs.json }} >> $GITHUB_ENV
+          echo 'EOF' >> $SCAN_RESULT
+      - run: |
+          echo '${{ fromJson(env.SCAN_RESULT).version }}'
       - name: Send a saved artifact to a Slack workflow
         uses: slackapi/slack-github-action@v2.0.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: webhook-trigger
           payload: |
-            results: "${{ fromJson(steps.set_var.outputs.content) }}"
+            results: "${{ env.SCAN_RESULT }}"

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -91,7 +91,6 @@ jobs:
       # from https://stackoverflow.com/questions/61919141/read-json-file-in-github-actions
       - run: echo "SCAN_RESULT=$(jq -c . < ${{ steps.scan.outputs.json }})" >> $GITHUB_ENV
       - run: |
-          echo '${{ fromJson(env.SCAN_RESULT) }}'
           echo '${{ env.SCAN_RESULT }}'
       - name: Send a saved artifact to a Slack workflow
         uses: slackapi/slack-github-action@v2.0.0
@@ -99,4 +98,4 @@ jobs:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: webhook-trigger
           payload: |
-            results: "${{ env.SCAN_RESULT }}"
+            results: '${{ env.SCAN_RESULT }}'

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -92,7 +92,7 @@ jobs:
         if: success() || failure()
       # from https://stackoverflow.com/questions/61919141/read-json-file-in-github-actions
       - run: |
-          SCAN_RESULT=$(jq -r '"**\(.ArtifactName)**:\n", ( .Results | .[] | select(.Vulnerabilities != null) | .Vulnerabilities[] | "- \(.VulnerabilityID)" ) | @text' ${{ steps.scan.outputs.json }})
+          SCAN_RESULT=$(jq -r '"**\(.ArtifactName)**:", ( .Results | .[] | select(.Vulnerabilities != null) | .Vulnerabilities[] | "- \(.VulnerabilityID)" ) | @text' ${{ steps.scan.outputs.json }})
           echo "SCAN_RESULT<<EOF" >> $GITHUB_ENV
           echo "$SCAN_RESULT" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
@@ -105,7 +105,12 @@ jobs:
         uses: slackapi/slack-github-action@v2.0.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          webhook-type: webhook-trigger
+          webhook-type: incoming-webhook
           payload: |
-            results: >-
-             ${{ env.SCAN_RESULT }}
+            text: "Image Security Status"
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: |
+                    ${{ env.SCAN_RESULT }}

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -93,6 +93,7 @@ jobs:
       - run: |
           echo '${{ env.SCAN_RESULT }}'
       - name: Send a saved artifact to a Slack workflow
+        if: success() || failure()
         uses: slackapi/slack-github-action@v2.0.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -92,7 +92,7 @@ jobs:
         if: success() || failure()
       # from https://stackoverflow.com/questions/61919141/read-json-file-in-github-actions
       - run: |
-          SCAN_RESULT=$(jq -r '{results: ("\(.ArtifactName):\n" + (.Results | .[] | select(.Vulnerabilities != null) | .Vulnerabilities | map(.VulnerabilityID) | join(", ")))}' ${{ steps.scan.outputs.json }} ${{ steps.scan.outputs.json }})
+          SCAN_RESULT=$(jq -r '{results: ("\(.ArtifactName):\n" + (.Results | .[] | select(.Vulnerabilities != null) | .Vulnerabilities | map(.VulnerabilityID) | join(", ")))}' ${{ steps.scan.outputs.json }})
           echo "SCAN_RESULT<<EOF" >> $GITHUB_ENV
           echo "$SCAN_RESULT" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -89,7 +89,7 @@ jobs:
           severity_threshold: HIGH
           annotations: true
       # from https://stackoverflow.com/questions/61919141/read-json-file-in-github-actions
-      - run: echo "SCAN_RESULT=$(jq -s  . ${{ steps.scan.outputs.json }})" >> $GITHUB_ENV
+      - run: echo "SCAN_RESULT=$(jq -sc  . ${{ steps.scan.outputs.json }})" >> $GITHUB_ENV
         if: success() || failure()
       - if: success() || failure()
         run: |

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -88,7 +88,7 @@ jobs:
           image: ${{ steps.registry.outputs.result }}/${{ steps.repository.outputs.result }}:${{ steps.tag.outputs.result }}
           severity_threshold: HIGH
           annotations: true
-      - run: echo $(jq -rs . ${{ steps.scan.outputs.json }})
+      - run: cat ${{ steps.scan.outputs.json }}
       # from https://stackoverflow.com/questions/61919141/read-json-file-in-github-actions
       - run: echo "SCAN_RESULT=$(jq -r '.[] | "**\(.ArtifactName)**:\n" + ( .Results // empty | .[] | select(.Vulnerabilities != null) | .Vulnerabilities[] | "- \(.VulnerabilityID)" ) | @text' ${{ steps.scan.outputs.json }})" >> $GITHUB_ENV
         if: success() || failure()

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -92,7 +92,7 @@ jobs:
         if: success() || failure()
       # from https://stackoverflow.com/questions/61919141/read-json-file-in-github-actions
       - run: |
-          SCAN_RESULT=$(jq -r '"\(.ArtifactName):", ( .Results | .[] | select(.Vulnerabilities != null) | .Vulnerabilities[] | "* \(.VulnerabilityID)" ) | @text' ${{ steps.scan.outputs.json }})
+          SCAN_RESULT=$(jq -r '{results: ("\(.ArtifactName):\n" + (.Results | .[] | select(.Vulnerabilities != null) | .Vulnerabilities | map(.VulnerabilityID) | join(", ")))}' ${{ steps.scan.outputs.json }} ${{ steps.scan.outputs.json }})
           echo "SCAN_RESULT<<EOF" >> $GITHUB_ENV
           echo "$SCAN_RESULT" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -89,10 +89,7 @@ jobs:
           severity_threshold: HIGH
           annotations: true
       # from https://stackoverflow.com/questions/61919141/read-json-file-in-github-actions
-      - run: |
-          echo 'SCAN_RESULT<<EOF' >> $GITHUB_ENV
-          cat ${{ steps.scan.outputs.json }} >> $GITHUB_ENV
-          echo '\nEOF' >> $GITHUB_ENV
+      - run: echo "SCAN_RESULT=$(jq -c . < ${{ steps.scan.outputs.json }})" >> $GITHUB_ENV
       - run: |
           echo '${{ fromJson(env.SCAN_RESULT) }}'
           echo '${{ env.SCAN_RESULT }}'

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -88,7 +88,7 @@ jobs:
           image: ${{ steps.registry.outputs.result }}/${{ steps.repository.outputs.result }}:${{ steps.tag.outputs.result }}
           severity_threshold: HIGH
           annotations: true
-      - run: echo $(jq -r . ${{ steps.scan.outputs.json }})
+      - run: echo $(jq -rs . ${{ steps.scan.outputs.json }})
       # from https://stackoverflow.com/questions/61919141/read-json-file-in-github-actions
       - run: echo "SCAN_RESULT=$(jq -r '.[] | "**\(.ArtifactName)**:\n" + ( .Results // empty | .[] | select(.Vulnerabilities != null) | .Vulnerabilities[] | "- \(.VulnerabilityID)" ) | @text' ${{ steps.scan.outputs.json }})" >> $GITHUB_ENV
         if: success() || failure()

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -92,7 +92,7 @@ jobs:
         if: success() || failure()
       # from https://stackoverflow.com/questions/61919141/read-json-file-in-github-actions
       - run: |
-          SCAN_RESULT=$(SCAN_RESULT=$(jq -r '"**\(.ArtifactName)**:\n", ( .Results | .[] | select(.Vulnerabilities != null) | .Vulnerabilities[] | "- \(.VulnerabilityID)" ) | @text' ${{ steps.scan.outputs.json }})
+          SCAN_RESULT=$(jq -r '"**\(.ArtifactName)**:\n", ( .Results | .[] | select(.Vulnerabilities != null) | .Vulnerabilities[] | "- \(.VulnerabilityID)" ) | @text' ${{ steps.scan.outputs.json }})
           echo "SCAN_RESULT<<EOF" >> $GITHUB_ENV
           echo "$SCAN_RESULT" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -92,7 +92,7 @@ jobs:
         if: success() || failure()
       # from https://stackoverflow.com/questions/61919141/read-json-file-in-github-actions
       - run: |
-          SCAN_RESULT=$(jq -cr '"\(.ArtifactName): " + (.Results | .[] | select(.Vulnerabilities != null) | .Vulnerabilities | map(.VulnerabilityID) | join(", "))' ${{ steps.scan.outputs.json }})
+          SCAN_RESULT=$(jq -cr '"\(.ArtifactName): " + (.Results | .[] | select(.Vulnerabilities != null) | .Vulnerabilities | map(.VulnerabilityID) | join(", "))' ${{ steps.scan.outputs.json }} | cut -c -2999)
           echo "SCAN_RESULT<<EOF" >> $GITHUB_ENV
           echo "$SCAN_RESULT" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
@@ -101,7 +101,7 @@ jobs:
         run: |
           echo '${{ env.SCAN_RESULT }}'
       - name: Send a saved artifact to a Slack workflow
-        if: success() || failure()
+        if: success() || failure() || ${{ env.SCAN_RESULT != '' }} 
         run: |
           curl -X POST "${{ secrets.SLACK_WEBHOOK_URL }}" \
             -H "Content-Type: application/json" \

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -82,8 +82,15 @@ jobs:
           cmd: yq '${{ matrix.container_images.tag }}' charts/amazon-cloudwatch-observability/values.yaml
 
       - name: "Scan for vulnerabilities"
+        id: scan
         uses: crazy-max/ghaction-container-scan@v3
         with:
           image: ${{ steps.registry.outputs.result }}/${{ steps.repository.outputs.result }}:${{ steps.tag.outputs.result }}
           severity_threshold: HIGH
           annotations: true
+      - name: Send a saved artifact to a Slack workflow
+        uses: slackapi/slack-github-action@v3
+        with:
+          payload-file-path: ${{ steps.scan.outputs.json }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -88,9 +88,21 @@ jobs:
           image: ${{ steps.registry.outputs.result }}/${{ steps.repository.outputs.result }}:${{ steps.tag.outputs.result }}
           severity_threshold: HIGH
           annotations: true
+      # from https://stackoverflow.com/questions/61919141/read-json-file-in-github-actions
+      - name: "Read json file"
+        id: set_var
+        run: |
+          content=`cat ${{ steps.scan.outputs.json }}`
+          # the following lines are only required for multi line json
+          content="${content//'%'/'%25'}"
+          content="${content//$'\n'/'%0A'}"
+          content="${content//$'\r'/'%0D'}"
+          # end of optional handling for multi line json
+          echo "::set-output name=content::$content"
       - name: Send a saved artifact to a Slack workflow
         uses: slackapi/slack-github-action@v2.0.0
         with:
-          payload-file-path: ${{ steps.scan.outputs.json }}
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: webhook-trigger
+          payload: |
+            results: "${{ steps.set_var.outputs.content }}"

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -107,5 +107,5 @@ jobs:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: webhook-trigger
           payload: |
-            results: >-
+            results: |
                ${{ env.SCAN_RESULT }}

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -101,7 +101,7 @@ jobs:
         run: |
           echo '${{ env.SCAN_RESULT }}'
       - name: Send a saved artifact to a Slack workflow
-        if: (success() || failure()) && ${{ env.SCAN_RESULT != '' }} 
+        if: ${{ env.SCAN_RESULT != '' }} 
         run: |
           curl -X POST "${{ secrets.SLACK_WEBHOOK_URL }}" \
             -H "Content-Type: application/json" \

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -101,7 +101,7 @@ jobs:
         run: |
           echo '${{ env.SCAN_RESULT }}'
       - name: Send a saved artifact to a Slack workflow
-        if: ${{ env.SCAN_RESULT != '' }} 
+        if: success() || failure()
         run: |
           curl -X POST "${{ secrets.SLACK_WEBHOOK_URL }}" \
             -H "Content-Type: application/json" \

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -89,7 +89,7 @@ jobs:
           severity_threshold: HIGH
           annotations: true
       # from https://stackoverflow.com/questions/61919141/read-json-file-in-github-actions
-      - run: echo "SCAN_RESULT=$(jq -r '.[] | "**\(.ArtifactName)**:\n" + (.Results[] | select(.Vulnerabilities != null) | .Vulnerabilities[] | "- \(.VulnerabilityID)\n" ) | @text' ${{ steps.scan.outputs.json }})" >> $GITHUB_ENV
+      - run: echo "SCAN_RESULT=$(jq -r '.[] | "**\(.ArtifactName)**:\n" + ( .Results // empty | .[] | select(.Vulnerabilities != null) | .Vulnerabilities[] | "- \(.VulnerabilityID)" ) | @text' ${{ steps.scan.outputs.json }})" >> $GITHUB_ENV
         if: success() || failure()
       - if: success() || failure()
         run: |

--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -89,7 +89,7 @@ jobs:
           severity_threshold: HIGH
           annotations: true
       # from https://stackoverflow.com/questions/61919141/read-json-file-in-github-actions
-      - run: echo "SCAN_RESULT=$(jq -cR . < ${{ steps.scan.outputs.json }})" >> $GITHUB_ENV
+      - run: echo "SCAN_RESULT=$(jq -cRs  . ${{ steps.scan.outputs.json }})" >> $GITHUB_ENV
         if: success() || failure()
       - if: success() || failure()
         run: |


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
- Added a step to extract the relevant vulnerability IDs from JSON report.
- Added a step to send the formatted scan results to Slack via a curl POST request, with the results included in the "results" key of the JSON payload.

These changes improve the scanning workflow and provide Slack notifications with scan results.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

