### PR TITLE
Implement exponential backoff by configuring kube-client env vars

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
@@ -229,6 +229,12 @@ spec:
   - name: K8S_CLUSTER_NAME
     value: {{ $.Values.clusterName }}
   {{- with $.Values.tolerations }}
+  {{- if $.Values.k8sClientExponentialBackoff.enabled }}
+  - name: KUBE_CLIENT_BACKOFF_BASE
+    value: {{ $.Values.k8sClientExponentialBackoff.backoffBaseSeconds | quote }}
+  - name: KUBE_CLIENT_BACKOFF_DURATION
+    value: {{ $.Values.k8sClientExponentialBackoff.backoffMaxDurationSeconds | quote }}
+  {{- end }}
   tolerations: {{- toYaml . | nindent 2}}
   {{- end }}
 ---

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -1451,3 +1451,7 @@ neuronMonitor:
         - SYS_ADMIN
   serviceAccount:
     name: # override exporter service account name
+k8sClientExponentialBackoff:
+  enabled: true
+  backoffBaseSeconds: 1
+  backoffMaxDurationSeconds: 120


### PR DESCRIPTION
*Description of changes:*
The CloudWatch Agent overloads the API server due to there not being an exponential back-off strategy implemented in the Kubernetes client when there's a timeout issue, as described in https://github.com/cilium/cilium/issues/36525#issuecomment-2541833105.

This change configures environmental variables that enables exponential back-off for timeout issues.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

