### PR TITLE
Fix merge ordering for agent overlay

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
@@ -51,7 +51,7 @@ data:
 {{- $region := .Values.region | required ".Values.region is required." -}}
 
 {{- range .Values.agents }}
-{{- $agent := merge (deepCopy $.Values.agent) . }}
+{{- $agent := merge . (deepCopy $.Values.agent) }}
 apiVersion: cloudwatch.aws.amazon.com/v1alpha1
 kind: AmazonCloudWatchAgent
 metadata:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Fix merge ordering for agent overlay. The merge should use the `agent` section as the baseline and the items in `agents` as overrides.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

