### PR TITLE
Refactor: Use tpl conditionals for fluent-bit region-specific config

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-configmap.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-configmap.yaml
@@ -14,15 +14,9 @@ data:
     {{- end }}
   parsers.conf: |
     {{- .Values.containerLogs.fluentBit.config.customParsers  | nindent 4 }}
-{{- if hasKey .Values.adcEndpointOverrides .Values.region }}
-  {{- range $key, $val := .Values.containerLogs.fluentBit.config.adcRegionExtraFiles }}
+{{- range $key, $val := .Values.containerLogs.fluentBit.config.extraFiles }}
   {{ $key }}: |
-    {{- include "fluent-bit.add-dualstack-endpoints" (dict "Values" $.Values "config" (tpl $val $)) | nindent 4 }}
-  {{- end -}}
-{{- else }}
-  {{- range $key, $val := .Values.containerLogs.fluentBit.config.extraFiles }}
-  {{ $key }}: |
-    {{- include "fluent-bit.add-dualstack-endpoints" (dict "Values" $.Values "config" (tpl $val $)) | nindent 4 }}
-  {{- end -}}
+    {{- $config := tpl $val $ }}
+    {{- include "fluent-bit.add-dualstack-endpoints" (dict "Values" $.Values "config" $config) | nindent 4 }}
 {{- end -}}
 {{- end -}}

--- a/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
@@ -54,10 +54,6 @@ spec:
               fieldPath: metadata.name
         - name: CI_VERSION
           value: "k8s/1.3.17"
-        {{- if hasKey .Values.adcEndpointOverrides .Values.region }}
-        - name: ADC_REGION_ENDPOINT
-          value: {{ index .Values.adcEndpointOverrides .Values.region | quote }}
-        {{- end }}
         {{- with .Values.containerLogs.fluentBit.resources }}
         resources: {{- toYaml . | nindent 10}}
         {{- end }}

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -155,6 +155,9 @@ containerLogs:
             log_stream_prefix   ${HOST_NAME}-
             auto_create_group   true
             extra_user_agent    container-insights
+            {{- if hasKey .Values.adcEndpointOverrides .Values.region }}
+            endpoint            logs.${AWS_REGION}.{{ index .Values.adcEndpointOverrides .Values.region }}
+            {{- end }}
             add_entity          true
         dataplane-log.conf: |
           [INPUT]
@@ -201,6 +204,9 @@ containerLogs:
             log_stream_prefix   ${HOST_NAME}-
             auto_create_group   true
             extra_user_agent    container-insights
+            {{- if hasKey .Values.adcEndpointOverrides .Values.region }}
+            endpoint            logs.${AWS_REGION}.{{ index .Values.adcEndpointOverrides .Values.region }}
+            {{- end }}
         host-log.conf: |
           [INPUT]
             Name                systemd
@@ -259,173 +265,9 @@ containerLogs:
             log_stream_prefix   ${HOST_NAME}.
             auto_create_group   true
             extra_user_agent    container-insights
