### PR TITLE
Introduce config for AutoMonitor (simpler enablement for Application Signals)

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -28,6 +28,7 @@ spec:
         args:
         - {{ printf "--auto-instrumentation-config=%s" (dict "java" (merge .Values.manager.autoInstrumentationResources.java .Values.manager.autoInstrumentationConfiguration.java) "python" (merge .Values.manager.autoInstrumentationResources.python .Values.manager.autoInstrumentationConfiguration.python) "dotnet" (merge .Values.manager.autoInstrumentationResources.dotnet .Values.manager.autoInstrumentationConfiguration.dotnet) "nodejs" (.Values.manager.autoInstrumentationResources.nodejs) | toJson) | quote }}
         - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}
+        - {{ printf "--auto-monitor-config=%s" (.Values.manager.applicationSignals.autoMonitor | toJson) | quote }}
         - "--auto-instrumentation-java-image={{ template "auto-instrumentation-java.image" . }}"
         - "--auto-instrumentation-python-image={{ template "auto-instrumentation-python.image" . }}"
         - "--auto-instrumentation-dotnet-image={{ template "auto-instrumentation-dotnet.image" . }}"

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -1037,7 +1037,7 @@ manager:
   name:
   image:
     repository: cloudwatch-agent-operator
-    tag: 2.2.1
+    tag: 3.0.0
     repositoryDomainMap:
       public: public.ecr.aws/cloudwatch-agent
       cn-north-1: 934860584483.dkr.ecr.cn-north-1.amazonaws.com.cn
@@ -1061,6 +1061,53 @@ manager:
       repositoryDomain: public.ecr.aws/aws-observability
       repository: adot-autoinstrumentation-node
       tag: v0.6.0
+  applicationSignals:
+    autoMonitor:
+      monitorAllServices: false
+      languages: ["java", "python", "dotnet", "nodejs"]
+      restartPods: false
+      exclude:
+        java:
+          namespaces: []
+          deployments: []
+          daemonsets: []
+          statefulsets: []
+        python:
+          namespaces: []
+          deployments: []
+          daemonsets: []
+          statefulsets: []
+        dotnet:
+          namespaces: []
+          deployments: []
+          daemonsets: []
+          statefulsets: []
+        nodejs:
+          namespaces: []
+          deployments: []
+          daemonsets: []
+          statefulsets: []
+      customSelector:
+        java:
+          namespaces: []
+          deployments: []
+          daemonsets: []
+          statefulsets: []
+        python:
+          namespaces: []
+          deployments: []
+          daemonsets: []
+          statefulsets: []
+        dotnet:
+          namespaces: []
+          deployments: []
+          daemonsets: []
+          statefulsets: []
+        nodejs:
+          namespaces: []
+          deployments: []
+          daemonsets: []
+          statefulsets: []
   autoInstrumentationConfiguration:
     java:
       runtime_metrics:


### PR DESCRIPTION
### Changes
Adds helm-charts support for https://github.com/aws/amazon-cloudwatch-agent-operator/pull/309

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

### Testing

```
~/GolandProjects/helm-charts (mpmann/1-step-enablement ✔) minikube start
😄  minikube v1.35.0 on Darwin 15.4.1 (arm64)
✨  Using the docker driver based on user configuration
📌  Using Docker Desktop driver with root privileges
👍  Starting "minikube" primary control-plane node in "minikube" cluster
🚜  Pulling base image v0.0.46 ...
🔥  Creating docker container (CPUs=2, Memory=8100MB) ...
🐳  Preparing Kubernetes v1.32.0 on Docker 27.4.1 ...
    ▪ Generating certificates and keys .../ ^[
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
~/GolandProjects/helm-charts (mpmann/1-step-enablement ✔) helm upgrade --install --namespace amazon-cloudwatch amazon-cloudwatch-observability ./charts/amazon-cloudwatch-observability/ --set clusterName=minikube --set region=us-west-2 --create-namespace
Release "amazon-cloudwatch-observability" does not exist. Installing it now.
NAME: amazon-cloudwatch-observability
LAST DEPLOYED: Fri May  9 14:13:55 2025
NAMESPACE: amazon-cloudwatch
STATUS: deployed
REVISION: 1
TEST SUITE: None
```

