### PR TITLE
Merge agent overlays

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
@@ -86,38 +86,13 @@ Name for neuron-monitor
 {{/*
 Get the current recommended cloudwatch agent image for a region
 */}}
-{{- define "cloudwatch-agent.modify-image" -}}
-{{- $repository := .Values.agent.image.repository -}}
-{{- $tag := .Values.agent.image.tag -}}
-
-{{- if (.image) }}
-{{- $imageCopy := deepCopy .image }}
-{{- if hasKey $imageCopy "repository" }}
-{{- $repository = $imageCopy.repository -}}
-{{- end -}}
-{{- if hasKey $imageCopy "tag" }}
-{{- $tag =  $imageCopy.tag -}}
-{{- end -}}
-{{- end -}}
-
-{{- $imageDomain := "" -}}
-{{- $imageDomain = index .Values.agent.image.repositoryDomainMap .Values.region -}}
-{{- if not $imageDomain -}}
-{{- $imageDomain = .Values.agent.image.repositoryDomainMap.public -}}
-{{- end -}}
-{{- printf "%s/%s:%s" $imageDomain $repository $tag -}}
-{{- end -}}
-
-{{/*
-Get the current recommended cloudwatch agent image for a region
-*/}}
 {{- define "cloudwatch-agent.image" -}}
 {{- $imageDomain := "" -}}
-{{- $imageDomain = index .Values.agent.image.repositoryDomainMap .Values.region -}}
+{{- $imageDomain = index .repositoryDomainMap .region -}}
 {{- if not $imageDomain -}}
-{{- $imageDomain = .Values.agent.image.repositoryDomainMap.public -}}
+{{- $imageDomain = .repositoryDomainMap.public -}}
 {{- end -}}
-{{- printf "%s/%s:%s" $imageDomain .Values.agent.image.repository .Values.agent.image.tag -}}
+{{- printf "%s/%s:%s" $imageDomain .repository .tag -}}
 {{- end -}}
 
 {{/*
@@ -136,26 +111,13 @@ Get the current recommended cloudwatch agent operator image for a region
 {{/*
 Get the current recommended target allocator image for a region
 */}}
-{{- define "target-allocator.modify-image" -}}
-{{- $repository := .Values.agent.prometheus.targetAllocator.image.repository -}}
-{{- $tag := .Values.agent.prometheus.targetAllocator.image.tag -}}
-
-{{- if (.image) }}
-{{- $imageCopy := deepCopy .image }}
-{{- if hasKey $imageCopy "repository" }}
-{{- $repository = $imageCopy.repository -}}
-{{- end -}}
-{{- if hasKey $imageCopy "tag" }}
-{{- $tag =  $imageCopy.tag -}}
-{{- end -}}
-{{- end -}}
-
+{{- define "target-allocator.image" -}}
 {{- $imageDomain := "" -}}
-{{- $imageDomain = index .Values.agent.prometheus.targetAllocator.image.repositoryDomainMap .Values.region -}}
+{{- $imageDomain = index .repositoryDomainMap .region -}}
 {{- if not $imageDomain -}}
-{{- $imageDomain = .Values.agent.prometheus.targetAllocator.image.repositoryDomainMap.public -}}
+{{- $imageDomain = .repositoryDomainMap.public -}}
 {{- end -}}
