### PR TITLE
Add automatic rolling deployment & option to re-create admission webhook certs

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
@@ -342,3 +342,33 @@ Define the default service name
 {{- define "amazon-cloudwatch-observability.webhookServiceName" -}}
 {{- default (printf "%s-webhook-service" (include "amazon-cloudwatch-observability.name" .)) .Values.manager.service.name }}
 {{- end -}}
+
+{{/*
+Returns auto-generated certificate and CA for admission webhooks.
+*/}}
+{{- define "amazon-cloudwatch-observability.webhookCert" -}}
+{{- $tlsCrt := "" }}
+{{- $tlsKey := "" }}
+{{- $caCrt := "" }}
+{{- if .Values.admissionWebhooks.autoGenerateCert.enabled }}
+{{- $existingCert := ( lookup "v1" "Secret" .Release.Namespace (include "amazon-cloudwatch-observability.certificateSecretName" .) ) }}
+{{- if and (not .Values.admissionWebhooks.autoGenerateCert.recreate) $existingCert }}
+{{- $tlsCrt = index $existingCert "data" "tls.crt" }}
+{{- $tlsKey = index $existingCert "data" "tls.key" }}
+{{- $caCrt = index $existingCert "data" "ca.crt" }}
+{{- if not $caCrt }}
+{{- $existingWebhook := ( lookup "admissionregistration.k8s.io/v1" "MutatingWebhookConfiguration" "" (printf "%s-mutating-webhook-configuration" (include "amazon-cloudwatch-observability.name" .)) ) }}
+{{- $caCrt = (first $existingWebhook.webhooks).clientConfig.caBundle }}
+{{- end }}
+{{- else }}
+{{- $altNames := list ( printf "%s-webhook-service.%s" (include "amazon-cloudwatch-observability.name" .) .Release.Namespace ) ( printf "%s-webhook-service.%s.svc" (include "amazon-cloudwatch-observability.name" .) .Release.Namespace ) ( printf "%s-webhook-service.%s.svc.cluster.local" (include "amazon-cloudwatch-observability.name" .) .Release.Namespace ) -}}
+{{- $ca := genCA ( printf "%s-ca" (include "amazon-cloudwatch-observability.name" .) ) ( .Values.admissionWebhooks.autoGenerateCert.expiryDays | int ) -}}
+{{- $cert := genSignedCert (include "amazon-cloudwatch-observability.name" .) nil $altNames ( .Values.admissionWebhooks.autoGenerateCert.expiryDays | int ) $ca -}}
+{{- $tlsCrt = b64enc $cert.Cert }}
+{{- $tlsKey = b64enc $cert.Key }}
+{{- $caCrt = b64enc $ca.Cert }}
+{{- end }}
+{{- $result := dict "Cert" $tlsCrt "Key" $tlsKey "Ca" $caCrt }}
+{{- $result | toYaml }}
+{{- end }}
+{{- end }}

--- a/charts/amazon-cloudwatch-observability/templates/admission-webhooks/operator-webhook.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/admission-webhooks/operator-webhook.yaml
@@ -1,7 +1,5 @@
 {{- if and (.Values.admissionWebhooks.create) (.Values.admissionWebhooks.autoGenerateCert.enabled) (not .Values.admissionWebhooks.certManager.enabled) }}
-{{- $altNames := list ( printf "%s-webhook-service.%s" (include "amazon-cloudwatch-observability.name" .) .Release.Namespace ) ( printf "%s-webhook-service.%s.svc" (include "amazon-cloudwatch-observability.name" .) .Release.Namespace ) ( printf "%s-webhook-service.%s.svc.cluster.local" (include "amazon-cloudwatch-observability.name" .) .Release.Namespace ) -}}
-{{- $ca := genCA ( printf "%s-ca" (include "amazon-cloudwatch-observability.name" .) ) ( .Values.admissionWebhooks.autoGenerateCert.expiryDays | int ) -}}
-{{- $cert := genSignedCert (include "amazon-cloudwatch-observability.name" .) nil $altNames ( .Values.admissionWebhooks.autoGenerateCert.expiryDays | int ) $ca -}}
+{{- $cert := fromYaml (include "amazon-cloudwatch-observability.webhookCert" .) }}
 apiVersion: v1
 kind: Secret
 type: kubernetes.io/tls
