### PR TITLE
Quote cluster name in env var and config

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
@@ -33,14 +33,14 @@ Helper function to modify cloudwatch-agent config
 
 {{- $appSignals := pluck "application_signals" $configCopy.logs.metrics_collected | first }}
 {{- if and (hasKey $configCopy.logs.metrics_collected "application_signals") (empty $appSignals.hosted_in) }}
-{{- $clusterName := .Values.clusterName | required ".Values.clusterName is required." -}}
-{{- $appSignals := set $appSignals "hosted_in" .Values.clusterName }}
+{{- $clusterName := .Values.clusterName | toString | required ".Values.clusterName is required." -}}
+{{- $appSignals := set $appSignals "hosted_in" $clusterName }}
 {{- end }}
 
 {{- $containerInsights := pluck "kubernetes" $configCopy.logs.metrics_collected | first }}
 {{- if and (hasKey $configCopy.logs.metrics_collected "kubernetes") (empty $containerInsights.cluster_name) }}
-{{- $clusterName := .Values.clusterName | required ".Values.clusterName is required." -}}
-{{- $containerInsights := set $containerInsights "cluster_name" .Values.clusterName }}
+{{- $clusterName := .Values.clusterName | toString | required ".Values.clusterName is required." -}}
+{{- $containerInsights := set $containerInsights "cluster_name" $clusterName }}
 {{- end }}
 
 {{- default ""  $configCopy | toJson | quote }}

--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
@@ -233,7 +233,7 @@ spec:
     value: "True"
   {{ end }}
   - name: K8S_CLUSTER_NAME
-    value: {{ $.Values.clusterName }}
+    value: {{ $.Values.clusterName | quote }}
   {{- dict "component" $agent "context" $ | include "amazon-cloudwatch-observability.common.tolerations" | nindent 2 }}
 ---
 {{- end }}


### PR DESCRIPTION
*Issue #, if available:*

Fixes #193

*Description of changes:*

"This CR modifies the templating of the environment variables in regards to the user-provided cluster name, to surround it with quotes, to ensure that it remains a string regardless of the cluster name. This fixes issues where a cluster name may be something like `409238` which gets translated in yaml to a number, not a string without quotes." - https://github.com/aws-observability/helm-charts/pull/194

*Testing:*
Numerical:
<img width="986" alt="Screenshot 2025-04-16 at 3 27 49 PM" src="https://github.com/user-attachments/assets/03f3dc64-1eaf-46f9-b552-5be9563fdf33" />
<img width="227" alt="Screenshot 2025-04-16 at 3 28 04 PM" src="https://github.com/user-attachments/assets/b8246432-3308-49e8-8b8a-f557449752c7" />

String:
<img width="974" alt="Screenshot 2025-04-16 at 3 29 49 PM" src="https://github.com/user-attachments/assets/f0c796af-cf6c-4f92-ad72-18dfeb535eed" />
<img width="357" alt="Screenshot 2025-04-16 at 3 29 41 PM" src="https://github.com/user-attachments/assets/cd1ddcb3-9a3c-47d9-b90c-aa978dd160a0" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

