### PR TITLE
Set Application Signals Auto Monitor to true by default

### DIFF
--- a/.github/workflows/amazon-cloudwatch-observability-integration-test.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-integration-test.yaml
@@ -32,9 +32,43 @@ jobs:
       - name: Build
         run: make all
 
+  Minikube-IntegrationTests:
+    name: Minikube
+    needs: [ Build ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        scenario: [default, appsignals-disabled, appsignals-disabled-multi-agents, appsignals-enabled-multi-agents]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Start minikube
+        uses: medyagh/setup-minikube@master
+        with:
+          driver: docker
+
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.1.7"
+
+      - name: Run scenario test
+        run: |
+          cd integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/${{ matrix.scenario }}
+          terraform init
+          terraform apply -auto-approve
+          terraform destroy -auto-approve
+
+      - name: Cleanup on failure
+        if: ${{ cancelled() || failure() }}
+        run: |
+          cd integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/${{ matrix.scenario }}
+          terraform destroy -auto-approve || true
+
   EKS-IntegrationTest:
     name: EKS-IntegrationTest
-    needs: [ Build ]
+    needs: [ Minikube-IntegrationTests ]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -95,7 +129,7 @@ jobs:
 
   EKS-IntegrationTest-Win2022:
     name: EKS-IntegrationTest-Win2022
-    needs: [ Build ]
+    needs: [ Minikube-IntegrationTests ]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -156,7 +190,7 @@ jobs:
 
   EKS-IntegrationTest-Win2019:
     name: EKS-IntegrationTest-Win2019
-    needs: [ Build ]
+    needs: [ Minikube-IntegrationTests ]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -28,7 +28,7 @@ spec:
         args:
         - {{ printf "--auto-instrumentation-config=%s" (dict "java" (merge .Values.manager.autoInstrumentationResources.java .Values.manager.autoInstrumentationConfiguration.java) "python" (merge .Values.manager.autoInstrumentationResources.python .Values.manager.autoInstrumentationConfiguration.python) "dotnet" (merge .Values.manager.autoInstrumentationResources.dotnet .Values.manager.autoInstrumentationConfiguration.dotnet) "nodejs" (.Values.manager.autoInstrumentationResources.nodejs) | toJson) | quote }}
         - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}
-        - {{ printf "--auto-monitor-config=%s" (.Values.manager.applicationSignals.autoMonitor | toJson) | quote }}
+        - {{ printf "--auto-monitor-config=%s" (include "manager.modify-auto-monitor-config" .) | quote }}
         - "--auto-instrumentation-java-image={{ template "auto-instrumentation-java.image" . }}"
         - "--auto-instrumentation-python-image={{ template "auto-instrumentation-python.image" . }}"
         - "--auto-instrumentation-dotnet-image={{ template "auto-instrumentation-dotnet.image" . }}"

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -1063,7 +1063,7 @@ manager:
       tag: v0.7.0
   applicationSignals:
     autoMonitor:
