### PR TITLE
Upgrade neuron-monitor to 1.4.0

### DIFF
--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -1427,7 +1427,7 @@ neuronMonitor:
   name:
   image:
     repository: neuron-monitor
-    tag: 1.3.0
+    tag: 1.4.0
     repositoryDomainMap:
       public: public.ecr.aws/neuron
   resources:


### PR DESCRIPTION
*Description of changes:*

The Neuron team has released a new version of the Neuron Monitor. Upgrading helm-charts to use the latest version.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

*Testing*
* Create trainium EKS cluster:
```
% cat cluster-config.yaml
apiVersion: eksctl.io/v1alpha5
kind: ClusterConfig
metadata:
  name: trainium-cluster
  version: "1.30"
  region: us-east-2
availabilityZones:
  - us-east-2a
  - us-east-2c
managedNodeGroups:
  - name: trn1-2xl
    instanceType: trn1.2xlarge
    instancePrefix: trn1-2xl
    privateNetworking: true
    efaEnabled: false
    minSize: 0
    desiredCapacity: 1
    maxSize: 1
    volumeSize: 80
    iam:
      withAddonPolicies:
        cloudWatch: true
  - name: sys
    instanceType: m5.large
    desiredCapacity: 1
    maxSize: 1
    iam:
      withAddonPolicies:
        autoScaler: true
        cloudWatch: true
iam:
  withOIDC: true
% eksctl create cluster -f ./cluster-config.yaml   
...
```

Install helm chart:
```
% helm upgrade \                                                   
  --install amazon-cloudwatch-observability ../helm-charts/charts/amazon-cloudwatch-observability \
  --values ../helm-charts/charts/amazon-cloudwatch-observability/values.yaml \
  --set clusterName=trainium-cluster \
  --set region=us-east-2 \
  --namespace amazon-cloudwatch --create-namespace
Release "amazon-cloudwatch-observability" does not exist. Installing it now.
NAME: amazon-cloudwatch-observability
LAST DEPLOYED: Fri Apr 18 14:36:41 2025
NAMESPACE: amazon-cloudwatch
STATUS: deployed
REVISION: 1
TEST SUITE: None
```

Check for existence of the metrics listed in our awsneuron integration test: https://github.com/aws/amazon-cloudwatch-agent-test/blob/main/test/awsneuron/resources/metrics_list.go


![image](https://github.com/user-attachments/assets/3b8fd699-87fe-4c2b-8f46-e778ac353c78)

Values are all 0, which seems odd

I **do not** see some of the metrics listed in the integration test. Will require investigation.
