### PR TITLE
Set deploymentUpdateStrategy when agent mode is deployment

### DIFF
--- a/charts/amazon-cloudwatch-observability/crds/cloudwatch.aws.amazon.com_amazoncloudwatchagents.yaml
+++ b/charts/amazon-cloudwatch-observability/crds/cloudwatch.aws.amazon.com_amazoncloudwatchagents.yaml
@@ -2595,6 +2595,59 @@ spec:
                       - name
                     type: object
                   type: array
+                deploymentUpdateStrategy:
+                  description: |-
+                    UpdateStrategy represents the strategy the operator will take replacing existing Deployment pods with new pods
+                    https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/deployment-v1/#DeploymentSpec
+                    This is only applicable to Deployment mode.
+                  properties:
+                    rollingUpdate:
+                      description: |-
+                        Rolling update config params. Present only if DeploymentStrategyType =
+                        RollingUpdate.
+                        ---
+                        TODO: Update this to follow our convention for oneOf, whatever we decide it
+                        to be.
+                      properties:
+                        maxSurge:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: |-
+                            The maximum number of pods that can be scheduled above the desired number of
+                            pods.
+                            Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                            This can not be 0 if MaxUnavailable is 0.
+                            Absolute number is calculated from percentage by rounding up.
+                            Defaults to 25%.
+                            Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when
+                            the rolling update starts, such that the total number of old and new pods do not exceed
+                            130% of desired pods. Once old pods have been killed,
+                            new ReplicaSet can be scaled up further, ensuring that total number of pods running
+                            at any time during the update is at most 130% of desired pods.
+                          x-kubernetes-int-or-string: true
+                        maxUnavailable:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: |-
+                            The maximum number of pods that can be unavailable during the update.
+                            Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                            Absolute number is calculated from percentage by rounding down.
+                            This can not be 0 if MaxSurge is 0.
+                            Defaults to 25%.
+                            Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods
+                            immediately when the rolling update starts. Once new pods are ready, old ReplicaSet
+                            can be scaled down further, followed by scaling up the new ReplicaSet, ensuring
+                            that the total number of pods available at all times during the update is at
+                            least 70% of desired pods.
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    type:
+                      description: Type of deployment. Can be "Recreate" or "RollingUpdate".
+                        Default is RollingUpdate.
+                      type: string
+                  type: object
                 env:
                   description: |-
                     ENV vars to set on the OpenTelemetry Collector's Pods. These can then in certain cases be

--- a/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
@@ -87,6 +87,14 @@ Helper function to modify cloudwatch-agent YAML config
 {{- end -}}
 {{- end -}}
 
+{{- define "cloudwatch-agent.updateStrategy" -}}
+{{- if eq .mode "deployment" -}}
+deploymentUpdateStrategy
+{{- else -}}
+updateStrategy
+{{- end -}}
+{{- end -}}
+
 {{- define "cloudwatch-agent.rolloutStrategyMaxSurge" -}}
 {{- if eq .mode "daemonset" -}}
 0

--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
@@ -71,13 +71,13 @@ metadata:
   name: {{ $agent.name | default (include "cloudwatch-agent.name" $) }}
   namespace: {{ $.Release.Namespace }}
 spec:
-  updateStrategy:
-      type: {{ $agent.updateStrategy.type }}
-      {{- if eq $agent.updateStrategy.type "RollingUpdate" }}
-      rollingUpdate:
-        maxUnavailable: {{ $agent.updateStrategy.rollingUpdate.maxUnavailable | default (include "cloudwatch-agent.rolloutStrategyMaxUnavailable" (dict "mode" $agent.mode)) }}
-        maxSurge: {{ $agent.updateStrategy.rollingUpdate.maxSurge | default (include "cloudwatch-agent.rolloutStrategyMaxSurge" (dict "mode" $agent.mode)) }}
-      {{- end }}
+  {{ template "cloudwatch-agent.updateStrategy" (dict "mode" $agent.mode) }}:
+    type: {{ $agent.updateStrategy.type }}
+    {{- if eq $agent.updateStrategy.type "RollingUpdate" }}
+    rollingUpdate:
+      maxUnavailable: {{ $agent.updateStrategy.rollingUpdate.maxUnavailable | default (include "cloudwatch-agent.rolloutStrategyMaxUnavailable" (dict "mode" $agent.mode)) }}
+      maxSurge: {{ $agent.updateStrategy.rollingUpdate.maxSurge | default (include "cloudwatch-agent.rolloutStrategyMaxSurge" (dict "mode" $agent.mode)) }}
+    {{- end }}
   image: {{ template "cloudwatch-agent.image" (merge $agent.image (dict "region" $.Values.region)) }}
   mode: {{ $agent.mode }}
   replicas: {{ $agent.replicas }}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Currently, spinning up the agent with its mode as `deployment` causes it to fail with the following error:
```the OpenTelemetry Collector mode is set to deployment, which does not support the attribute 'updateStrategy'```

https://github.com/aws/amazon-cloudwatch-agent-operator/pull/320 updated the CRD to allow specifying `deploymentUpdateStrategy` when the agent mode is `deployment`. Hence the helm chart will also now conditionally set the correct field on the custom resource depending on the agent mode.

*Testing:*
Before change:
```
➜  helm-charts git:(main) ✗ helm upgrade --install --wait --create-namespace --namespace amazon-cloudwatch amazon-cloudwatch-observability ./charts/amazon-cloudwatch-observability --set clusterName=cw1 --set region=us-east-1 --set agent.mode=deployment
Release "amazon-cloudwatch-observability" does not exist. Installing it now.
NAME: amazon-cloudwatch-observability
LAST DEPLOYED: Wed Jun 25 13:14:21 2025
NAMESPACE: amazon-cloudwatch
STATUS: deployed
REVISION: 1
TEST SUITE: None
➜  helm-charts git:(main) ✗ helm upgrade --install --wait --create-namespace --namespace amazon-cloudwatch amazon-cloudwatch-observability ./charts/amazon-cloudwatch-observability --set clusterName=cw1 --set region=us-east-1 --set agent.mode=deployment
Error: UPGRADE FAILED: cannot patch "cloudwatch-agent" with kind AmazonCloudWatchAgent: admission webhook "vamazoncloudwatchagentcreateupdate.kb.io" denied the request: the OpenTelemetry Collector mode is set to deployment, which does not support the attribute 'updateStrategy'
```
After change:
```
➜  helm-charts git:(sky333999/update-strategy) ✗ helm upgrade --install --wait --create-namespace --namespace amazon-cloudwatch amazon-cloudwatch-observability ./charts/amazon-cloudwatch-observability --set clusterName=cw1 --set region=us-east-1 --set agent.mode=deployment
Release "amazon-cloudwatch-observability" does not exist. Installing it now.
NAME: amazon-cloudwatch-observability
LAST DEPLOYED: Wed Jun 25 13:17:36 2025
NAMESPACE: amazon-cloudwatch
STATUS: deployed
REVISION: 1
TEST SUITE: None
➜  helm-charts git:(sky333999/update-strategy) ✗ helm upgrade --install --wait --create-namespace --namespace amazon-cloudwatch amazon-cloudwatch-observability ./charts/amazon-cloudwatch-observability --set clusterName=cw1 --set region=us-east-1 --set agent.mode=deployment
Release "amazon-cloudwatch-observability" has been upgraded. Happy Helming!
NAME: amazon-cloudwatch-observability
LAST DEPLOYED: Wed Jun 25 13:17:51 2025
NAMESPACE: amazon-cloudwatch
STATUS: deployed
REVISION: 2
TEST SUITE: None
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

