### PR TITLE
Pass TA Image to Operator Deployment

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -32,6 +32,7 @@ spec:
         - "--auto-instrumentation-python-image={{ template "auto-instrumentation-python.image" . }}"
         - "--auto-instrumentation-dotnet-image={{ template "auto-instrumentation-dotnet.image" . }}"
         - "--auto-instrumentation-nodejs-image={{ template "auto-instrumentation-nodejs.image" . }}"
+        - "--target-allocator-image={{ template "target-allocator.modify-image" }}"
         - "--feature-gates=operator.autoinstrumentation.multi-instrumentation,operator.autoinstrumentation.multi-instrumentation.skip-container-validation"
         command:
         - /manager

--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -32,7 +32,7 @@ spec:
         - "--auto-instrumentation-python-image={{ template "auto-instrumentation-python.image" . }}"
         - "--auto-instrumentation-dotnet-image={{ template "auto-instrumentation-dotnet.image" . }}"
         - "--auto-instrumentation-nodejs-image={{ template "auto-instrumentation-nodejs.image" . }}"
-        - "--target-allocator-image={{ template "target-allocator.modify-image" }}"
+        - "--target-allocator-image={{ template "target-allocator.modify-image" . }}"
         - "--feature-gates=operator.autoinstrumentation.multi-instrumentation,operator.autoinstrumentation.multi-instrumentation.skip-container-validation"
         command:
         - /manager


### PR DESCRIPTION
*Description of changes:*
- Pass `target-allocator` image to `operator-deployment.yaml`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

