### PR TITLE
Allow both YAML string and objects to get passed in for OTEL config.

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
@@ -46,14 +46,17 @@ Helper function to modify customer supplied agent config if ContainerInsights or
 {{/*
 Helper function to modify cloudwatch-agent YAML config
 */}}
-{{- define "cloudwatch-agent.modify-yaml-config" -}}
+{{- define "cloudwatch-agent.modify-otel-config" -}}
 {{- $configCopy := deepCopy .OtelConfig }}
+{{- if kindIs "string" $configCopy }}
+  {{- $configCopy = fromYaml $configCopy }}
+{{- end }}
 
 {{- range $name, $component := $configCopy }}
-{{- if $component -}}
+{{- if and $component (kindIs "map" $component) }}
   {{- range $key, $value := $component }}
-    {{- if (and (quote $value | empty) (not (hasKey $component $key))) }}
-      {{- $component = set $component $key (dict) }}
+    {{- if eq $value nil }}
+      {{- $_ := set $component $key dict }}
     {{- end -}}
   {{- end }}
 {{- end }}

--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
@@ -81,7 +81,7 @@ spec:
   config: {{ include "cloudwatch-agent.modify-config" (merge (dict "Config" $agent.defaultConfig) $ ) }}
   {{- end }}
   {{- if $agent.otelConfig }}
-  otelConfig: {{ include "cloudwatch-agent.modify-yaml-config" (merge (dict "OtelConfig" $agent.otelConfig) . ) }}
+  otelConfig: {{ include "cloudwatch-agent.modify-otel-config" (merge (dict "OtelConfig" $agent.otelConfig) . ) }}
   {{- end }}
   {{- if $agent.prometheus.config }}
   prometheus:


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* With the current implementation, the `otelConfig` expects a YAML object in the `values.yaml`
```
  otelConfig:
    receivers:
      otlp/custom-suffix:
        protocols:
          http:
    exporters:
      awscloudwatchlogs/custom-suffix:
        log_group_name: "test-group"
        log_stream_name: "test-stream"
    service:
      pipelines:
        logs/from-values:
          receivers: [ otlp/custom-suffix ]
          exporters: [ awscloudwatchlogs/custom-suffix ]
```
but does not work for YAML strings (e.g. when passing in the value using `--set agent.otelConfig`).

```
Error: UPGRADE FAILED: template: amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml:84:17: executing "amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml" at <include "cloudwatch-agent.modify-yaml-config" (merge (dict "OtelConfig" $agent.otelConfig) .)>: error calling include: template: amazon-cloudwatch-observability/templates/_helpers.tpl:52:31: executing "cloudwatch-agent.modify-yaml-config" at <$configCopy>: range can't iterate over 
```

With the change, the helm chart can now accept either a YAML object or string, which means the `values.yaml` can take an object and `--set agent.otelConfig` can be used to pass in a string.

```
helm upgrade --install --namespace amazon-cloudwatch amazon-cloudwatch-observability ./charts/amazon-cloudwatch-observability/ --create-namespace --set region=$REGION --set clusterName=$CLUSTER_NAME --set agent.otelConfig='
  receivers:
    otlp/custom-suffix:
      protocols:
        http:
  exporters:
    awscloudwatchlogs/custom-suffix:
      log_group_name: "test-group"
      log_stream_name: "test-stream"
  service:
    pipelines:
      logs/on-set:
        receivers: [otlp/custom-suffix]
        exporters: [awscloudwatchlogs/custom-suffix]                                                                                                                                                           
Release "amazon-cloudwatch-observability" has been upgraded. Happy Helming!
NAME: amazon-cloudwatch-observability
LAST DEPLOYED: Fri Jan 24 11:08:44 2025
NAMESPACE: amazon-cloudwatch
STATUS: deployed
REVISION: 37
TEST SUITE: None
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

