### PR TITLE
upgrade neuron monitor version to 1.5.0

### DIFF
--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -1502,7 +1502,7 @@ neuronMonitor:
   name:
   image:
     repository: neuron-monitor
-    tag: 1.4.0
+    tag: 1.5.0
     repositoryDomainMap:
       public: public.ecr.aws/neuron
   resources:


### PR DESCRIPTION
*Description of changes:*
Upgrade the neuron monitor version to 1.5.0

*Test*
<img width="1409" alt="Screenshot 2025-05-22 at 11 33 42 AM" src="https://github.com/user-attachments/assets/967ce78d-8f4f-4626-9475-5150205e117e" />
Metrics are showing 0s with no active workloads. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


