### PR TITLE
Add Tensor core utilization to DCGM exporter daemonset metrics config

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/linux/dcgm-exporter-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/dcgm-exporter-daemonset.yaml
@@ -63,6 +63,7 @@ spec:
     DCGM_FI_DEV_MEMORY_TEMP, gauge, Memory temperature (in C).
     DCGM_FI_DEV_GPU_TEMP,    gauge, GPU temperature (in C).
     DCGM_FI_DEV_POWER_USAGE,              gauge, Power draw (in W).
+    DCGM_FI_PROF_PIPE_TENSOR_ACTIVE, gauge, Tensor Core utilization (in %).
   tlsConfig: |
     tls_server_config:
       cert_file: /etc/amazon-cloudwatch-observability-dcgm-cert/server.crt


### PR DESCRIPTION
## Description 
Updated the metricsConfig list to include a new Tensor Core Utilization field identifier 

### Related PRs
* Opentelemetry: https://github.com/amazon-contributing/opentelemetry-collector-contrib/pull/338
* Agent: https://github.com/aws/amazon-cloudwatch-agent/pull/1814