### PR TITLE
Expose updateStrategy to make it configurable for cloudwatch agent and fluentbit

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
@@ -59,11 +59,11 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
   updateStrategy:
-      type: {{ .Values.agent.updateStrategy.type | default "RollingUpdate" }}
-      {{- if eq .Values.agent.updateStrategy.type "RollingUpdate" }}
+      type: {{ $agent.updateStrategy.type | default "RollingUpdate" }}
+      {{- if eq $agent.updateStrategy.type "RollingUpdate" }}
       rollingUpdate:
-        maxUnavailable: {{ .Values.agent.updateStrategy.rollingUpdate.maxUnavailable | default 1 }}
-        maxSurge: {{ .Values.agent.updateStrategy.rollingUpdate.maxSurge | default 0 }}
+        maxUnavailable: {{ $agent.updateStrategy.rollingUpdate.maxUnavailable | default 1 }}
+        maxSurge: {{ $agent.updateStrategy.rollingUpdate.maxSurge | default 0 }}
       {{- end }}
   image: {{ template "cloudwatch-agent.image" (merge $agent.image (dict "region" $.Values.region)) }}
   mode: {{ $agent.mode }}

--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
@@ -59,11 +59,11 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
   updateStrategy:
-      type: {{ $agent.updateStrategy.type | default "RollingUpdate" }}
+      type: {{ $agent.updateStrategy.type }}
       {{- if eq $agent.updateStrategy.type "RollingUpdate" }}
       rollingUpdate:
-        maxUnavailable: {{ $agent.updateStrategy.rollingUpdate.maxUnavailable | default 1 }}
-        maxSurge: {{ $agent.updateStrategy.rollingUpdate.maxSurge | default 0 }}
+        maxUnavailable: {{ $agent.updateStrategy.rollingUpdate.maxUnavailable }}
+        maxSurge: {{ $agent.updateStrategy.rollingUpdate.maxSurge }}
       {{- end }}
   image: {{ template "cloudwatch-agent.image" (merge $agent.image (dict "region" $.Values.region)) }}
   mode: {{ $agent.mode }}

--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
@@ -58,6 +58,13 @@ metadata:
   name: {{ $agent.name | default (include "cloudwatch-agent.name" $) }}
   namespace: {{ $.Release.Namespace }}
 spec:
+  updateStrategy:
+      type: {{ .Values.agent.updateStrategy.type | default "RollingUpdate" }}
+      {{- if eq .Values.agent.updateStrategy.type "RollingUpdate" }}
+      rollingUpdate:
+        maxUnavailable: {{ .Values.agent.updateStrategy.rollingUpdate.maxUnavailable | default 1 }}
+        maxSurge: {{ .Values.agent.updateStrategy.rollingUpdate.maxSurge | default 0 }}
+      {{- end }}
   image: {{ template "cloudwatch-agent.image" (merge $agent.image (dict "region" $.Values.region)) }}
   mode: {{ $agent.mode }}
   replicas: {{ $agent.replicas }}

--- a/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
@@ -79,11 +79,11 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       priorityClassName: {{ .Values.containerLogs.fluentBit.priorityClassName }}
       updateStrategy:
-        type: {{ .Values.containerLogs.fluentBit.updateStrategy.type | default "RollingUpdate" }}
+        type: {{ .Values.containerLogs.fluentBit.updateStrategy.type }}
         {{- if eq .Values.containerLogs.fluentBit.updateStrategy.type "RollingUpdate" }}
         rollingUpdate:
-          maxUnavailable: {{ .Values.containerLogs.fluentBit.updateStrategy.rollingUpdate.maxUnavailable | default 1 }}
-          maxSurge: {{ .Values.containerLogs.fluentBit.updateStrategy.rollingUpdate.maxSurge | default 0 }}
+          maxUnavailable: {{ .Values.containerLogs.fluentBit.updateStrategy.rollingUpdate.maxUnavailable }}
+          maxSurge: {{ .Values.containerLogs.fluentBit.updateStrategy.rollingUpdate.maxSurge }}
         {{- end }}
       volumes:
       - name: fluentbitstate

--- a/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
@@ -78,6 +78,13 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       priorityClassName: {{ .Values.containerLogs.fluentBit.priorityClassName }}
+      updateStrategy:
+        type: {{ .Values.containerLogs.fluentBit.updateStrategy.type | default "RollingUpdate" }}
+        {{- if eq .Values.containerLogs.fluentBit.updateStrategy.type "RollingUpdate" }}
+        rollingUpdate:
+          maxUnavailable: {{ .Values.containerLogs.fluentBit.updateStrategy.rollingUpdate.maxUnavailable | default 1 }}
+          maxSurge: {{ .Values.containerLogs.fluentBit.updateStrategy.rollingUpdate.maxSurge | default 0 }}
+        {{- end }}
       volumes:
       - name: fluentbitstate
         hostPath:

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -191,7 +191,7 @@ containerLogs:
       type: RollingUpdate
       rollingUpdate:
         maxUnavailable: 1
-        maxSurge: 
+        maxSurge: 0
     config:
       service: |
         [SERVICE]

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -187,6 +187,11 @@ containerLogs:
         cpu: 50m
         memory: 25Mi
     priorityClassName: system-node-critical
+    updateStrategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 1
+        maxSurge: 
     config:
       service: |
         [SERVICE]

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -1340,6 +1340,11 @@ agent:
     limits:
       memory: 512Mi
       cpu: 500m
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0
   ## TLS Certificate Option 1: Use Helm to automatically generate self-signed certificate.
   ## autoGenerateCert must be enabled. This is the default option.
   ## If true, Helm will automatically create a self-signed cert and secret for you.


### PR DESCRIPTION
Expose updateStrategy to make it configurable for cloudwatch agent and fluentbit (daemonset only)  


Cloudwatch agent - output after `helm upgrade`:

```
---
# Source: amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
apiVersion: cloudwatch.aws.amazon.com/v1alpha1
kind: AmazonCloudWatchAgent
metadata:
  name: cloudwatch-agent
  namespace: amazon-cloudwatch
spec:
  updateStrategy:
      type: OnDelete
```

```
---
# Source: amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
apiVersion: cloudwatch.aws.amazon.com/v1alpha1
kind: AmazonCloudWatchAgent
metadata:
  name: cloudwatch-agent
  namespace: amazon-cloudwatch
spec:
  updateStrategy:
      type: RollingUpdate
      rollingUpdate:
        maxUnavailable: 1
        maxSurge: 0
```

FluentBit changes - output after `helm upgrade --dry-run`:
```
---
# Source: amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: fluent-bit
  namespace: amazon-cloudwatch
  labels:
    k8s-app: fluent-bit
    version: v1
    kubernetes.io/cluster-service: "true"
spec:
    ...
    spec:
      ...
      priorityClassName: system-node-critical
      priorityClassName: system-node-critical
      updateStrategy:
        type: RollingUpdate
        rollingUpdate:
          maxUnavailable: 1
          maxSurge: 0
      ...
 ```
 
 ```
 ---
# Source: amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: fluent-bit
  namespace: amazon-cloudwatch
  labels:
    k8s-app: fluent-bit
    version: v1
    kubernetes.io/cluster-service: "true"
spec:
    ...
    spec:
      ...
      priorityClassName: system-node-critical
      updateStrategy:
        type: OnDelete
 ```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. ✅ 
