### PR TITLE
Enable k8s metadata for fluentbit application logs

### DIFF
--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -497,6 +497,27 @@ containerLogs:
             Refresh_Interval    10
             Read_from_Head      ${READ_FROM_HEAD}
 
+          [FILTER]
+            Name                aws
+            Match               application.*
+            az                  false
+            ec2_instance_id     false
+
+          [FILTER]
+            Name                kubernetes
+            Match               application.*
+            Kube_URL            https://kubernetes.default.svc:443
+            Kube_Tag_Prefix     application.C.var.log.containers.
+            Merge_Log           On
+            Merge_Log_Key       log_processed
+            K8S-Logging.Parser  On
+            K8S-Logging.Exclude Off
+            Labels              Off
+            Annotations         Off
+            Use_Kubelet         On
+            Kubelet_Port        10250
+            Buffer_Size         0
+
           [OUTPUT]
             Name                cloudwatch_logs
             Match               application.*


### PR DESCRIPTION
*Issue #, if available:*
Currently, workload application logs collected by fluentbit on Windows doesn't include k8s metadata. The logs looks like  
```
{
    "log": "2025-12-18T20:37:42.4954622Z stdout F Reply from ::1: time<1ms "
}
```
This change add k8s metadata logs to application logs, similar to application logs on Linux.

```
{
    "log": "2025-12-19T03:08:02.5138241Z stdout F Reply from ::1: time<1ms ",
    "kubernetes": {
        "pod_name": "windows-server-iis-ltsc2022-1-99b69f97c-2hblx",
        "namespace_name": "default",
        "pod_id": "a5b75d0c-0373-4c9e-a23e-bd03990efb86",
        "host": "ip-192-168-5-35.us-west-2.compute.internal",
        "container_name": "windows-server-iis-ltsc2022-1",
        "docker_id": "ca60d4c0d33f8730b92614bbcd84652e70459247808ad4f563d72e95318777be",
        "container_hash": "mcr.microsoft.com/windows/servercore/iis@sha256:03c5cbdb04a92e1316409a3e5df5963dac8a2b20fa37cede95bb2b2a1014e751",
        "container_image": "mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2022"
    }
}
```

*Description of changes:*

Adds a new k8s filter to fluentbit configuration for Windows only

*Tested*
Ran a manual test and the change on cluster succeeds.
<img width="1268" height="366" alt="Screenshot 2025-12-18 at 9 18 53 PM" src="https://github.com/user-attachments/assets/fc4a828b-6e64-4bcf-99c5-6193bd0c0c3f" />



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

