### PR TITLE
Support per-component tolerations (+ manager)

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
@@ -5,6 +5,20 @@ Expand the name of the chart.
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+{{- define "amazon-cloudwatch-observability.common.tolerations" -}}
+{{- $tolerations := .context.Values.tolerations }}
+{{- if .component }}
+  {{- $componentTolerations := dig "tolerations" nil .component }}
+  {{- if ne nil $componentTolerations }}
+      {{- $tolerations = $componentTolerations }}
+  {{- end }}
+{{- end }}
+{{- with $tolerations }}
+tolerations:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
 {{/*
 Helper function to modify cloudwatch-agent config
 */}}

--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
@@ -191,9 +191,7 @@ spec:
     valueFrom:
       fieldRef:
         fieldPath: metadata.namespace
-  {{- with $.Values.tolerations }}
-  tolerations: {{- toYaml . | nindent 2}}
-  {{- end }}
+  {{- dict "component" $agent "context" $ | include "amazon-cloudwatch-observability.common.tolerations" | nindent 2 }}
 ---
 {{- end }}
 {{- end }}

--- a/charts/amazon-cloudwatch-observability/templates/linux/dcgm-exporter-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/dcgm-exporter-daemonset.yaml
@@ -71,6 +71,4 @@ spec:
     tls_server_config:
       cert_file: /etc/amazon-cloudwatch-observability-dcgm-cert/server.crt
       key_file: /etc/amazon-cloudwatch-observability-dcgm-cert/server.key
-  {{- with .Values.tolerations }}
-  tolerations: {{- toYaml . | nindent 2}}
-  {{- end }}
+  {{- dict "component" .Values.dcgmExporter "context" . | include "amazon-cloudwatch-observability.common.tolerations" | nindent 2 }}

--- a/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
@@ -123,7 +123,5 @@ spec:
                       - fargate
       nodeSelector:
         kubernetes.io/os: linux
-      {{- with .Values.tolerations }}
-      tolerations: {{- toYaml . | nindent 6}}
-      {{- end }}
+      {{- dict "component" .Values.containerLogs.fluentBit "context" . | include "amazon-cloudwatch-observability.common.tolerations" | nindent 6 }}
 {{- end }}

--- a/charts/amazon-cloudwatch-observability/templates/linux/neuron-monitor-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/neuron-monitor-daemonset.yaml
@@ -93,6 +93,4 @@ spec:
         }
       ]
     }
-  {{- with .Values.tolerations }}
-  tolerations: {{- toYaml . | nindent 2}}
-  {{- end }}
+  {{- dict "component" .Values.neuronMonitor "context" . | include "amazon-cloudwatch-observability.common.tolerations" | nindent 2 }}

--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -55,3 +55,4 @@ spec:
           secretName: {{ template "amazon-cloudwatch-observability.certificateSecretName" . }}
       nodeSelector:
         kubernetes.io/os: linux
+      {{- dict "component" .Values.manager "context" . | include "amazon-cloudwatch-observability.common.tolerations" | nindent 6 }}

--- a/charts/amazon-cloudwatch-observability/templates/windows/cloudwatch-agent-windows-container-insights-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/windows/cloudwatch-agent-windows-container-insights-daemonset.yaml
@@ -45,7 +45,5 @@ spec:
       value: "True"
     - name: RUN_AS_HOST_PROCESS_CONTAINER
       value: "True"
-  {{- with .Values.tolerations }}
-  tolerations: {{- toYaml . | nindent 2}}
-  {{- end }}
+  {{- dict "component" .Values.agent "context" . | include "amazon-cloudwatch-observability.common.tolerations" | nindent 2 }}
 {{- end }}

--- a/charts/amazon-cloudwatch-observability/templates/windows/cloudwatch-agent-windows-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/windows/cloudwatch-agent-windows-daemonset.yaml
@@ -38,7 +38,5 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
-  {{- with .Values.tolerations }}
-  tolerations: {{- toYaml . | nindent 2}}
-  {{- end }}
+  {{- dict "component" .Values.agent "context" . | include "amazon-cloudwatch-observability.common.tolerations" | nindent 2 }}
 {{- end }}

--- a/charts/amazon-cloudwatch-observability/templates/windows/fluent-bit-windows-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/windows/fluent-bit-windows-daemonset.yaml
@@ -67,7 +67,5 @@ spec:
       terminationGracePeriodSeconds: 10
       dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: {{ template "cloudwatch-agent.serviceAccountName" . }}
-      {{- with .Values.tolerations }}
-      tolerations: {{- toYaml . | nindent 6}}
-      {{- end }}
+      {{- dict "component" .Values.containerLogs.fluentBit "context" . | include "amazon-cloudwatch-observability.common.tolerations" | nindent 6 }}
 {{- end }}

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -186,6 +186,8 @@ containerLogs:
       requests:
         cpu: 50m
         memory: 25Mi
+    ## Override root tolerations
+    # tolerations: []
     priorityClassName: system-node-critical
     config:
       service: |
@@ -1263,6 +1265,7 @@ manager:
     requests:
       cpu: 100m
       memory: 64Mi
+  tolerations: []
   ## Adds additional environment variables
   ## e.g ENV_VAR: env_value
   env:
@@ -1340,6 +1343,8 @@ agent:
     limits:
       memory: 512Mi
       cpu: 500m
+  ## Override root tolerations
+  # tolerations: []
   ## TLS Certificate Option 1: Use Helm to automatically generate self-signed certificate.
   ## autoGenerateCert must be enabled. This is the default option.
   ## If true, Helm will automatically create a self-signed cert and secret for you.
@@ -1411,6 +1416,8 @@ dcgmExporter:
     limits:
       cpu: 500m
       memory: 500Mi
+  ## Override root tolerations
+  # tolerations: []
   configmap: dcgm-exporter-config-map
   arguments:
     - --web-config-file=/etc/dcgm-exporter/web-config.yaml
@@ -1436,6 +1443,8 @@ neuronMonitor:
     requests:
       cpu: 256m
       memory: 128Mi
+  ## Override root tolerations
+  # tolerations: []
   configmap: neuron-monitor-config-map
   service:
     enable: true


### PR DESCRIPTION
Should partially fix https://github.com/aws/containers-roadmap/issues/2515

*Issue #, if available:*

https://github.com/aws/containers-roadmap/issues/2515


*Description of changes:*

1. Let's support per-component tolerations
2. Add tolerations for `manager`

*Behavior*

* Root tolerations is applied by default
* Manager tolerations is disabled by default (`[]` value, see below)
* Each component may override tolerations
* Tolerations can be disabled by using empty list `[]` (root or specific)
* If specific tolerations is `null` (`nil` in Go/Template), root ones are used.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

