### PR TITLE
Remove unsupported metrics from neuron monitor config

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/linux/neuron-monitor-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/neuron-monitor-daemonset.yaml
@@ -82,12 +82,6 @@ spec:
       ],
       "system_metrics": [
         {
-          "type": "memory_info"
-        },
-        {
-          "type": "vcpu_usage"
-        },
-        {
           "period": "5s",
           "type": "neuron_hw_counters"
         }

--- a/charts/amazon-cloudwatch-observability/templates/linux/neuron-monitor-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/neuron-monitor-daemonset.yaml
@@ -75,9 +75,6 @@ spec:
               "type": "memory_used"
             },
             {
-              "type": "neuron_runtime_vcpu_usage"
-            },
-            {
               "type": "execution_stats"
             }
           ]
@@ -86,6 +83,9 @@ spec:
       "system_metrics": [
         {
           "type": "memory_info"
+        },
+        {
+          "type": "vcpu_usage"
         },
         {
           "period": "5s",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Remove `neuron_runtime_vcpu_usage` from supported metrics, as its not supported by neuron-monitor with-in a container.
- As the `neuron-monitor` runs with-in a container, it isn't usable for host level metrics like memory & cpu. Removed them from the supported `system_metrics`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