```
~/GolandProjects/helm-charts (mpmann/1-step-enablement ✔) kubectl get deployment/amazon-cloudwatch-observability-controller-manager -n amazon-cloudwatch -o yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  annotations:
    deployment.kubernetes.io/revision: "1"
    meta.helm.sh/release-name: amazon-cloudwatch-observability
    meta.helm.sh/release-namespace: amazon-cloudwatch
  creationTimestamp: "2025-05-09T18:13:57Z"
  generation: 1
  labels:
    app.kubernetes.io/instance: amazon-cloudwatch-observability
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: amazon-cloudwatch-observability
    app.kubernetes.io/version: 1.0.0
    control-plane: controller-manager
  name: amazon-cloudwatch-observability-controller-manager
  namespace: amazon-cloudwatch
  resourceVersion: "442"
  uid: 86170d7c-97e9-4141-9033-fcb4be274e37
spec:
  progressDeadlineSeconds: 600
  replicas: 1
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app.kubernetes.io/name: amazon-cloudwatch-observability
      control-plane: controller-manager
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
    type: RollingUpdate
  template:
    metadata:
      creationTimestamp: null
      labels:
        app.kubernetes.io/name: amazon-cloudwatch-observability
        control-plane: controller-manager
    spec:
      containers:
      - args:
        - --auto-instrumentation-config={"dotnet":{"limits":{"cpu":"500m","memory":"128Mi"},"requests":{"cpu":"50m","memory":"128Mi"},"runtime_metrics":{"enabled":"true"}},"java":{"limits":{"cpu":"500m","memory":"64Mi"},"requests":{"cpu":"50m","memory":"64Mi"},"runtime_metrics":{"enabled":"true"}},"nodejs":{"limits":{"cpu":"500m","memory":"128Mi"},"requests":{"cpu":"50m","memory":"128Mi"}},"python":{"limits":{"cpu":"500m","memory":"32Mi"},"requests":{"cpu":"50m","memory":"32Mi"},"runtime_metrics":{"enabled":"true"}}}
        - --auto-annotation-config={"dotnet":{"daemonsets":[],"deployments":[],"namespaces":[],"statefulsets":[]},"java":{"daemonsets":[],"deployments":[],"namespaces":[],"statefulsets":[]},"nodejs":{"daemonsets":[],"deployments":[],"namespaces":[],"statefulsets":[]},"python":{"daemonsets":[],"deployments":[],"namespaces":[],"statefulsets":[]}}
        - --auto-monitor-config={"customSelector":{"dotnet":{"daemonsets":[],"deployments":[],"namespaces":[],"statefulsets":[]},"java":{"daemonsets":[],"deployments":[],"namespaces":[],"statefulsets":[]},"nodejs":{"daemonsets":[],"deployments":[],"namespaces":[],"statefulsets":[]},"python":{"daemonsets":[],"deployments":[],"namespaces":[],"statefulsets":[]}},"exclude":{"dotnet":{"daemonsets":[],"deployments":[],"namespaces":[],"statefulsets":[]},"java":{"daemonsets":[],"deployments":[],"namespaces":[],"statefulsets":[]},"nodejs":{"daemonsets":[],"deployments":[],"namespaces":[],"statefulsets":[]},"python":{"daemonsets":[],"deployments":[],"namespaces":[],"statefulsets":[]}},"languages":["java","python","dotnet","nodejs"],"monitorAllServices":false,"restartPods":false}
        - --auto-instrumentation-java-image=public.ecr.aws/aws-observability/adot-autoinstrumentation-java:v2.10.0
        - --auto-instrumentation-python-image=public.ecr.aws/aws-observability/adot-autoinstrumentation-python:v0.9.0
        - --auto-instrumentation-dotnet-image=public.ecr.aws/aws-observability/adot-autoinstrumentation-dotnet:v1.7.0
        - --auto-instrumentation-nodejs-image=public.ecr.aws/aws-observability/adot-autoinstrumentation-node:v0.6.0
        - --target-allocator-image=public.ecr.aws/cloudwatch-agent/cloudwatch-agent-target-allocator:1.0.0
        - --feature-gates=operator.autoinstrumentation.multi-instrumentation,operator.autoinstrumentation.multi-instrumentation.skip-container-validation
        command:
        - /manager
        image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent-operator:3.0.0
        imagePullPolicy: IfNotPresent
        name: manager
        ports:
        - containerPort: 9443
          name: webhook-server
          protocol: TCP
        resources:
          requests:
            cpu: 100m
            memory: 64Mi
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
        volumeMounts:
        - mountPath: /tmp/k8s-webhook-server/serving-certs
          name: cert
          readOnly: true
      dnsPolicy: ClusterFirst
      nodeSelector:
        kubernetes.io/os: linux
      restartPolicy: Always
      schedulerName: default-scheduler
      securityContext: {}
      serviceAccount: amazon-cloudwatch-observability-controller-manager
      serviceAccountName: amazon-cloudwatch-observability-controller-manager
      terminationGracePeriodSeconds: 10
      volumes:
      - name: cert
        secret:
          defaultMode: 420
          secretName: amazon-cloudwatch-observability-controller-manager-service-cert
status:
  conditions:
  - lastTransitionTime: "2025-05-09T18:13:57Z"
    lastUpdateTime: "2025-05-09T18:13:57Z"
    message: Deployment does not have minimum availability.
    reason: MinimumReplicasUnavailable
    status: "False"
    type: Available
  - lastTransitionTime: "2025-05-09T18:13:57Z"
    lastUpdateTime: "2025-05-09T18:13:57Z"
    message: ReplicaSet "amazon-cloudwatch-observability-controller-manager-67fbc4994f"
      is progressing.
    reason: ReplicaSetUpdated
    status: "True"
    type: Progressing
  observedGeneration: 1
  replicas: 1
  unavailableReplicas: 1
  updatedReplicas: 1
  ```