### PR TITLE
Add environmental variable to determine the agent's cluster name

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
@@ -191,6 +191,8 @@ spec:
     valueFrom:
       fieldRef:
         fieldPath: metadata.namespace
+  - name: K8S_CLUSTER_NAME
+    value: {{ $.Values.clusterName }}
   {{- with $.Values.tolerations }}
   tolerations: {{- toYaml . | nindent 2}}
   {{- end }}


### PR DESCRIPTION
# Description of the issue
When running on a Kubernetes cluster, the only way the CloudWatch Agent can detect the cluster name is:

1) If it's provided in the configuration:
```
"kubernetes": {
  "cluster_name": "<cluster-name>",
  "enhanced_container_insights": true
},
"application_signals": {
  "hosted_in": "<cluster-name>"
}
```

2) By making a `ec2:DescribeTags` call.

Ideally, the agent should minimize external API calls, so we should implement a global way to retrieve the cluster name in case it isn't provided in the configuration. The Amazon CloudWatch Observability EKS add-on / Helm chart includes a `.Values.clusterName`, which can be passed in as an environmental variable for the agent's pod.

# Description of changes
> [!IMPORTANT]
> **Co-PRs:** https://github.com/aws/amazon-cloudwatch-agent/pull/1529; https://github.com/amazon-contributing/opentelemetry-collector-contrib/pull/291
- Add `K8S_CLUSTER_NAME` with cluster name from received from `.Values.clusterName`.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
<img width="264" alt="Screenshot 2025-02-02 at 11 32 40 PM" src="https://github.com/user-attachments/assets/757f11fd-cde4-4484-846b-345474254030" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