-      monitorAllServices: false
+      monitorAllServices: true
       languages:
         - java
         - python

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/main.tf
@@ -1,0 +1,54 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+terraform {
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "kubernetes" {
+  config_path = "~/.kube/config"
+}
+
+provider "helm" {
+  kubernetes {
+    config_path = "~/.kube/config"
+  }
+}
+
+resource "null_resource" "minikube_start" {
+  provisioner "local-exec" {
+    command = <<-EOT
+      minikube start --driver=docker --kubernetes-version=${var.k8s_version}
+      minikube status
+    EOT
+  }
+  
+  provisioner "local-exec" {
+    when    = destroy
+    command = "minikube delete"
+  }
+}
+
+resource "helm_release" "cloudwatch_observability" {
+  depends_on = [null_resource.minikube_start]
+
+  name             = "amazon-cloudwatch-observability"
+  namespace        = "amazon-cloudwatch"
+  create_namespace = true
+  chart            = var.helm_dir
+
+  values = [file(var.helm_values_file)]
+}
+
+output "helm_release" {
+  value = helm_release.cloudwatch_observability
+}

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/appsignals-disabled-multi-agents/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/appsignals-disabled-multi-agents/main.tf
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+module "base" {
+  source           = "../.."
+  helm_values_file = "${path.module}/values.yaml"
+  helm_dir         = var.helm_dir
+}
+
+variable "helm_dir" {
+  type    = string
+  default = "../../../../../../charts/amazon-cloudwatch-observability"
+}
+
+resource "null_resource" "validator" {
+  depends_on = [module.base.helm_release]
+
+  provisioner "local-exec" {
+    command = "go test ${var.test_dir} -v -run=TestAppSignalsDisabledMultiAgents"
+  }
+}
+
+variable "test_dir" {
+  type    = string
+  default = "../../../../validations/minikube/scenarios"
+}

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/appsignals-disabled-multi-agents/values.yaml
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/appsignals-disabled-multi-agents/values.yaml
@@ -1,0 +1,27 @@
+region: us-west-2
+clusterName: minikube
+
+agents:
+  - name: cloudwatch-agent
+    config:
+      {
+        "logs": {
+          "metrics_collected": {
+            "kubernetes": {
+              "enhanced_container_insights": true
+            }
+          }
+        }
+      }
+  - name: cloudwatch-agent-prom
+    mode: deployment
+    config:
+      {
+        "metrics": {
+          "metrics_collected": {
+            "prometheus": {
+              "prometheus_config_path": "/test/path"
+            }
+          }
+        }
+      }

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/appsignals-disabled/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/appsignals-disabled/main.tf
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+module "base" {
+  source           = "../.."
+  helm_values_file = "${path.module}/values.yaml"
+  helm_dir         = var.helm_dir
+}
+
+variable "helm_dir" {
+  type    = string
+  default = "../../../../../../charts/amazon-cloudwatch-observability"
+}
+
+resource "null_resource" "validator" {
+  depends_on = [module.base.helm_release]
+
+  provisioner "local-exec" {
+    command = "go test ${var.test_dir} -v -run=TestAppSignalsDisabled"
+  }
+}
+
+variable "test_dir" {
+  type    = string
+  default = "../../../../validations/minikube/scenarios"
+}

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/appsignals-disabled/values.yaml
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/appsignals-disabled/values.yaml
@@ -1,0 +1,15 @@
+region: us-west-2
+clusterName: minikube
+
+agents:
+  - name: cloudwatch-agent
+    config:
+      {
+        "logs": {
+          "metrics_collected": {
+            "kubernetes": {
+              "enhanced_container_insights": true
+            }
+          }
+        }
+      }

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/appsignals-enabled-multi-agents/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/appsignals-enabled-multi-agents/main.tf
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+module "base" {
+  source           = "../.."
+  helm_dir         = var.helm_dir
+  helm_values_file = "${path.module}/values.yaml"
+}
+
+variable "helm_dir" {
+  type    = string
+  default = "../../../../../../charts/amazon-cloudwatch-observability"
+}
+
+resource "null_resource" "validator" {
+  depends_on = [module.base.helm_release]
+
+  provisioner "local-exec" {
+    command = "go test ${var.test_dir} -v -run=TestAppSignalsEnabledMultiAgents"
+  }
+}
+
+variable "test_dir" {
+  type    = string
+  default = "../../../../validations/minikube/scenarios"
+}

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/appsignals-enabled-multi-agents/values.yaml
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/appsignals-enabled-multi-agents/values.yaml
@@ -1,0 +1,17 @@
+region: us-west-2
+clusterName: minikube
+
+agents:
+  - name: cloudwatch-agent # AppSignals enabled via default config
+  - name: cloudwatch-agent-prom
+    mode: deployment
+    config:
+      {
+        "metrics": {
+          "metrics_collected": {
+            "prometheus": {
+              "prometheus_config_path": "/test/path"
+            }
+          }
+        }
+      }

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/default/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/default/main.tf
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+module "base" {
+  source           = "../.."
+  helm_values_file = "${path.module}/values.yaml"
+  helm_dir         = var.helm_dir
+}
+
+resource "null_resource" "validator" {
+  depends_on = [module.base.helm_release]
+
+  provisioner "local-exec" {
+    command = "go test ${var.test_dir} -v -run=TestDefault"
+  }
+}
+
+variable "test_dir" {
+  type    = string
+  default = "../../../../validations/minikube/scenarios"
+}
+
+variable "helm_dir" {
+  type    = string
+  default = "../../../../../../charts/amazon-cloudwatch-observability"
+}

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/default/values.yaml
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/default/values.yaml
@@ -1,0 +1,2 @@
+region: us-west-2
+clusterName: minikube

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/variables.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/variables.tf
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+variable "k8s_version" {
+  type    = string
+  default = "v1.33.0"
+}
+
+variable "helm_dir" {
+  type    = string
+  default = "../../../../charts/amazon-cloudwatch-observability"
+}
+
+variable "helm_values_file" {
+  type        = string
+  description = "Path to helm values file for the specific scenario"
+}

--- a/integration-tests/amazon-cloudwatch-observability/util/k8sclient.go
+++ b/integration-tests/amazon-cloudwatch-observability/util/k8sclient.go
@@ -3,9 +3,10 @@ package util
 import (
 	"context"
 	"fmt"
-	"k8s.io/client-go/tools/clientcmd"
 	"os"
 	"path/filepath"
+
+	"k8s.io/client-go/tools/clientcmd"
 
 	arv1 "k8s.io/api/admissionregistration/v1"
 	appsV1 "k8s.io/api/apps/v1"
@@ -137,47 +138,80 @@ func (k *K8sClient) ListValidatingWebhookConfigurations() (*arv1.ValidatingWebho
 	return validatingWebhookConfigurations, nil
 }
 
-func ValidateServiceAccount(serviceAccounts *v1.ServiceAccountList, serviceAccountName string) bool {
+func (k *K8sClient) ValidateServiceAccountExists(namespace, serviceAccountName string) (bool, error) {
+	serviceAccounts, err := k.ListServiceAccounts(namespace)
+	if err != nil {
+		return false, err
+	}
 	for _, serviceAccount := range serviceAccounts.Items {
 		if serviceAccount.Name == serviceAccountName {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
-func ValidateClusterRoles(clusterRoles *rbacV1.ClusterRoleList, clusterRoleName string) bool {
+func (k *K8sClient) ValidateClusterRoleExists(clusterRoleName string) (bool, error) {
+	clusterRoles, err := k.ListClusterRoles()
+	if err != nil {
+		return false, err
+	}
 	for _, clusterRole := range clusterRoles.Items {
 		if clusterRole.Name == clusterRoleName {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
-func ValidateRoles(roles *rbacV1.RoleList, roleName string) bool {
+func (k *K8sClient) ValidateRoleExists(namespace, roleName string) (bool, error) {
+	roles, err := k.ListRoles(namespace)
+	if err != nil {
+		return false, err
+	}
 	for _, role := range roles.Items {
 		if role.Name == roleName {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
-func ValidateClusterRoleBindings(clusterRoleBindings *rbacV1.ClusterRoleBindingList, clusterRoleBindingName string) bool {
+func (k *K8sClient) ValidateClusterRoleBindingExists(clusterRoleBindingName string) (bool, error) {
+	clusterRoleBindings, err := k.ListClusterRoleBindings()
+	if err != nil {
+		return false, err
+	}
 	for _, clusterRoleBinding := range clusterRoleBindings.Items {
 		if clusterRoleBinding.Name == clusterRoleBindingName {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
-func ValidateRoleBindings(roleBindings *rbacV1.RoleBindingList, roleBindingName string) bool {
+func (k *K8sClient) ValidateRoleBindingExists(namespace, roleBindingName string) (bool, error) {
+	roleBindings, err := k.ListRoleBindings(namespace)
+	if err != nil {
+		return false, err
+	}
 	for _, roleBinding := range roleBindings.Items {
 		if roleBinding.Name == roleBindingName {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
+}
+
+func (k *K8sClient) ValidateDeploymentExists(namespace, deploymentName string) (bool, error) {
+	deployments, err := k.ListDeployments(namespace)
+	if err != nil {
+		return false, err
+	}
+	for _, deployment := range deployments.Items {
+		if deployment.Name == deploymentName {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/integration-tests/amazon-cloudwatch-observability/validations/eks/resources_generated_test.go
+++ b/integration-tests/amazon-cloudwatch-observability/validations/eks/resources_generated_test.go
@@ -102,34 +102,50 @@ func TestResourcesGenerated(t *testing.T) {
 	for _, sa := range serviceAccounts.Items {
 		t.Logf("serviceAccount: " + sa.Name + " namespace:" + sa.Namespace)
 	}
-	assert.True(t, util.ValidateServiceAccount(serviceAccounts, addOnName+"-controller-manager"))
-	assert.True(t, util.ValidateServiceAccount(serviceAccounts, agentName))
-	assert.True(t, util.ValidateServiceAccount(serviceAccounts, dcgmExporterName+"-service-acct"))
-	assert.True(t, util.ValidateServiceAccount(serviceAccounts, neuronMonitor+"-service-acct"))
+	exists, err := k8sClient.ValidateServiceAccountExists(namespace, addOnName+"-controller-manager")
+	assert.NoError(t, err)
+	assert.True(t, exists)
+	exists, err = k8sClient.ValidateServiceAccountExists(namespace, agentName)
+	assert.NoError(t, err)
+	assert.True(t, exists)
+	exists, err = k8sClient.ValidateServiceAccountExists(namespace, dcgmExporterName+"-service-acct")
+	assert.NoError(t, err)
+	assert.True(t, exists)
+	exists, err = k8sClient.ValidateServiceAccountExists(namespace, neuronMonitor+"-service-acct")
+	assert.NoError(t, err)
+	assert.True(t, exists)
 
 	// Validating ClusterRoles
-	clusterRoles, err := k8sClient.ListClusterRoles()
+	exists, err = k8sClient.ValidateClusterRoleExists(addOnName + "-manager-role")
 	assert.NoError(t, err)
-	assert.True(t, util.ValidateClusterRoles(clusterRoles, addOnName+"-manager-role"))
-	assert.True(t, util.ValidateClusterRoles(clusterRoles, agentName+"-role"))
+	assert.True(t, exists)
+	exists, err = k8sClient.ValidateClusterRoleExists(agentName + "-role")
+	assert.NoError(t, err)
+	assert.True(t, exists)
 
 	// Validating Roles
-	roles, err := k8sClient.ListRoles(namespace)
+	exists, err = k8sClient.ValidateRoleExists(namespace, dcgmExporterName+"-role")
 	assert.NoError(t, err)
-	assert.True(t, util.ValidateRoles(roles, dcgmExporterName+"-role"))
-	assert.True(t, util.ValidateRoles(roles, neuronMonitor+"-role"))
+	assert.True(t, exists)
+	exists, err = k8sClient.ValidateRoleExists(namespace, neuronMonitor+"-role")
+	assert.NoError(t, err)
+	assert.True(t, exists)
 
 	// Validating ClusterRoleBinding
-	clusterRoleBindings, err := k8sClient.ListClusterRoleBindings()
+	exists, err = k8sClient.ValidateClusterRoleBindingExists(addOnName + "-manager-rolebinding")
 	assert.NoError(t, err)
-	assert.True(t, util.ValidateClusterRoleBindings(clusterRoleBindings, addOnName+"-manager-rolebinding"))
-	assert.True(t, util.ValidateClusterRoleBindings(clusterRoleBindings, agentName+"-role-binding"))
+	assert.True(t, exists)
+	exists, err = k8sClient.ValidateClusterRoleBindingExists(agentName + "-role-binding")
+	assert.NoError(t, err)
+	assert.True(t, exists)
 
 	// Validating RoleBinding
-	roleBindings, err := k8sClient.ListRoleBindings(namespace)
+	exists, err = k8sClient.ValidateRoleBindingExists(namespace, dcgmExporterName+"-role-binding")
 	assert.NoError(t, err)
-	assert.True(t, util.ValidateRoleBindings(roleBindings, dcgmExporterName+"-role-binding"))
-	assert.True(t, util.ValidateRoleBindings(roleBindings, neuronMonitor+"-role-binding"))
+	assert.True(t, exists)
+	exists, err = k8sClient.ValidateRoleBindingExists(namespace, neuronMonitor+"-role-binding")
+	assert.NoError(t, err)
+	assert.True(t, exists)
 
 	// Validating MutatingWebhookConfiguration
 	mutatingWebhookConfigurations, err := k8sClient.ListMutatingWebhookConfigurations()

--- a/integration-tests/amazon-cloudwatch-observability/validations/minikube/common.go
+++ b/integration-tests/amazon-cloudwatch-observability/validations/minikube/common.go
@@ -1,0 +1,64 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package minikube
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/aws-observability/helm-charts/integration-tests/amazon-cloudwatch-observability/util"
+	"github.com/stretchr/testify/assert"
+	appsV1 "k8s.io/api/apps/v1"
+)
+
+const (
+	Namespace    = "amazon-cloudwatch"
+	operatorName = "amazon-cloudwatch-observability-controller-manager"
+)
+
+func ValidateOperatorAutoMonitorConfig(t *testing.T, expectedConfig map[string]interface{}) {
+	k8sClient, err := util.NewK8sClient()
+	assert.NoError(t, err)
+
+	deployments, err := k8sClient.ListDeployments(Namespace)
+	assert.NoError(t, err)
+
+	// Find the operator deployment by name
+	var deployment *appsV1.Deployment
+	for i := range deployments.Items {
+		if deployments.Items[i].Name == operatorName {
+			deployment = &deployments.Items[i]
+			break
+		}
+	}
+	assert.NotNil(t, deployment, "operator deployment not found")
+
+	// Find the auto-monitor-config argument
+	var autoMonitorArg string
+	for _, container := range deployment.Spec.Template.Spec.Containers {
+		for _, arg := range container.Args {
+			if strings.HasPrefix(arg, "--auto-monitor-config=") {
+				autoMonitorArg = strings.TrimPrefix(arg, "--auto-monitor-config=")
+				break
+			}
+		}
+	}
+
+	assert.NotEmpty(t, autoMonitorArg, "auto-monitor-config argument not found")
+
+	// Parse the JSON config
+	var config map[string]interface{}
+	err = json.Unmarshal([]byte(autoMonitorArg), &config)
+	assert.NoError(t, err)
+
+	// Validate config matches expected values
+	for key, expectedValue := range expectedConfig {
+		actualValue, exists := config[key]
+		assert.True(t, exists, "key %s not found in config", key)
+		assert.Equal(t, expectedValue, actualValue, "mismatch for key %s", key)
+	}
+
+	t.Logf("auto-monitor-config: %s", autoMonitorArg)
+}

--- a/integration-tests/amazon-cloudwatch-observability/validations/minikube/scenarios/appsignals_disabled_multi_agents_test.go
+++ b/integration-tests/amazon-cloudwatch-observability/validations/minikube/scenarios/appsignals_disabled_multi_agents_test.go
@@ -1,0 +1,37 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package scenarios
+
+import (
+	"testing"
+
+	"github.com/aws-observability/helm-charts/integration-tests/amazon-cloudwatch-observability/util"
+	"github.com/aws-observability/helm-charts/integration-tests/amazon-cloudwatch-observability/validations/minikube"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAppSignalsDisabledMultiAgents(t *testing.T) {
+	k8sClient, err := util.NewK8sClient()
+	assert.NoError(t, err)
+
+	// Validate namespace exists
+	ns, err := k8sClient.GetNamespace(minikube.Namespace)
+	assert.NoError(t, err)
+	assert.Equal(t, minikube.Namespace, ns.Name)
+
+	// Validate operator deployment exists
+	exists, err := k8sClient.ValidateDeploymentExists(minikube.Namespace, "amazon-cloudwatch-observability-controller-manager")
+	assert.NoError(t, err)
+	assert.True(t, exists)
+
+	// Validate auto-monitor-config has monitorAllServices: false
+	// because AppSignals is disabled on all agents
+	expectedConfig := map[string]interface{}{
+		"monitorAllServices": false,
+		"languages":          []interface{}{"java", "python", "dotnet", "nodejs"},
+	}
+	minikube.ValidateOperatorAutoMonitorConfig(t, expectedConfig)
+
+	t.Log("AppSignals disabled multi agents scenario validation passed")
+}

--- a/integration-tests/amazon-cloudwatch-observability/validations/minikube/scenarios/appsignals_disabled_test.go
+++ b/integration-tests/amazon-cloudwatch-observability/validations/minikube/scenarios/appsignals_disabled_test.go
@@ -1,0 +1,37 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package scenarios
+
+import (
+	"testing"
+
+	"github.com/aws-observability/helm-charts/integration-tests/amazon-cloudwatch-observability/util"
+	"github.com/aws-observability/helm-charts/integration-tests/amazon-cloudwatch-observability/validations/minikube"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAppSignalsDisabled(t *testing.T) {
+	k8sClient, err := util.NewK8sClient()
+	assert.NoError(t, err)
+
+	// Validate namespace exists
+	ns, err := k8sClient.GetNamespace(minikube.Namespace)
+	assert.NoError(t, err)
+	assert.Equal(t, minikube.Namespace, ns.Name)
+
+	// Validate operator deployment exists
+	exists, err := k8sClient.ValidateDeploymentExists(minikube.Namespace, "amazon-cloudwatch-observability-controller-manager")
+	assert.NoError(t, err)
+	assert.True(t, exists)
+
+	// Validate auto-monitor-config has monitorAllServices: false
+	// because AppSignals is NOT enabled in agent config
+	expectedConfig := map[string]interface{}{
+		"monitorAllServices": false,
+		"languages":          []interface{}{"java", "python", "dotnet", "nodejs"},
+	}
+	minikube.ValidateOperatorAutoMonitorConfig(t, expectedConfig)
+
+	t.Log("AppSignals disabled scenario validation passed")
+}

--- a/integration-tests/amazon-cloudwatch-observability/validations/minikube/scenarios/appsignals_enabled_multi_agents_test.go
+++ b/integration-tests/amazon-cloudwatch-observability/validations/minikube/scenarios/appsignals_enabled_multi_agents_test.go
@@ -1,0 +1,37 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package scenarios
+
+import (
+	"testing"
+
+	"github.com/aws-observability/helm-charts/integration-tests/amazon-cloudwatch-observability/util"
+	"github.com/aws-observability/helm-charts/integration-tests/amazon-cloudwatch-observability/validations/minikube"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAppSignalsEnabledMultiAgents(t *testing.T) {
+	k8sClient, err := util.NewK8sClient()
+	assert.NoError(t, err)
+
+	// Validate namespace exists
+	ns, err := k8sClient.GetNamespace(minikube.Namespace)
+	assert.NoError(t, err)
+	assert.Equal(t, minikube.Namespace, ns.Name)
+
+	// Validate operator deployment exists
+	exists, err := k8sClient.ValidateDeploymentExists(minikube.Namespace, "amazon-cloudwatch-observability-controller-manager")
+	assert.NoError(t, err)
+	assert.True(t, exists)
+
+	// Validate auto-monitor-config has monitorAllServices: true
+	// because AppSignals is by default enabled on the daemonSet agent
+	expectedConfig := map[string]interface{}{
+		"monitorAllServices": true,
+		"languages":          []interface{}{"java", "python", "dotnet", "nodejs"},
+	}
+	minikube.ValidateOperatorAutoMonitorConfig(t, expectedConfig)
+
+	t.Log("AppSignals enabled multi agents scenario validation passed")
+}

--- a/integration-tests/amazon-cloudwatch-observability/validations/minikube/scenarios/default_test.go
+++ b/integration-tests/amazon-cloudwatch-observability/validations/minikube/scenarios/default_test.go
@@ -1,0 +1,37 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package scenarios
+
+import (
+	"testing"
+
+	"github.com/aws-observability/helm-charts/integration-tests/amazon-cloudwatch-observability/util"
+	"github.com/aws-observability/helm-charts/integration-tests/amazon-cloudwatch-observability/validations/minikube"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefault(t *testing.T) {
+	k8sClient, err := util.NewK8sClient()
+	assert.NoError(t, err)
+
+	// Validate namespace exists
+	ns, err := k8sClient.GetNamespace(minikube.Namespace)
+	assert.NoError(t, err)
+	assert.Equal(t, minikube.Namespace, ns.Name)
+
+	// Validate operator deployment exists
+	exists, err := k8sClient.ValidateDeploymentExists(minikube.Namespace, "amazon-cloudwatch-observability-controller-manager")
+	assert.NoError(t, err)
+	assert.True(t, exists)
+
+	// Validate auto-monitor-config uses default values
+	// Default config has AppSignals enabled, so monitorAllServices should be true
+	expectedConfig := map[string]interface{}{
+		"monitorAllServices": true,
+		"languages":          []interface{}{"java", "python", "dotnet", "nodejs"},
+	}
+	minikube.ValidateOperatorAutoMonitorConfig(t, expectedConfig)
+
+	t.Log("Default scenario validation passed")
+}


### PR DESCRIPTION
*Description of changes:*
* Enables `applicationSignals` -> `autoMonitor` -> `monitorAllServices` by default.
* Adds logic to check if Application Signals is disabled on all CloudWatchAgent installations and if yes, disable `monitorAllServices`.
* Introduces minikube based integ tests to validate different scenarios. Added the following scenarios:
  * Default scenario
  * AppSignals disabled
  * AppSignals disabled on all agents, in a multi-agent setup
  * AppSignals enabled on atleast one agent, in a multi-agent setup

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