-      adcRegionExtraFiles:
-        application-log.conf: |
-          [INPUT]
-            Name                tail
-            Tag                 application.*
-            Exclude_Path        /var/log/containers/cloudwatch-agent*, /var/log/containers/fluent-bit*, /var/log/containers/aws-node*, /var/log/containers/kube-proxy*
-            Path                /var/log/containers/*.log
-            multiline.parser    docker, cri
-            DB                  /var/fluent-bit/state/flb_container.db
-            Mem_Buf_Limit       50MB
-            Skip_Long_Lines     On
-            Refresh_Interval    10
-            Rotate_Wait         30
-            storage.type        filesystem
-            Read_from_Head      ${READ_FROM_HEAD}
-
-          [INPUT]
-            Name                tail
-            Tag                 application.*
-            Path                /var/log/containers/fluent-bit*
-            multiline.parser    docker, cri
-            DB                  /var/fluent-bit/state/flb_log.db
-            Mem_Buf_Limit       5MB
-            Skip_Long_Lines     On
-            Refresh_Interval    10
-            Read_from_Head      ${READ_FROM_HEAD}
-
-          [INPUT]
-            Name                tail
-            Tag                 application.*
-            Path                /var/log/containers/cloudwatch-agent*
-            multiline.parser    docker, cri
-            DB                  /var/fluent-bit/state/flb_cwagent.db
-            Mem_Buf_Limit       5MB
-            Skip_Long_Lines     On
-            Refresh_Interval    10
-            Read_from_Head      ${READ_FROM_HEAD}
-
-          [FILTER]
-            Name                kubernetes
-            Match               application.*
-            Kube_URL            https://kubernetes.default.svc:443
-            Kube_Tag_Prefix     application.var.log.containers.
-            Merge_Log           On
-            Merge_Log_Key       log_processed
-            K8S-Logging.Parser  On
-            K8S-Logging.Exclude Off
-            Labels              Off
-            Annotations         Off
-            Use_Kubelet         On
-            Kubelet_Port        10250
-            Buffer_Size         0
-
-          [OUTPUT]
-            Name                cloudwatch_logs
-            Match               application.*
-            region              ${AWS_REGION}
-            log_group_name      /aws/containerinsights/${CLUSTER_NAME}/application
-            log_stream_prefix   ${HOST_NAME}-
-            auto_create_group   true
-            endpoint            logs.${AWS_REGION}.${ADC_REGION_ENDPOINT}
-            extra_user_agent    container-insights
-        dataplane-log.conf: |
-          [INPUT]
-            Name                systemd
-            Tag                 dataplane.systemd.*
-            Systemd_Filter      _SYSTEMD_UNIT=docker.service
-            Systemd_Filter      _SYSTEMD_UNIT=containerd.service
-            Systemd_Filter      _SYSTEMD_UNIT=kubelet.service
-            DB                  /var/fluent-bit/state/systemd.db
-            Path                /var/log/journal
-            Read_From_Tail      ${READ_FROM_TAIL}
-
-          [INPUT]
-            Name                tail
-            Tag                 dataplane.tail.*
-            Path                /var/log/containers/aws-node*, /var/log/containers/kube-proxy*
-            multiline.parser    docker, cri
-            DB                  /var/fluent-bit/state/flb_dataplane_tail.db
-            Mem_Buf_Limit       50MB
-            Skip_Long_Lines     On
-            Refresh_Interval    10
-            Rotate_Wait         30
-            storage.type        filesystem
-            Read_from_Head      ${READ_FROM_HEAD}
-
-          [FILTER]
-            Name                modify
-            Match               dataplane.systemd.*
-            Rename              _HOSTNAME                   hostname
-            Rename              _SYSTEMD_UNIT               systemd_unit
-            Rename              MESSAGE                     message
-            Remove_regex        ^((?!hostname|systemd_unit|message).)*$
-
-          [FILTER]
-            Name                aws
-            Match               dataplane.*
-            imds_version        v2
-
-          [OUTPUT]
-            Name                cloudwatch_logs
-            Match               dataplane.*
-            region              ${AWS_REGION}
-            log_group_name      /aws/containerinsights/${CLUSTER_NAME}/dataplane
-            log_stream_prefix   ${HOST_NAME}-
-            auto_create_group   true
-            endpoint            logs.${AWS_REGION}.${ADC_REGION_ENDPOINT}
-            extra_user_agent    container-insights
-        host-log.conf: |
-          [INPUT]
-            Name                systemd
-            Tag                 host.dmesg
-            Systemd_Filter      _TRANSPORT=kernel
-            DB                  /var/fluent-bit/state/flb_dmesg.db
-            Path                /var/log/journal
-            Read_From_Tail      ${READ_FROM_TAIL}
-
-          [INPUT]
-            Name                systemd
-            Tag                 host.messages
-            Systemd_Filter      PRIORITY=0
-            Systemd_Filter      PRIORITY=1
-            Systemd_Filter      PRIORITY=2
-            Systemd_Filter      PRIORITY=3
-            Systemd_Filter      PRIORITY=4
-            Systemd_Filter      PRIORITY=5
-            Systemd_Filter      PRIORITY=6
-            DB                  /var/fluent-bit/state/flb_messages.db
-            Path                /var/log/journal
-            Read_From_Tail      ${READ_FROM_TAIL}
-
-          [INPUT]
-            Name                systemd
-            Tag                 host.secure
-            Systemd_Filter      SYSLOG_FACILITY=10
-            DB                  /var/fluent-bit/state/flb_secure.db
-            Path                /var/log/journal
-            Read_From_Tail      ${READ_FROM_TAIL}
-
-          [FILTER]
-            Name                aws
-            Match               host.*
-            imds_version        v2
-
-          [FILTER]
-            Name                grep
-            Match               host.messages
-            Exclude             SYSLOG_FACILITY /^(2|9|10)$/
-
-          [FILTER]
-            Name                modify
-            Match               host.*
-            Rename             _HOSTNAME host
-            Rename             MESSAGE message
-            Rename             SYSLOG_IDENTIFIER ident
-            Rename             SYSLOG_PID pid
-            Remove_regex       [A-Z]
-
-          [OUTPUT]
-            Name                cloudwatch_logs
-            Match               host.*
-            region              ${AWS_REGION}
-            log_group_name      /aws/containerinsights/${CLUSTER_NAME}/host
-            log_stream_prefix   ${HOST_NAME}.
-            auto_create_group   true
-            endpoint            logs.${AWS_REGION}.${ADC_REGION_ENDPOINT}
-            extra_user_agent    container-insights
+            {{- if hasKey .Values.adcEndpointOverrides .Values.region }}
+            endpoint            logs.${AWS_REGION}.{{ index .Values.adcEndpointOverrides .Values.region }}
+            {{- end }}
     configWindows:
       service: |
         [ SERVICE ]


### PR DESCRIPTION
*Issue #, if available:*
N/A (follow-up to [#257](https://github.com/aws-observability/helm-charts/pull/257))

*Description of changes:*
This change aims to simplify isolated region configuration using single `extraFiles` with `tpl` functions provided by Helm.

Currently, the chart maintains separate configuration for `adcRegionExtraFiles` resulting in:
- Duplication
- Confusing user experience (User defined `extraFiles` will be overridden in isolated regions by the template which can be painful to debug)
- Difficult maintenance when there are configuration changes
- Risk of configuration drift between regions

This change uses Helm's `tpl` function with inline conditionals in `values.yaml` to dynamically render the correct default fluent-bit configuration for all regions from a single source. Currently values set to `On` or `true` I simply set to `Off` or `false` for isolated regions but conditional can easily be used to simply remove this inline during rendering if needed. I think this is also a good chance to evaluate the parity in these configurations and if they can simply be enabled for these regions.

Configuration differences were identified via diff between commercial and isolated region configs:
```
comet@pop-os:~/Projects/observability% diff commercial.txt adc.txt 
39,45d38
<             Name                aws
<             Match               application.*
<             az                  false
<             ec2_instance_id     false
<             Enable_Entity       true
< 
<           [FILTER]
59d51
<             Use_Pod_Association On
67a60
>             endpoint            logs.${AWS_REGION}.${ADC_REGION_ENDPOINT}
69d61
<             add_entity          true
113a106
>             endpoint            logs.${AWS_REGION}.${ADC_REGION_ENDPOINT}
171a165
>             endpoint            logs.${AWS_REGION}.${ADC_REGION_ENDPOINT}
```
 
This change has a lot of benefits including:
- Single configuration source eliminates configuration drift between regions
- Consistent user experience when using advanced configuration (`extraFiles`) where intent is preserved for all regions
- Self-documenting configuration using inline conditionals

**Testing**
```
wtr@dev:/local/home/wtr/Projects/helm-charts% helm lint charts/amazon-cloudwatch-observability --set region='us-east-1' --set clusterName="test"
==> Linting charts/amazon-cloudwatch-observability
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
wtr@dev:/local/home/wtr/Projects/helm-charts% helm lint charts/amazon-cloudwatch-observability --set region='us-isob-east-1' --set clusterName="test"
==> Linting charts/amazon-cloudwatch-observability
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
```

```
comet@pop-os:~/Projects/helm-charts% helm template test charts/amazon-cloudwatch-observability -f charts/amazon-cloudwatch-observability/values.yaml --set region=us-east-1 --set clusterName='testCluster' > rendered.yaml
comet@pop-os:~/Projects/helm-charts% helm template test charts/amazon-cloudwatch-observability -f charts/amazon-cloudwatch-observability/values.yaml --set region=us-isob-east-1 --set clusterName='testCluster' > renderedIso.yaml
comet@pop-os:~/Projects/helm-charts% diff rendered.yaml renderedIso.yaml 
---
---
omit for brevity
---
---
<     [FILTER]
<       Name                aws
<       Match               application.*
<       az                  false
<       ec2_instance_id     false
<       Enable_Entity       true
205,206c199
<       Use_Pod_Association On
<     
---
>       
215,216c208,209
<       add_entity          true
<     
---
>       endpoint            logs.${AWS_REGION}.sc2s.sgov.gov
>       
261a255
>       endpoint            logs.${AWS_REGION}.sc2s.sgov.gov
320a315
>       endpoint            logs.${AWS_REGION}.sc2s.sgov.gov
764c759
<         checksum/config: 3dc2029a374dd405bfc5878e0f77ee3eb00a016001cd384ac7c90d6d7a1e4a8d
---
>         checksum/config: 24ed911cefb206caeabd8a17f238ec4f70087470e628477aa4d40d31e8efe572
776c771
<           value: us-east-1
---
>           value: us-isob-east-1
793a789,790
>         - name: ADC_REGION_ENDPOINT
>           value: "sc2s.sgov.gov"
916c913
<           value: us-east-1
---
>           value: us-isob-east-1
```

**This chart was also successfully deployed in us-west-2 and us-isob-east-1. 
Validated addon activated, configmap was accurate, and logs emitting as expected. Screenshots from us-west-2 below.**
 
<img width="986" height="473" alt="image" src="https://github.com/user-attachments/assets/11beb138-4000-4ead-967a-2ede83caa641" />


<img width="612" height="737" alt="cwa2_pdx" src="https://github.com/user-attachments/assets/bab5e11b-0ba5-429b-9307-efe1118aab3b" />




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