-{{- printf "%s/%s:%s" $imageDomain $repository $tag -}}
+{{- printf "%s/%s:%s" $imageDomain .repository .tag -}}
 {{- end -}}
 
 {{/*

--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
@@ -58,7 +58,7 @@ metadata:
   name: {{ $agent.name | default (include "cloudwatch-agent.name" $) }}
   namespace: {{ $.Release.Namespace }}
 spec:
-  image: {{ include "cloudwatch-agent.image" (merge $agent.image (dict "region" $.Values.region)) }}
+  image: {{ template "cloudwatch-agent.image" (merge $agent.image (dict "region" $.Values.region)) }}
   mode: {{ $agent.mode }}
   replicas: {{ $agent.replicas }}
   nodeSelector:
@@ -93,7 +93,7 @@ spec:
   {{- if $agent.prometheus.targetAllocator.enabled }}
   targetAllocator:
     enabled: {{ $agent.prometheus.targetAllocator.enabled | default false }}
-    image: {{ include "target-allocator.image" (merge $agent.prometheus.targetAllocator.image (dict "region" $.Values.region)) }}
+    image: {{ template "target-allocator.image" (merge $agent.prometheus.targetAllocator.image (dict "region" $.Values.region)) }}
     allocationStrategy: "consistent-hashing"
     {{- if $agent.prometheus.targetAllocator.prometheusCR.enabled }}
     prometheusCR: {{ $agent.prometheus.targetAllocator.prometheusCR.enabled | default false }}

--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
@@ -47,22 +47,24 @@ data:
 ---
 {{- end -}}
 
-{{- range $i, $customAgent := .Values.agents }}
-{{- $clusterName := $.Values.clusterName | required "$.Values.clusterName is required." -}}
-{{- $region := $.Values.region | required "$.Values.region is required." -}}
+{{- $clusterName := .Values.clusterName | required ".Values.clusterName is required." -}}
+{{- $region := .Values.region | required ".Values.region is required." -}}
+
+{{- range .Values.agents }}
+{{- $agent := merge (deepCopy $.Values.agent) . }}
 apiVersion: cloudwatch.aws.amazon.com/v1alpha1
 kind: AmazonCloudWatchAgent
 metadata:
-  name: {{ $customAgent.name | default (include "cloudwatch-agent.name" $) }}
+  name: {{ $agent.name | default (include "cloudwatch-agent.name" $) }}
   namespace: {{ $.Release.Namespace }}
 spec:
-  image: {{ include "cloudwatch-agent.modify-image" (merge (dict "image" $customAgent.image) $ ) }}
-  mode: {{ $customAgent.mode | default "daemonset" }}
-  replicas: {{ $customAgent.replicas | default 1 }}
+  image: {{ include "cloudwatch-agent.modify-image" (merge (dict "image" $agent.image) $ ) }}
+  mode: {{ $agent.mode }}
+  replicas: {{ $agent.replicas }}
   nodeSelector:
     kubernetes.io/os: linux
-  serviceAccount: {{ if hasKey ($customAgent.serviceAccount) "name" }}{{ $customAgent.serviceAccount.Name }}{{ else }}{{ (include "cloudwatch-agent.serviceAccountName" $) }}{{ end }}
-  priorityClassName: {{ $customAgent.priorityClassName | default $.Values.agent.priorityClassName }}
+  serviceAccount: {{ $agent.serviceAccount.name | default (include "cloudwatch-agent.serviceAccountName" $) }}
+  priorityClassName: {{ $agent.priorityClassName | default $.Values.agent.priorityClassName }}
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -73,41 +75,33 @@ spec:
                 values:
                   - fargate
   hostNetwork: true
-  {{- if $customAgent.config }}
-  config: {{ include "cloudwatch-agent.modify-config" (merge (dict "Config" $customAgent.config) $ ) }}
+  {{- if $agent.config }}
+  config: {{ include "cloudwatch-agent.modify-config" (merge (dict "Config" $agent.config) $ ) }}
   {{- else }}
-  config: {{ include "cloudwatch-agent.modify-config" (merge (dict "Config" $.Values.agent.defaultConfig) $ ) }}
+  config: {{ include "cloudwatch-agent.modify-config" (merge (dict "Config" $agent.defaultConfig) $ ) }}
   {{- end }}
-  {{- if $customAgent.otelConfig }}
-  otelConfig: {{ include "cloudwatch-agent.modify-yaml-config" (merge (dict "OtelConfig" $customAgent.otelConfig) . ) }}
-  {{ else if $.Values.agent.otelConfig }}
-  otelConfig: {{ include "cloudwatch-agent.modify-yaml-config" (merge (dict "OtelConfig" $.Values.agent.otelConfig) . ) }}
+  {{- if $agent.otelConfig }}
+  otelConfig: {{ include "cloudwatch-agent.modify-yaml-config" (merge (dict "OtelConfig" $agent.otelConfig) . ) }}
   {{- end }}
-  {{- if $customAgent.prometheus }}
-  {{- if $customAgent.prometheus.config }}
+  {{- if $agent.prometheus.config }}
   prometheus:
-    {{- with $customAgent.prometheus.config }}
+    {{- with $agent.prometheus.config }}
     config:
       {{- toYaml . | nindent 6 }}
     {{- end }}
   {{- end }}
-  {{- if $customAgent.prometheus.targetAllocator }}
+  {{- if $agent.prometheus.targetAllocator.enabled }}
   targetAllocator:
-    enabled: {{ $customAgent.prometheus.targetAllocator.enabled | default false }}
-    image: {{ include "target-allocator.modify-image" (merge (dict "image" $customAgent.prometheus.targetAllocator.image) $ ) }}
+    enabled: {{ $agent.prometheus.targetAllocator.enabled | default false }}
+    image: {{ include "target-allocator.modify-image" (merge (dict "image" $agent.prometheus.targetAllocator.image) $ ) }}
     allocationStrategy: "consistent-hashing"
-    {{- if $customAgent.prometheus.targetAllocator.prometheusCR }}
-    prometheusCR: {{ $customAgent.prometheus.targetAllocator.prometheusCR.enabled | default false }}
+    {{- if $agent.prometheus.targetAllocator.prometheusCR.enabled }}
+    prometheusCR: {{ $agent.prometheus.targetAllocator.prometheusCR.enabled | default false }}
     {{- end }}
   {{- end }}
+  {{- with $agent.resources }}
+  resources: {{- toYaml . | nindent 4}}
   {{- end }}
-  resources:
-    requests:
-      memory: {{ if and (hasKey ($customAgent.resources) "requests") (hasKey ($customAgent.resources.requests) "memory") }}{{ $customAgent.resources.requests.memory }}{{ else }}{{ $.Values.agent.resources.requests.memory }}{{ end }}
-      cpu: {{ if and (hasKey ($customAgent.resources) "requests") (hasKey ($customAgent.resources.requests) "cpu") }}{{ $customAgent.resources.requests.cpu }}{{ else }}{{ $.Values.agent.resources.requests.cpu }}{{ end }}
-    limits:
-      memory: {{ if and (hasKey ($customAgent.resources) "limits") (hasKey ($customAgent.resources.limits) "memory") }}{{ $customAgent.resources.limits.memory }}{{ else }}{{ $.Values.agent.resources.limits.memory }}{{ end }}
-      cpu: {{ if and (hasKey ($customAgent.resources) "limits") (hasKey ($customAgent.resources.limits) "cpu") }}{{ $customAgent.resources.limits.cpu }}{{ else }}{{ $.Values.agent.resources.limits.cpu }}{{ end }}
   volumeMounts:
   - mountPath: /rootfs
     name: rootfs

--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
@@ -58,7 +58,7 @@ metadata:
   name: {{ $agent.name | default (include "cloudwatch-agent.name" $) }}
   namespace: {{ $.Release.Namespace }}
 spec:
-  image: {{ include "cloudwatch-agent.modify-image" (merge (dict "image" $agent.image) $ ) }}
+  image: {{ include "cloudwatch-agent.image" (merge $agent.image (dict "region" $.Values.region)) }}
   mode: {{ $agent.mode }}
   replicas: {{ $agent.replicas }}
   nodeSelector:
@@ -93,7 +93,7 @@ spec:
   {{- if $agent.prometheus.targetAllocator.enabled }}
   targetAllocator:
     enabled: {{ $agent.prometheus.targetAllocator.enabled | default false }}
-    image: {{ include "target-allocator.modify-image" (merge (dict "image" $agent.prometheus.targetAllocator.image) $ ) }}
+    image: {{ include "target-allocator.image" (merge $agent.prometheus.targetAllocator.image (dict "region" $.Values.region)) }}
     allocationStrategy: "consistent-hashing"
     {{- if $agent.prometheus.targetAllocator.prometheusCR.enabled }}
     prometheusCR: {{ $agent.prometheus.targetAllocator.prometheusCR.enabled | default false }}

--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -32,7 +32,7 @@ spec:
         - "--auto-instrumentation-python-image={{ template "auto-instrumentation-python.image" . }}"
         - "--auto-instrumentation-dotnet-image={{ template "auto-instrumentation-dotnet.image" . }}"
         - "--auto-instrumentation-nodejs-image={{ template "auto-instrumentation-nodejs.image" . }}"
-        - "--target-allocator-image={{ include "target-allocator.image" (merge .Values.agent.prometheus.targetAllocator.image (dict "region" $.Values.region)) }}"
+        - "--target-allocator-image={{ template "target-allocator.image" (merge .Values.agent.prometheus.targetAllocator.image (dict "region" $.Values.region)) }}"
         - "--feature-gates=operator.autoinstrumentation.multi-instrumentation,operator.autoinstrumentation.multi-instrumentation.skip-container-validation"
         command:
         - /manager

--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -32,7 +32,7 @@ spec:
         - "--auto-instrumentation-python-image={{ template "auto-instrumentation-python.image" . }}"
         - "--auto-instrumentation-dotnet-image={{ template "auto-instrumentation-dotnet.image" . }}"
         - "--auto-instrumentation-nodejs-image={{ template "auto-instrumentation-nodejs.image" . }}"
-        - "--target-allocator-image={{ template "target-allocator.modify-image" . }}"
+        - "--target-allocator-image={{ include "target-allocator.image" (merge .Values.agent.prometheus.targetAllocator.image (dict "region" $.Values.region)) }}"
         - "--feature-gates=operator.autoinstrumentation.multi-instrumentation,operator.autoinstrumentation.multi-instrumentation.skip-container-validation"
         command:
         - /manager

--- a/charts/amazon-cloudwatch-observability/templates/windows/cloudwatch-agent-windows-container-insights-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/windows/cloudwatch-agent-windows-container-insights-daemonset.yaml
@@ -14,7 +14,7 @@ spec:
       hostProcess: true
       runAsUserName: "NT AUTHORITY\\System"
   hostNetwork: true
-  image: {{ template "cloudwatch-agent.image" . }}
+  image: {{ include "cloudwatch-agent.image" (merge .Values.agent.image (dict "region" .Values.region)) }}
   workingDir: "%CONTAINER_SANDBOX_MOUNT_POINT%\\Program Files\\Amazon\\AmazonCloudWatchAgent"
   mode: daemonset
   serviceAccount: {{ template "cloudwatch-agent.serviceAccountName" . }}

--- a/charts/amazon-cloudwatch-observability/templates/windows/cloudwatch-agent-windows-container-insights-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/windows/cloudwatch-agent-windows-container-insights-daemonset.yaml
@@ -14,7 +14,7 @@ spec:
       hostProcess: true
       runAsUserName: "NT AUTHORITY\\System"
   hostNetwork: true
-  image: {{ include "cloudwatch-agent.image" (merge .Values.agent.image (dict "region" .Values.region)) }}
+  image: {{ template "cloudwatch-agent.image" (merge .Values.agent.image (dict "region" .Values.region)) }}
   workingDir: "%CONTAINER_SANDBOX_MOUNT_POINT%\\Program Files\\Amazon\\AmazonCloudWatchAgent"
   mode: daemonset
   serviceAccount: {{ template "cloudwatch-agent.serviceAccountName" . }}

--- a/charts/amazon-cloudwatch-observability/templates/windows/cloudwatch-agent-windows-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/windows/cloudwatch-agent-windows-daemonset.yaml
@@ -11,7 +11,7 @@ spec:
   podSecurityContext:
     windowsOptions:
       runAsUserName: "NT AUTHORITY\\System"
-  image: {{ template "cloudwatch-agent.image" . }}
+  image: {{ include "cloudwatch-agent.image" (merge .Values.agent.image (dict "region" .Values.region)) }}
   mode: daemonset
   serviceAccount: {{ template "cloudwatch-agent.serviceAccountName" . }}
   priorityClassName: {{ .Values.agent.priorityClassName }}

--- a/charts/amazon-cloudwatch-observability/templates/windows/cloudwatch-agent-windows-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/windows/cloudwatch-agent-windows-daemonset.yaml
@@ -11,7 +11,7 @@ spec:
   podSecurityContext:
     windowsOptions:
       runAsUserName: "NT AUTHORITY\\System"
-  image: {{ include "cloudwatch-agent.image" (merge .Values.agent.image (dict "region" .Values.region)) }}
+  image: {{ template "cloudwatch-agent.image" (merge .Values.agent.image (dict "region" .Values.region)) }}
   mode: daemonset
   serviceAccount: {{ template "cloudwatch-agent.serviceAccountName" . }}
   priorityClassName: {{ .Values.agent.priorityClassName }}

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -1315,8 +1315,8 @@ agents:
   - name: cloudwatch-agent
 agent:
   name:
-  mode: # represents the mode the cloudwatch-agent will run in (deployment, daemonset or statefulset)
-  replicas: # The total number non-terminated pods targeted by this cloudwatch-agent's deployment or statefulSet.
+  mode: daemonset # Represents the mode the AmazonCloudWatchAgent workload will run in (deployment, daemonset or statefulset)
+  replicas: 1 # The total number non-terminated pods targeted by this AmazonCloudWatchAgent's deployment or statefulSet.
   image:
     repository: cloudwatch-agent
     tag: 1.300051.0b992


### PR DESCRIPTION
*Description of changes:* When generating the AmazonCloudWatchAgent custom resources, iterate over the list of `agents` and for each item, merge it on top of the default `$.Values.agent` to ensure it truly behaves as overlays and simplify the conditional logic in the template.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

