### PR TITLE
add blackwell GPU instances

### DIFF
--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -1479,6 +1479,11 @@ dcgmExporter:
                   - p5.48xlarge
                   - p5e.48xlarge
                   - p5en.48xlarge
+                  - p6-b200.48xlarge
+                  - p6-b300.48xlarge
+                  - p6e-gb200.36xlarge
+                  - u-p6e-gb200x36
+                  - u-p6e-gb200x72
                   - ml.g3.4xlarge
                   - ml.g3.8xlarge
                   - ml.g3.16xlarge
@@ -1539,6 +1544,10 @@ dcgmExporter:
                   - ml.p5.48xlarge
                   - ml.p5e.48xlarge
                   - ml.p5en.48xlarge
+                  - ml.p6-b200.48xlarge
+                  - ml.p6e-gb200.36xlarge
+                  - ml.u-p6e-gb200x36
+                  - ml.u-p6e-gb200x72
               - key: eks.amazonaws.com/compute-type
                 operator: NotIn
                 values:


### PR DESCRIPTION
*Description of changes:*
Add Blackwell GPU instance types to `nodeAffinity` rule for DCGMExporter

Refs:
- https://aws.amazon.com/ec2/instance-types/p6/
- https://aws.amazon.com/sagemaker/ai/pricing/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

