### PR TITLE
Add liveness/readiness probe to operator deployment

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -42,6 +42,18 @@ spec:
         - containerPort: {{ .Values.manager.ports.containerPort }}
           name: webhook-server
           protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
         resources: {{ toYaml .Values.manager.resources | nindent 10 }}
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
- Add readiness probe
  - Uses `/readyz`
- Add liveness probe
  - Uses `/healthz`

The operator used/uses kubebuilder to create the operator. Kubebuilder did not include liveness/readiness probes for the deployment at the time the operator was created. In more recent versions, it is included: https://github.com/kubernetes-sigs/kubebuilder/pull/1856. Just following the same pattern, i.e. path, port, initial delay seconds, period seconds.

### Testing
#### Happy path
```
$ helm upgrade \
    --wait \
    --create-namespace \
    --namespace amazon-cloudwatch \
    amazon-cloudwatch-observability \
    ./charts/amazon-cloudwatch-observability \
    -f custom-values.yaml
Release "amazon-cloudwatch-observability" has been upgraded. Happy Helming!
NAME: amazon-cloudwatch-observability
LAST DEPLOYED: Thu Oct  2 21:25:34 2025
NAMESPACE: amazon-cloudwatch
STATUS: deployed
REVISION: 49
TEST SUITE: None
```

The deployment is in a `ready` state after the probe succeeds.

#### Unhappy path
If you change the port/path to something incorrect, the Helm upgrade will fail with
```
Error: UPGRADE FAILED: context deadline exceeded
```
you will also get this in the events for the deployment as well:
```
Warning  Unhealthy  2s (x4 over 32s)  kubelet            Readiness probe failed: Get "http://192.168.18.209:808/re │
│ adyz": dial tcp 192.168.18.209:808: connect: connection refused    
```

The deployment stays in a `not ready` state.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

