### PR TITLE
add SecurityContext to fluentBit DaemonSet

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
@@ -50,6 +50,10 @@ spec:
         {{- with .Values.containerLogs.fluentBit.resources }}
         resources: {{- toYaml . | nindent 10}}
         {{- end }}
+        {{- with .Values.containerLogs.fluentBit.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10}}
+        {{- end }}
         volumeMounts:
         # Please don't change below read-only permissions
         - name: fluentbitstate

--- a/charts/amazon-cloudwatch-observability/templates/windows/fluent-bit-windows-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/windows/fluent-bit-windows-daemonset.yaml
@@ -57,6 +57,10 @@ spec:
         {{- with .Values.containerLogs.fluentBit.resources }}
         resources: {{- toYaml . | nindent 10}}
         {{- end }}
+        {{- with .Values.containerLogs.fluentBit.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10}}
+        {{- end }}
         volumeMounts:
           - name: fluent-bit-config
             mountPath: fluent-bit\configuration\

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -179,6 +179,7 @@ containerLogs:
         cn-northwest-1: 128054284489.dkr.ecr.cn-northwest-1.amazonaws.com.cn
         us-gov-east-1: 161423150738.dkr.ecr.us-gov-east-1.amazonaws.com
         us-gov-west-1: 161423150738.dkr.ecr.us-gov-west-1.amazonaws.com
+    securityContext: {}
     resources:
       limits:
         cpu: 500m


### PR DESCRIPTION
No issue # for this change. We are using a Policy to enforce a SecurityContext to all Pods. The original FluentBit Helm has the capability of setting this while the AWS-Observability does not allow this. 

*Description of changes:*
Added Security Context to the DaemonSet. This change has been locally tested

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

