### PR TITLE
Support LNC with trn2

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/linux/neuron-monitor-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/neuron-monitor-daemonset.yaml
@@ -36,7 +36,7 @@ spec:
   - name: PATH
     value: /usr/local/bin:/usr/bin:/bin:/opt/aws/neuron/bin
   - name: GOMEMLIMIT
-    value: 160MiB
+    value: 320MiB
   ports:
   - name: "metrics"
     port: {{ .Values.neuronMonitor.service.port }}
@@ -52,6 +52,9 @@ spec:
   - mountPath: /etc/amazon-cloudwatch-observability-neuron-cert/
     name: neurontls
     readOnly: true
+  - mountPath: /opt-aws
+    name: "aws-config"
+    readOnly: true
   volumes:
   - name: neurontls
     secret:
@@ -61,6 +64,9 @@ spec:
           path: server.crt
         - key: tls.key
           path: server.key
+  - name: "aws-config"
+    hostPath:
+      path: /opt/aws
   monitorConfig: |
     {
       "period": "5s",

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -1423,7 +1423,7 @@ neuronMonitor:
   name:
   image:
     repository: neuron-monitor
-    tag: 1.2.1
+    tag: 1.3.0
     repositoryDomainMap:
       public: public.ecr.aws/neuron
   resources:

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -1429,7 +1429,7 @@ neuronMonitor:
   resources:
     limits:
       cpu: 500m
-      memory: 500`Mi
+      memory: 500Mi
     requests:
       cpu: 256m
       memory: 128Mi

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -1429,7 +1429,7 @@ neuronMonitor:
   resources:
     limits:
       cpu: 500m
-      memory: 256Mi
+      memory: 500`Mi
     requests:
       cpu: 256m
       memory: 128Mi


### PR DESCRIPTION
[LNC](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/libraries/nxd-inference/tutorials/trn2-llama3.1-405b-tutorial.html#logical-neuroncores-lnc) (Logical Neuron Cores), concept to represents multiple Neuron cores as a single Neuron core, is a new feature supported with trn2. This requires a new volume mount for `nueron-monitor` to get LNC configuration. 

*Description of changes:*
- Bump `neuron-monitor` image to `1.3.0`
- Add new volume mount for `/opt` 
- Update `GOMEMLIMIT` to `320MiB`

Tested by deploying the changes to a test cluster:
```
# describe neuron monitor (some truncated)

Containers:
  neuron-monitor:
    Image:         public.ecr.aws/neuron/neuron-monitor:1.3.0
    Image ID:      public.ecr.aws/neuron/neuron-monitor@sha256:[sha]
    Port:          8000/TCP
    Host Port:     0/TCP
    ...
    State:          Running
      Started:      Thu, 09 Jan 2025 13:03:44 -0500
    Ready:          True
    Limits:
      cpu:     500m
      memory:  256Mi
    Requests:
      cpu:     256m
      memory:  128Mi
    Environment:
      NODE_NAME:    (v1:spec.nodeName)
      PATH:        /usr/local/bin:/usr/bin:/bin:/opt/aws/neuron/bin
      GOMEMLIMIT:  320MiB
    Mounts:
      /etc/amazon-cloudwatch-observability-neuron-cert/ from neurontls (ro)
      /etc/neuron-monitor-config from neuron-monitor-config (rw)
      /opt-aws from aws-config (ro)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-hxmsx (ro)
    Volumes:
      aws-config:
        Type:          HostPath (bare host directory volume)
        Path:          /opt/aws
        HostPathType:


```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

