### PR TITLE
Add Application Signals .NET runtime metrics config

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
       - image: {{ template "cloudwatch-agent-operator.image" . }}
         args:
-        - {{ printf "--auto-instrumentation-config=%s" (dict "java" (merge .Values.manager.autoInstrumentationResources.java .Values.manager.autoInstrumentationConfiguration.java) "python" (merge .Values.manager.autoInstrumentationResources.python .Values.manager.autoInstrumentationConfiguration.python) "dotnet" (.Values.manager.autoInstrumentationResources.dotnet) "nodejs" (.Values.manager.autoInstrumentationResources.nodejs) | toJson) | quote }}
+        - {{ printf "--auto-instrumentation-config=%s" (dict "java" (merge .Values.manager.autoInstrumentationResources.java .Values.manager.autoInstrumentationConfiguration.java) "python" (merge .Values.manager.autoInstrumentationResources.python .Values.manager.autoInstrumentationConfiguration.python) "dotnet" (merge .Values.manager.autoInstrumentationResources.dotnet .Values.manager.autoInstrumentationConfiguration.dotnet) "nodejs" (.Values.manager.autoInstrumentationResources.nodejs) | toJson) | quote }}
         - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}
         - "--auto-instrumentation-java-image={{ template "auto-instrumentation-java.image" . }}"
         - "--auto-instrumentation-python-image={{ template "auto-instrumentation-python.image" . }}"

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -1199,6 +1199,9 @@ manager:
     python:
       runtime_metrics:
         enabled: "true"
+    dotnet:
+      runtime_metrics:
+        enabled: "true"
   autoInstrumentationResources:
     java:
       limits:


### PR DESCRIPTION
*Description of changes:*
This PR allows customers to configure dotnet runtime metrics collection at cluster level.

Dependent PR:
https://github.com/aws/amazon-cloudwatch-agent-operator/pull/279

*Test*
```
helm install--namespace amazon-cloudwatch amazon-cloudwatch-operator ./ \
--create-namespace --set region=us-east-1 --set clusterName=k8s-demo \
--set-string manager.autoInstrumentationConfiguration.java.runtime_metrics.enabled=false \
--set-string manager.autoInstrumentationConfiguration.python.runtime_metrics.enabled=false \
--set-string manager.autoInstrumentationConfiguration.dotnet.runtime_metrics.enabled=false \
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

