### PR TITLE
Set up dcgmexporter interval to 1000ms when accelerated_compute_gpu_metrics_collection_interval is present and less than 60

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/linux/dcgm-exporter-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/dcgm-exporter-daemonset.yaml
@@ -31,6 +31,7 @@ spec:
     valueFrom:
       fieldRef:
         fieldPath: spec.nodeName
+  {{- include "dcgm-exporter.env" . | nindent 2 }}
   ports:
   - name: "metrics"
     port: {{ .Values.dcgmExporter.service.port }}


### PR DESCRIPTION


### Issue 
Enabling high frequency GPU metrics requires customer to make changes in 2 places: one is cw agent config, the other is dcgmexporter config. It's a bit complicated and hard for add-on customers to make these changes.
### Description of changes:
Write a help function to check the presence of `accelerated_compute_gpu_metrics_collection_interval`, if it is present and value < 60, then add `DCGM_EXPORTER_INTERVAL: 1000` to dcgmexporter env.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

### Testing
1. use default helm-chart configs and deploy dcgmexporter, checked `DCGM_EXPORTER_INTERVAL: 1000` was not in its env.
<img width="1689" height="828" alt="image" src="https://github.com/user-attachments/assets/f3bf11fe-7b06-4a0e-a744-bdb253e22616" />


2. add `accelerated_compute_gpu_metrics_collection_interval: 1` to `values.yaml` and deploy pod, checked  `DCGM_EXPORTER_INTERVAL` was in its env.

<img width="1700" height="836" alt="image" src="https://github.com/user-attachments/assets/2732b31f-dc0b-4c5b-b2d3-bfc8ef917bdb" />