@@ -11,8 +9,8 @@ metadata:
   name: {{ template "amazon-cloudwatch-observability.certificateSecretName" . }}
   namespace: {{ .Release.Namespace }}
 data:
-  tls.crt: {{ $cert.Cert | b64enc }}
-  tls.key: {{ $cert.Key | b64enc }}
+  tls.crt: {{ $cert.Cert }}
+  tls.key: {{ $cert.Key }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -28,7 +26,7 @@ webhooks:
       name: {{ template "amazon-cloudwatch-observability.webhookServiceName" . }}
       namespace: {{ .Release.Namespace }}
       path: /mutate-cloudwatch-aws-amazon-com-v1alpha1-instrumentation
-    caBundle: {{ $ca.Cert | b64enc }}
+    caBundle: {{ $cert.Ca }}
   failurePolicy: {{ .Values.admissionWebhooks.failurePolicy }}
   name: minstrumentation.kb.io
   {{- if .Values.admissionWebhooks.namespaceSelector }}
@@ -58,7 +56,7 @@ webhooks:
       name: {{ template "amazon-cloudwatch-observability.webhookServiceName" . }}
       namespace: {{ .Release.Namespace }}
       path: /mutate-cloudwatch-aws-amazon-com-v1alpha1-amazoncloudwatchagent
-    caBundle: {{ $ca.Cert | b64enc }}
+    caBundle: {{ $cert.Ca }}
   failurePolicy: {{ .Values.admissionWebhooks.failurePolicy }}
   name: mamazoncloudwatchagent.kb.io
   {{- if .Values.admissionWebhooks.namespaceSelector }}
@@ -88,7 +86,7 @@ webhooks:
       name: {{ template "amazon-cloudwatch-observability.webhookServiceName" . }}
       namespace: {{ .Release.Namespace }}
       path: /mutate-v1-pod
-    caBundle: {{ $ca.Cert | b64enc }}
+    caBundle: {{ $cert.Ca }}
   failurePolicy: {{ .Values.admissionWebhooks.pods.failurePolicy }}
   name: mpod.kb.io
   {{- if .Values.admissionWebhooks.namespaceSelector }}
@@ -118,7 +116,7 @@ webhooks:
       name: {{ template "amazon-cloudwatch-observability.webhookServiceName" . }}
       namespace: {{ .Release.Namespace }}
       path: /mutate-v1-namespace
-    caBundle: {{ $ca.Cert | b64enc }}
+    caBundle: {{ $cert.Ca }}
   failurePolicy: {{ .Values.admissionWebhooks.pods.failurePolicy }}
   name: mnamespace.kb.io
   {{- if .Values.admissionWebhooks.namespaceSelector }}
@@ -148,7 +146,7 @@ webhooks:
       name: {{ template "amazon-cloudwatch-observability.webhookServiceName" . }}
       namespace: {{ .Release.Namespace }}
       path: /mutate-v1-workload
-    caBundle: {{ $ca.Cert | b64enc }}
+    caBundle: {{ $cert.Ca }}
   failurePolicy: {{ .Values.admissionWebhooks.pods.failurePolicy }}
   name: mworkload.kb.io
   {{- if .Values.admissionWebhooks.namespaceSelector }}
@@ -188,7 +186,7 @@ webhooks:
       name: {{ template "amazon-cloudwatch-observability.webhookServiceName" . }}
       namespace: {{ .Release.Namespace }}
       path: /validate-cloudwatch-aws-amazon-com-v1alpha1-instrumentation
-    caBundle: {{ $ca.Cert | b64enc }}
+    caBundle: {{ $cert.Ca }}
   failurePolicy: {{ .Values.admissionWebhooks.failurePolicy }}
   name: vinstrumentationcreateupdate.kb.io
   {{- if .Values.admissionWebhooks.namespaceSelector }}
@@ -218,7 +216,7 @@ webhooks:
       name: {{ template "amazon-cloudwatch-observability.webhookServiceName" . }}
       namespace: {{ .Release.Namespace }}
       path: /validate-cloudwatch-aws-amazon-com-v1alpha1-instrumentation
-    caBundle: {{ $ca.Cert | b64enc }}
+    caBundle: {{ $cert.Ca }}
   failurePolicy: Ignore
   name: vinstrumentationdelete.kb.io
   {{- if .Values.admissionWebhooks.namespaceSelector }}
@@ -247,7 +245,7 @@ webhooks:
       name: {{ template "amazon-cloudwatch-observability.webhookServiceName" . }}
       namespace: {{ .Release.Namespace }}
       path: /validate-cloudwatch-aws-amazon-com-v1alpha1-amazoncloudwatchagent
-    caBundle: {{ $ca.Cert | b64enc }}
+    caBundle: {{ $cert.Ca }}
   failurePolicy: {{ .Values.admissionWebhooks.failurePolicy }}
   name: vamazoncloudwatchagentcreateupdate.kb.io
   {{- if .Values.admissionWebhooks.namespaceSelector }}
@@ -277,7 +275,7 @@ webhooks:
       name: {{ template "amazon-cloudwatch-observability.webhookServiceName" . }}
       namespace: {{ .Release.Namespace }}
       path: /validate-cloudwatch-aws-amazon-com-v1alpha1-amazoncloudwatchagent
-    caBundle: {{ $ca.Cert | b64enc }}
+    caBundle: {{ $cert.Ca }}
   failurePolicy: Ignore
   name: vamazoncloudwatchagentdelete.kb.io
   {{- if .Values.admissionWebhooks.namespaceSelector }}

--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -18,6 +18,9 @@ spec:
         {{- if .Values.manager.podAnnotations }}
         {{- include "amazon-cloudwatch-observability.podAnnotations" . | nindent 8 }}
         {{- end }}
+        {{- if .Values.manager.rolling }}
+        rollme: {{ randAlphaNum 5 | quote }}
+        {{- end }}
       labels:
         app.kubernetes.io/name: {{ template "amazon-cloudwatch-observability.name" . }}
         control-plane: controller-manager

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -1197,6 +1197,8 @@ manager:
   affinity: {}
   nodeSelector:
     kubernetes.io/os: linux
+  # Enable automatic rolling by forcing a deployment spec change
+  rolling: false
 ## Admission webhooks make sure only requests with correctly formatted rules will get into the Operator.
 admissionWebhooks:
   create: true

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -1223,6 +1223,7 @@ admissionWebhooks:
   autoGenerateCert:
     enabled: true
     expiryDays: 3650 # 10 years
+    recreate: true
   ## TLS Certificate Option 2: Use certManager to generate self-signed certificate.
   ## certManager must be enabled. If enabled, it takes precedence over option 1.
   certManager:


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:*

**Certificate Management Enhancement:**
- Added a `recreate` flag for auto-generated certificates in the admission webhooks configuration
- This flag allows users to control whether existing certificates should be recreated during deployments
- Updated the helper templates and operator webhook configuration to support this new functionality
  - Will first check to see if autoGenerateCert is enabled, then check to see if there is an already existing cert with the recreate option set to false. If so, then it will retrieve the cert info. The ca.crt is not in the secret so we retrieve that from the caBundle from the admission webhooks to be re-used. Otherwise it will create new certs - the logic is taken from the operator-webhook.yaml file (copy & paste).
  - The operator-webhook.yaml file is updated to use the cert values from the helper
- Default value is set to `true` to maintain backward compatibility

**Operator Deployment Rolling:**
- Technique taken from: https://v3.helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
- Introduced a `rolling` flag in the operator configuration to enable automatic deployment rolling
- When enabled, this forces a deployment spec change to trigger pod restarts without manual intervention
- Default value is set to `false` to preserve existing behavior


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

