### PR TITLE
Refactored logic for Fluentbit config parsing in isolated regions

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-configmap.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-configmap.yaml
@@ -14,7 +14,7 @@ data:
     {{- end }}
   parsers.conf: |
     {{- .Values.containerLogs.fluentBit.config.customParsers  | nindent 4 }}
-{{- if or (hasPrefix "us-iso-" .Values.region) (hasPrefix "us-isob-" .Values.region) (hasPrefix "us-isof-" .Values.region) (hasPrefix "eusc-de-" .Values.region) (hasPrefix "eu-isoe-" .Values.region) }}
+{{- if hasKey .Values.adcEndpointOverrides .Values.region }}
   {{- range $key, $val := .Values.containerLogs.fluentBit.config.adcRegionExtraFiles }}
   {{ $key }}: |
     {{- include "fluent-bit.add-dualstack-endpoints" (dict "Values" $.Values "config" (tpl $val $)) | nindent 4 }}

--- a/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
@@ -54,8 +54,10 @@ spec:
               fieldPath: metadata.name
         - name: CI_VERSION
           value: "k8s/1.3.17"
+        {{- if hasKey .Values.adcEndpointOverrides .Values.region }}
         - name: ADC_REGION_ENDPOINT
-          value: {{ index .Values.adcEndpointOverrides .Values.region | default "" | quote }}
+          value: {{ index .Values.adcEndpointOverrides .Values.region | quote }}
+        {{- end }}
         {{- with .Values.containerLogs.fluentBit.resources }}
         resources: {{- toYaml . | nindent 10}}
         {{- end }}

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -369,42 +369,53 @@ containerLogs:
             extra_user_agent    container-insights
         host-log.conf: |
           [INPUT]
-            Name                tail
+            Name                systemd
             Tag                 host.dmesg
-            Path                /var/log/dmesg
-            Key                 message
+            Systemd_Filter      _TRANSPORT=kernel
             DB                  /var/fluent-bit/state/flb_dmesg.db
-            Mem_Buf_Limit       5MB
-            Skip_Long_Lines     On
-            Refresh_Interval    10
-            Read_from_Head      ${READ_FROM_HEAD}
+            Path                /var/log/journal
+            Read_From_Tail      ${READ_FROM_TAIL}
 
           [INPUT]
-            Name                tail
+            Name                systemd
             Tag                 host.messages
-            Path                /var/log/messages
-            Parser              syslog
+            Systemd_Filter      PRIORITY=0
+            Systemd_Filter      PRIORITY=1
+            Systemd_Filter      PRIORITY=2
+            Systemd_Filter      PRIORITY=3
+            Systemd_Filter      PRIORITY=4
+            Systemd_Filter      PRIORITY=5
+            Systemd_Filter      PRIORITY=6
             DB                  /var/fluent-bit/state/flb_messages.db
-            Mem_Buf_Limit       5MB
-            Skip_Long_Lines     On
-            Refresh_Interval    10
-            Read_from_Head      ${READ_FROM_HEAD}
+            Path                /var/log/journal
+            Read_From_Tail      ${READ_FROM_TAIL}
 
           [INPUT]
-            Name                tail
+            Name                systemd
             Tag                 host.secure
-            Path                /var/log/secure
-            Parser              syslog
+            Systemd_Filter      SYSLOG_FACILITY=10
             DB                  /var/fluent-bit/state/flb_secure.db
-            Mem_Buf_Limit       5MB
-            Skip_Long_Lines     On
-            Refresh_Interval    10
-            Read_from_Head      ${READ_FROM_HEAD}
+            Path                /var/log/journal
+            Read_From_Tail      ${READ_FROM_TAIL}
 
           [FILTER]
             Name                aws
             Match               host.*
             imds_version        v2
+
+          [FILTER]
+            Name                grep
+            Match               host.messages
+            Exclude             SYSLOG_FACILITY /^(2|9|10)$/
+
+          [FILTER]
+            Name                modify
+            Match               host.*
+            Rename             _HOSTNAME host
+            Rename             MESSAGE message
+            Rename             SYSLOG_IDENTIFIER ident
+            Rename             SYSLOG_PID pid
+            Remove_regex       [A-Z]
 
           [OUTPUT]
             Name                cloudwatch_logs


### PR DESCRIPTION
Issue #, if available:

Description of changes:

This change builds on top of https://github.com/aws-observability/helm-charts/pull/94. I was able to consolidate down the logic and added in THF. The changes should just be a logic change in generating them, but the generated artifact should not differ. 

###Testing
I was able to confirm that we were able to apply the helm chart in 3 ADC regions aws-iso-b, aws-isof, and aws-iso as well as THF and GovCloud regions. 


