### PR TITLE
Fix dcgm exporter image

### DIFF
--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -1336,7 +1336,7 @@ dcgmExporter:
   name:
   image:
     repository: dcgm-exporter
-    tag: 3.3.9-3.6.1-ubuntu22.04-amd64
+    tag: 3.3.9-3.6.1-ubuntu22.04
     repositoryDomainMap:
       public: nvcr.io/nvidia/k8s
       cn-north-1: 934860584483.dkr.ecr.cn-north-1.amazonaws.com.cn


### PR DESCRIPTION
*Description of changes:* Keep the dcgm image unchanged i.e. `3.3.9-3.6.1-ubuntu22.04`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

