### PR TITLE
Updating values.yaml to use the latest version of aws-for-fluent-bit

### DIFF
--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -19,7 +19,7 @@ containerLogs:
   fluentBit:
     image:
       repository: aws-for-fluent-bit
-      tag: 2.32.5.20250327
+      tag: 2.32.5.20250527
       tagWindows: 2.31.12-windowsservercore
       repositoryDomainMap:
         public: public.ecr.aws/aws-observability


### PR DESCRIPTION
1. Bumping aws-for-fluent-bit to 2.32.5.20250527 based on this release - https://github.com/aws/aws-for-fluent-bit/releases


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

