### PR TITLE
[FluentBit] Use systemd plugins for retrieving host logs

### DIFF
--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -193,42 +193,53 @@ containerLogs:
             extra_user_agent    container-insights
         host-log.conf: |
           [INPUT]
-            Name                tail
+            Name                systemd
             Tag                 host.dmesg
-            Path                /var/log/dmesg
-            Key                 message
+            Systemd_Filter      _TRANSPORT=kernel
             DB                  /var/fluent-bit/state/flb_dmesg.db
-            Mem_Buf_Limit       5MB
-            Skip_Long_Lines     On
-            Refresh_Interval    10
-            Read_from_Head      ${READ_FROM_HEAD}
+            Path                /var/log/journal
+            Read_From_Tail      ${READ_FROM_TAIL}
 
           [INPUT]
-            Name                tail
+            Name                systemd
             Tag                 host.messages
-            Path                /var/log/messages
-            Parser              syslog
+            Systemd_Filter      PRIORITY=0
+            Systemd_Filter      PRIORITY=1
+            Systemd_Filter      PRIORITY=2
+            Systemd_Filter      PRIORITY=3
+            Systemd_Filter      PRIORITY=4
+            Systemd_Filter      PRIORITY=5
+            Systemd_Filter      PRIORITY=6
             DB                  /var/fluent-bit/state/flb_messages.db
-            Mem_Buf_Limit       5MB
-            Skip_Long_Lines     On
-            Refresh_Interval    10
-            Read_from_Head      ${READ_FROM_HEAD}
+            Path                /var/log/journal
+            Read_From_Tail      ${READ_FROM_TAIL}
 
           [INPUT]
-            Name                tail
+            Name                systemd
             Tag                 host.secure
-            Path                /var/log/secure
-            Parser              syslog
+            Systemd_Filter      SYSLOG_FACILITY=10
             DB                  /var/fluent-bit/state/flb_secure.db
-            Mem_Buf_Limit       5MB
-            Skip_Long_Lines     On
-            Refresh_Interval    10
-            Read_from_Head      ${READ_FROM_HEAD}
+            Path                /var/log/journal
+            Read_From_Tail      ${READ_FROM_TAIL}
 
           [FILTER]
             Name                aws
             Match               host.*
             imds_version        v2
+
+          [FILTER]
+            Name                grep
+            Match               host.messages
+            Exclude             SYSLOG_FACILITY /^(2|9|10)$/
+
+          [FILTER]
+            Name                modify
+            Match               host.*
+            Rename             _HOSTNAME host
+            Rename             MESSAGE message
+            Rename             SYSLOG_IDENTIFIER ident
+            Rename             SYSLOG_PID pid
+            Remove_regex       [A-Z]
 
           [OUTPUT]
             Name                cloudwatch_logs


### PR DESCRIPTION
## Background
Amazon Linux 2023 (AL2023) is now the [default AMI for new EKS clusters](https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html), replacing Amazon Linux 2 (AL2). AL2023 moved to a new logging system where system logs are no longer emitted as a local file. The current Fluent Bit configuration for CW Observability Add-on collect logs from log paths specific to AL2. When running on AL2023 nodes, Fluent Bit cannot find these expected log paths therefore customers lose system and container runtime logs. FluentBit can be configured to collect the same logs from AL2023 by using a different plugin called systemd.

*Issue #, if available:*
https://github.com/aws-samples/amazon-cloudwatch-container-insights/issues/136

*Description of changes:*

## Dmesg(Kernel) Logs

For kernel messages host.dmesg, we replaced the file-based tail plugin reading from /var/log/dmesg with the systemd plugin using _TRANSPORT=kernel filter. This ensures we continue collecting the same kernel messages but through systemd's journal instead of a log file. There is also existing issue where this is proposed as a workaround for Bottlerocket so should help there as well: https://github.com/aws-samples/amazon-cloudwatch-container-insights/issues/136#issuecomment-2143989603

## System message Logs

```
# Log anything (except mail) of level info or higher.
# Don't log private authentication messages!
*.info;mail.none;authpriv.none;cron.none                /var/log/messages
```

For system messages host.messages, the original configuration read from /var/log/messages which contained all info logs except mail, authpriv, and cron as defined in the rsyslog configuration. The new configuration achieves this same behavior by using the systemd plugin to collect all priority levels (0-6) which are info level and above, and then explicitly filtering out messages from mail (facility 2), cron (facility 9), and authpriv (facility 10) facilities using a grep filter.

## Security Logs
```
# The authpriv file has restricted access.
authpriv.*                                              /var/log/secure
```
For security logs host.secure, we replaced reading from /var/log/secure with the systemd plugin filtered on SYSLOG_FACILITY=10, which specifically captures authpriv messages. This maintains the same security log collection capability through the new logging system.

To ensure backward compatibility with existing log processing and analytics, we added a modify filter that renames systemd specific fields to match the previous log format and removes unnecessary systemd metadata fields.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

