### PR TITLE
add option to include custom scripts

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-configmap.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-configmap.yaml
@@ -14,6 +14,10 @@ data:
     {{- end }}
   parsers.conf: |
     {{- .Values.containerLogs.fluentBit.config.customParsers  | nindent 4 }}
+  {{- range $key, $val := .Values.containerLogs.fluentBit.config.extraScripts }}
+  {{ $key }}: |
+    {{ $val | nindent 4}}
+  {{- end -}}
 {{- if hasPrefix "us-iso-" .Values.region }}
   {{- range $key, $val := .Values.containerLogs.fluentBit.config.adcIsoExtraFiles }}
   {{ $key }}: |

--- a/charts/amazon-cloudwatch-observability/templates/windows/fluent-bit-windows-configmap.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/windows/fluent-bit-windows-configmap.yaml
@@ -14,6 +14,10 @@ data:
     {{- end }}
   parsers.conf: |
     {{- .Values.containerLogs.fluentBit.configWindows.customParsers  | nindent 4 }}
+  {{- range $key, $val := .Values.containerLogs.fluentBit.config.extraScripts }}
+  {{ $key }}: |
+    {{ $val | nindent 4}}
+  {{- end -}}
   {{- range $key, $val := .Values.containerLogs.fluentBit.configWindows.extraFiles }}
   {{ $key }}: |
     {{- (tpl $val $) | nindent 4 }}

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -78,6 +78,7 @@ containerLogs:
           Regex               (?<log>(?<="log":")\d{4}[\/-]\d{1,2}[\/-]\d{1,2}[ T]\d{2}:\d{2}:\d{2}(?!\.).*?)(?<!\\)".*(?<stream>(?<="stream":").*?)".*(?<time>\d{4}-\d{1,2}-\d{1,2}T\d{2}:\d{2}:\d{2}\.\w*).*(?=})
           Time_Key            time
           Time_Format         %Y-%m-%dT%H:%M:%S.%LZ
+      extraScripts: {}
       extraFiles:
         application-log.conf: |
           [INPUT]
@@ -907,6 +908,7 @@ containerLogs:
           Regex               (?<log>(?<="log":")\S(?!\.).*?)(?<!\\)".*(?<stream>(?<="stream":").*?)".*(?<time>\d{4}-\d{1,2}-\d{1,2}T\d{2}:\d{2}:\d{2}\.\w*).*(?=})
           Time_Key            time
           Time_Format         %Y-%m-%dT%H:%M:%S.%LZ
+      extraScripts: {}
       extraFiles:
         application-log.conf: |
           [INPUT]


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-observability/helm-charts/issues/222
*Description of changes:*
adding option to pass custom scripts (lua)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

