### PR TITLE
support p5en instance type

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/linux/neuron-monitor-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/neuron-monitor-daemonset.yaml
@@ -36,7 +36,7 @@ spec:
   - name: PATH
     value: /usr/local/bin:/usr/bin:/bin:/opt/aws/neuron/bin
   - name: GOMEMLIMIT
-    value: 160MiB
+    value: 320MiB
   ports:
   - name: "metrics"
     port: {{ .Values.neuronMonitor.service.port }}
@@ -52,6 +52,9 @@ spec:
   - mountPath: /etc/amazon-cloudwatch-observability-neuron-cert/
     name: neurontls
     readOnly: true
+  - mountPath: /opt-aws
+    name: "aws-config"
+    readOnly: true
   volumes:
   - name: neurontls
     secret:
@@ -61,6 +64,9 @@ spec:
           path: server.crt
         - key: tls.key
           path: server.key
+  - name: "aws-config"
+    hostPath:
+      path: /opt/aws
   monitorConfig: |
     {
       "period": "5s",

--- a/charts/amazon-cloudwatch-observability/templates/linux/neuron-monitor-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/neuron-monitor-daemonset.yaml
@@ -79,7 +79,7 @@ spec:
             },
             {
               "type": "execution_stats"
-            }``
+            }
           ]
         }
       ],

--- a/charts/amazon-cloudwatch-observability/templates/linux/neuron-monitor-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/neuron-monitor-daemonset.yaml
@@ -36,7 +36,7 @@ spec:
   - name: PATH
     value: /usr/local/bin:/usr/bin:/bin:/opt/aws/neuron/bin
   - name: GOMEMLIMIT
-    value: 320MiB
+    value: 160MiB
   ports:
   - name: "metrics"
     port: {{ .Values.neuronMonitor.service.port }}
@@ -52,9 +52,6 @@ spec:
   - mountPath: /etc/amazon-cloudwatch-observability-neuron-cert/
     name: neurontls
     readOnly: true
-  - mountPath: /opt-aws
-    name: "aws-config"
-    readOnly: true
   volumes:
   - name: neurontls
     secret:
@@ -64,9 +61,6 @@ spec:
           path: server.crt
         - key: tls.key
           path: server.key
-  - name: "aws-config"
-    hostPath:
-      path: /opt/aws
   monitorConfig: |
     {
       "period": "5s",
@@ -85,7 +79,7 @@ spec:
             },
             {
               "type": "execution_stats"
-            }
+            }``
           ]
         }
       ],

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -73,6 +73,7 @@ gpuInstances:
   - p4de.24xlarge
   - p5.48xlarge
   - p5e.48xlarge
+  - p5en.48xlarge
   - ml.g3.4xlarge
   - ml.g3.8xlarge
   - ml.g3.16xlarge
@@ -132,6 +133,7 @@ gpuInstances:
   - ml.p4de.24xlarge
   - ml.p5.48xlarge
   - ml.p5e.48xlarge
+  - ml.p5en.48xlarge
 ## Tranium/Infrentia instance types
 neuronInstances:
   - trn1.2xlarge


### PR DESCRIPTION
*Description of changes:*
- Add p5en to the list of supported GPU instance types
~~- Mount `/opt/aws` to neuron monitor pods to fully support trn2 and increase `GOMEMLIMIT`~~


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

