### PR TITLE
Version bumps for CWAgent, Operator, JAVA, .NET, NodeJS, Python SDKs

### DIFF
--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -1170,7 +1170,7 @@ manager:
   name:
   image:
     repository: cloudwatch-agent-operator
-    tag: 2.0.1
+    tag: 2.1.0
     repositoryDomainMap:
       public: public.ecr.aws/cloudwatch-agent
       cn-north-1: 934860584483.dkr.ecr.cn-north-1.amazonaws.com.cn
@@ -1181,19 +1181,19 @@ manager:
     java:
       repositoryDomain: public.ecr.aws/aws-observability
       repository: adot-autoinstrumentation-java
-      tag: v1.32.6
+      tag: v1.33.0
     python:
       repositoryDomain: public.ecr.aws/aws-observability
       repository: adot-autoinstrumentation-python
-      tag: v0.7.0
+      tag: v0.8.0
     dotnet:
       repositoryDomain: public.ecr.aws/aws-observability
       repository: adot-autoinstrumentation-dotnet
-      tag: v1.4.0
+      tag: v1.6.0
     nodejs:
       repositoryDomain: public.ecr.aws/aws-observability
       repository: adot-autoinstrumentation-node
-      tag: v0.3.0
+      tag: v0.5.0
   autoInstrumentationConfiguration:
     java:
       runtime_metrics:
@@ -1324,7 +1324,7 @@ agent:
   replicas: 1 # The total number non-terminated pods targeted by this AmazonCloudWatchAgent's deployment or statefulSet.
   image:
     repository: cloudwatch-agent
-    tag: 1.300051.0b992
+    tag: 1.300052.0b1023
     repositoryDomainMap:
       public: public.ecr.aws/cloudwatch-agent
       cn-north-1: 934860584483.dkr.ecr.cn-north-1.amazonaws.com.cn


### PR DESCRIPTION
*Description of changes:* Version bumps for:
CloudWatchAgent: 1.300051.0b992 -> 1.300052.0b1023
CloudWatchAgentOperator: 2.0.1 -> 2.1.0
JAVA SDK: v1.32.6 -> v1.33.0
Python SDK: v0.7.0 -> v0.8.0
NodeJS SDK: v0.3.0 -> v0.5.0
.NET SDK: v1.4.0 -> v1.6.0


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

