### PR TITLE
Exclude publishing fluentd container logs by default

### DIFF
--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -225,7 +225,7 @@ containerLogs:
           [INPUT]
             Name                tail
             Tag                 application.*
-            Exclude_Path        /var/log/containers/cloudwatch-agent*, /var/log/containers/fluent-bit*, /var/log/containers/aws-node*, /var/log/containers/kube-proxy*
+            Exclude_Path        /var/log/containers/cloudwatch-agent*, /var/log/containers/fluent-bit*, /var/log/containers/fluentd*, /var/log/containers/aws-node*, /var/log/containers/kube-proxy*
             Path                /var/log/containers/*.log
             multiline.parser    docker, cri
             DB                  /var/fluent-bit/state/flb_container.db
@@ -387,7 +387,7 @@ containerLogs:
           [INPUT]
             Name                tail
             Tag                 application.*
-            Exclude_Path        /var/log/containers/cloudwatch-agent*, /var/log/containers/fluent-bit*, /var/log/containers/aws-node*, /var/log/containers/kube-proxy*
+            Exclude_Path        /var/log/containers/cloudwatch-agent*, /var/log/containers/fluent-bit*, /var/log/containers/fluentd*, /var/log/containers/aws-node*, /var/log/containers/kube-proxy*
             Path                /var/log/containers/*.log
             multiline.parser    docker, cri
             DB                  /var/fluent-bit/state/flb_container.db
@@ -543,7 +543,7 @@ containerLogs:
           [INPUT]
             Name                tail
             Tag                 application.*
-            Exclude_Path        /var/log/containers/cloudwatch-agent*, /var/log/containers/fluent-bit*, /var/log/containers/aws-node*, /var/log/containers/kube-proxy*
+            Exclude_Path        /var/log/containers/cloudwatch-agent*, /var/log/containers/fluent-bit*, /var/log/containers/fluentd*, /var/log/containers/aws-node*, /var/log/containers/kube-proxy*
             Path                /var/log/containers/*.log
             multiline.parser    docker, cri
             DB                  /var/fluent-bit/state/flb_container.db
@@ -699,7 +699,7 @@ containerLogs:
           [INPUT]
             Name                tail
             Tag                 application.*
-            Exclude_Path        /var/log/containers/cloudwatch-agent*, /var/log/containers/fluent-bit*, /var/log/containers/aws-node*, /var/log/containers/kube-proxy*
+            Exclude_Path        /var/log/containers/cloudwatch-agent*, /var/log/containers/fluent-bit*, /var/log/containers/fluentd*, /var/log/containers/aws-node*, /var/log/containers/kube-proxy*
             Path                /var/log/containers/*.log
             multiline.parser    docker, cri
             DB                  /var/fluent-bit/state/flb_container.db
@@ -855,7 +855,7 @@ containerLogs:
           [INPUT]
             Name                tail
             Tag                 application.*
-            Exclude_Path        /var/log/containers/cloudwatch-agent*, /var/log/containers/fluent-bit*, /var/log/containers/aws-node*, /var/log/containers/kube-proxy*
+            Exclude_Path        /var/log/containers/cloudwatch-agent*, /var/log/containers/fluent-bit*, /var/log/containers/fluentd*, /var/log/containers/aws-node*, /var/log/containers/kube-proxy*
             Path                /var/log/containers/*.log
             multiline.parser    docker, cri
             DB                  /var/fluent-bit/state/flb_container.db
@@ -1043,7 +1043,7 @@ containerLogs:
           [INPUT]
             Name                tail
             Tag                 application.*
-            Exclude_Path        C:\\var\\log\\containers\\fluent-bit*, C:\\var\\log\\containers\\cloudwatch-agent*
+            Exclude_Path        C:\\var\\log\\containers\\fluent-bit*, C:\\var\\log\\containers\\fluentd*, C:\\var\\log\\containers\\cloudwatch-agent*
             Path                C:\\var\\log\\containers\\*.log
             Parser              docker
             DB                  C:\\var\\fluent-bit\\state\\flb_container.db


### PR DESCRIPTION
*Description of changes:*
We've historically recommended that customers migrate from FluentD to FluentBit due to issues when running FluentD on EKS >=1.24.
Any FluentD pods that arent cleaned up are very noisy by logging a lot of errors which are in turn published by FluentBit.
We now disregard these by default to match the behavior from https://github.com/aws-samples/amazon-cloudwatch-container-insights/pull/183.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

