### PR TITLE
Update CWAOperator default tolerations and CWA/FluentBit default PriorityClass

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -54,6 +54,3 @@ spec:
           secretName: {{ template "amazon-cloudwatch-observability.certificateSecretName" . }}
       nodeSelector:
         kubernetes.io/os: linux
-      {{- with .Values.tolerations }}
-      tolerations: {{- toYaml . | nindent 6}}
-      {{- end }}

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -47,7 +47,7 @@ containerLogs:
       requests:
         cpu: 50m
         memory: 25Mi
-    priorityClassName: ""
+    priorityClassName: "system-node-critical"
     config:
       service: |
         [SERVICE]
@@ -1198,7 +1198,7 @@ agent:
       us-gov-east-1: 743662458514.dkr.ecr.us-gov-east-1.amazonaws.com
       us-gov-west-1: 743662458514.dkr.ecr.us-gov-west-1.amazonaws.com
   enabled: true
-  priorityClassName: ""
+  priorityClassName: "system-node-critical"
   resources:
     requests:
       memory: "128Mi"


### PR DESCRIPTION
…riority class name to system-node-critical for CWA and FluentBit

*Issue #, if available:* https://github.com/aws-observability/helm-charts/issues/54

*Description of changes:*
* Default tolerations are mainly applicable for daemonsets deployed by the helm-chart / EKS add-on such as CloudWatchAgent and FluentBit. These should not apply to the CloudWatchAgentOperator deployment by default as this impacts scenarios such as a node draining.
* https://github.com/aws-observability/helm-charts/pull/70 introduced the ability to set the PriorityClass for the CloudWatchAgent and the FluentBit daemonsets, but set the default to "". Given observability agents are critical to the health of a cluster, this change updates these to run as "system-node-critical" by default.

Both of these changes will be included in the next major version bump of the helm-chart / EKS add-on.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

