### PR TITLE
Update version of aws-for-fluent-bit to most recent version

### DIFF
--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -172,7 +172,7 @@ containerLogs:
   fluentBit:
     image:
       repository: aws-for-fluent-bit
-      tag: 2.32.5
+      tag: 2.32.5.20250327
       tagWindows: 2.31.12-windowsservercore
       repositoryDomainMap:
         public: public.ecr.aws/aws-observability


### PR DESCRIPTION
*Description of changes:*
Update version of aws-for-fluent-bit to most recent version

*Testing:*

After running a helm-upgrade, the version was updated as expected:

```diff
 - env:
    - name: AWS_REGION
      value: us-east-1
    - name: CLUSTER_NAME
      value: load-test-fluent-bit-eks-cluster
    - name: READ_FROM_HEAD
      value: "Off"
    - name: READ_FROM_TAIL
      value: "On"
    - name: HOST_NAME
      valueFrom:
        fieldRef:
          apiVersion: v1
          fieldPath: spec.nodeName
    - name: HOSTNAME
      valueFrom:
        fieldRef:
          apiVersion: v1
          fieldPath: metadata.name
    - name: CI_VERSION
      value: k8s/1.3.17
+    image: public.ecr.aws/aws-observability/aws-for-fluent-bit:2.32.5.20250327
    imagePullPolicy: Always
    name: fluent-bit
```

I also verified that `/application`, `/dataplane`, and `/host` logs were being published to.

Integration test run: https://github.com/aws-observability/helm-charts/actions/runs/14270700762

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. ✅ 