### PR TITLE
fix bugs around prometheus cr

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
@@ -105,7 +105,8 @@ spec:
     image: {{ template "target-allocator.image" (merge $agent.prometheus.targetAllocator.image (dict "region" $.Values.region)) }}
     allocationStrategy: "consistent-hashing"
     {{- if $agent.prometheus.targetAllocator.prometheusCR.enabled }}
-    prometheusCR: {{ $agent.prometheus.targetAllocator.prometheusCR.enabled | default false }}
+    prometheusCR:
+      enabled: {{ $agent.prometheus.targetAllocator.prometheusCR.enabled | default false }}
     {{- end }}
   {{- end }}
   {{- with $agent.resources }}

--- a/charts/amazon-cloudwatch-observability/templates/target-allocator-clusterrole.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/target-allocator-clusterrole.yaml
@@ -22,7 +22,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - nonResourceURLs: ["/metrics"]
     verbs: ["get"]
-  {{- if and (hasKey ($customAgent.prometheus.targetAllocator) "PrometheusCR") $customAgent.prometheus.targetAllocator.PrometheusCR.enabled }}
+  {{- if and (hasKey ($customAgent.prometheus.targetAllocator) "prometheusCR") $customAgent.prometheus.targetAllocator.prometheusCR.enabled }}
   - apiGroups: [ "monitoring.coreos.com"]
     resources: ["podmonitors", "servicemonitors"]
     verbs: ["get", "list", "watch"]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The helm charts have bugs around enabling prometheusCR. If prometheusCR is enabled true, it leads to this error.
```
Error: UPGRADE FAILED: cannot patch "cloudwatch-agent" with kind AmazonCloudWatchAgent: admission webhook "mamazoncloudwatchagent.kb.io" denied the request: json: cannot unmarshal bool into Go struct field AmazonCloudWatchAgentTargetAllocator.spec.targetAllocator.prometheusCR of type v1alpha1.AmazonCloudWatchAgentTargetAllocatorPrometheusCR
```

 The value is  passed as 
```
prometheusCR: true
```
Instead of this
```
prometheusCR:
  enabled: true
```
Also there is case bug in target allocator cluster role yaml

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

