### PR TITLE
disable entity filter when application_signals is disabled

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
@@ -243,6 +243,8 @@ Helper function to set Enable_Entity in fluent-bit aws filter based on Applicati
 {{- $hasAppSignals := include "fluent-bit.hasAppSignals" .context | trim | eq "true" -}}
 {{- if not $hasAppSignals -}}
 {{- $config = mustRegexReplaceAll "Enable_Entity\\s+true" $config "Enable_Entity       false" -}}
+{{- $config = mustRegexReplaceAll "add_entity\\s+true" $config "add_entity          false" -}}
+{{- $config = mustRegexReplaceAll "Use_Pod_Association\\s+On" $config "Use_Pod_Association Off" -}}
 {{- end -}}
 {{- $config -}}
 {{- end -}}

--- a/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
@@ -218,6 +218,36 @@ Get the current recommended fluent-bit image for a region
 {{- end -}}
 
 {{/*
+Helper function to check if Application Signals is enabled in any agent config
+*/}}
+{{- define "fluent-bit.hasAppSignals" -}}
+{{- $hasAppSignals := false -}}
+{{- range .Values.agents -}}
+{{- $agent := merge . (deepCopy $.Values.agent) -}}
+{{- $agentConfig := $agent.config | default $agent.defaultConfig -}}
+{{- if and (hasKey $agentConfig "logs") (hasKey $agentConfig.logs "metrics_collected") (hasKey $agentConfig.logs.metrics_collected "application_signals") -}}
+{{- $hasAppSignals = true -}}
+{{- end -}}
+{{- if and (hasKey $agentConfig "traces") (hasKey $agentConfig.traces "traces_collected") (hasKey $agentConfig.traces.traces_collected "application_signals") -}}
+{{- $hasAppSignals = true -}}
+{{- end -}}
+{{- end -}}
+{{- $hasAppSignals -}}
+{{- end -}}
+
+{{/*
+Helper function to set Enable_Entity in fluent-bit aws filter based on Application Signals status
+*/}}
+{{- define "fluent-bit.set-entity-flag" -}}
+{{- $config := .config -}}
+{{- $hasAppSignals := include "fluent-bit.hasAppSignals" .context | trim | eq "true" -}}
+{{- if not $hasAppSignals -}}
+{{- $config = mustRegexReplaceAll "Enable_Entity\\s+true" $config "Enable_Entity       false" -}}
+{{- end -}}
+{{- $config -}}
+{{- end -}}
+
+{{/*
 Helper function to add dualstack endpoints to fluent-bit OUTPUT sections
 Uses regex to handle variable whitespace in the region line
 */}}

--- a/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-configmap.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-configmap.yaml
@@ -22,7 +22,7 @@ data:
 {{- else }}
   {{- range $key, $val := .Values.containerLogs.fluentBit.config.extraFiles }}
   {{ $key }}: |
-    {{- include "fluent-bit.add-dualstack-endpoints" (dict "Values" $.Values "config" (tpl $val $)) | nindent 4 }}
+    {{- include "fluent-bit.set-entity-flag" (dict "context" $ "config" (include "fluent-bit.add-dualstack-endpoints" (dict "Values" $.Values "config" (tpl $val $)))) | nindent 4 }}
   {{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
#### Issue
When customers use a custom config without Application Signals, FluentBit's `Enable_Entity` flag causes connection errors to `cloudwatch-agent:4311` (entity endpoint).
```
[warn] [net] getaddrinfo(host='cloudwatch-agent.amazon-cloudwatch', err=-2): Name or service not known
[error] [filter:kubernetes:kubernetes.1] no upstream connections available to cloudwatch-agent.amazon-cloudwatch:4311
```
#### Description of changes:
Added logic to conditionally set Enable_Entity based on agent config:
- `_helpers.tpl`: Added `fluent-bit.hasAppSignals` helper to detect if application_signals is in agent config
- `_helpers.tpl`: Added `fluent-bit.set-entity-flag` helper to set the flag accordingly
- `fluent-bit-configmap.yaml`: Applied the helper when rendering config

Tested using `helm template test`
```
> TEST 1: Default agent config (has application_signals)

Agent config:
{
  "logs": {
    "metrics_collected": {
      "kubernetes": { "enhanced_container_insights": true },
      "application_signals": { }
    }
  },
  "traces": {
    "traces_collected": {
      "application_signals": { }
    }
  }
}

Enable_Entity: true
Use_Pod_Association: On
add_entity: true

> TEST 2: Custom agent config (NO application_signals)

Agent config override:
agent.config.logs.metrics_collected.kubernetes.enhanced_container_insights=true
(no application_signals key)

Enable_Entity: false
Use_Pod_Association: Off
add_entity: false
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

