### PR TITLE
Increase dcgm-exporter memory limit to 750Mi

### DIFF
--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -1352,7 +1352,7 @@ dcgmExporter:
       memory: 128Mi
     limits:
       cpu: 500m
-      memory: 500Mi
+      memory: 750Mi
   ## Override root tolerations
   # tolerations: []
   configmap: dcgm-exporter-config-map


### PR DESCRIPTION
*Description of changes:* Increasing the default dcgm-exporter memory limit to 750Mi; keeping the requests the same.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

