### PR TITLE
Add setup terraform step to integration tests

### DIFF
--- a/.github/workflows/amazon-cloudwatch-observability-helm-integration-test.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-helm-integration-test.yaml
@@ -50,6 +50,11 @@ jobs:
       - name: Set KUBECONFIG environment variable
         run: echo KUBECONFIG="${{ github.workspace }}/../../../.kube/config" >> $GITHUB_ENV
 
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.1.7"
+
       - name: Verify Terraform version
         run: terraform --version
 
@@ -106,6 +111,11 @@ jobs:
       - name: Set KUBECONFIG environment variable
         run: echo KUBECONFIG="${{ github.workspace }}/../../../.kube/config" >> $GITHUB_ENV
 
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.1.7"
+
       - name: Verify Terraform version
         run: terraform --version
 
@@ -161,6 +171,11 @@ jobs:
 
       - name: Set KUBECONFIG environment variable
         run: echo KUBECONFIG="${{ github.workspace }}/../../../.kube/config" >> $GITHUB_ENV
+        
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.1.7"
 
       - name: Verify Terraform version
         run: terraform --version


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently the helm chart integration tests fail due to terraform not being installed:

```
/home/runner/work/_temp/8a6c2cf6-f346-4e0d-82b6-52a44be638c8.sh: line 1: terraform: command not found
```

We can add a step to install terraform before the verify terraform step using https://github.com/hashicorp/setup-terraform

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

