### PR TITLE
Move args into command and add neuron-monitor-blocker volume

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/linux/neuron-monitor-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/neuron-monitor-daemonset.yaml
@@ -32,11 +32,14 @@ spec:
   - name: "metrics"
     port: {{ .Values.neuronMonitor.service.port }}
   command:
-    - "/opt/bin/entrypoint.sh"
-  args:
-    port: "{{ .Values.neuronMonitor.service.port }}"
-    cert-file: "/etc/amazon-cloudwatch-observability-neuron-cert/server.crt"
-    key-file: "/etc/amazon-cloudwatch-observability-neuron-cert/server.key"
+  - "/bin/bash"
+  - "-c"
+  - |
+    /opt/bin/entrypoint.sh \
+      --cert-file /etc/amazon-cloudwatch-observability-neuron-cert/server.crt \
+      --key-file /etc/amazon-cloudwatch-observability-neuron-cert/server.key \
+      --port {{ .Values.neuronMonitor.service.port }} \
+      --neuron-monitor-config /etc/neuron-monitor-config/monitor.json
   securityContext:
     privileged: true
   volumeMounts:
@@ -45,6 +48,9 @@ spec:
     readOnly: true
   - mountPath: /opt-aws
     name: "aws-config"
+    readOnly: true
+  - mountPath: /neuron-monitor-blocker
+    name: neuron-monitor-blocker
     readOnly: true
   volumes:
   - name: neurontls
@@ -58,6 +64,10 @@ spec:
   - name: "aws-config"
     hostPath:
       path: /opt/aws
+  - name: neuron-monitor-blocker
+    hostPath:
+      path: /var/neuron-monitor-blocker
+      type: ""
   monitorConfig: |
     {
       "period": "5s",

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -1127,7 +1127,7 @@ neuronMonitor:
   name:
   image:
     repository: neuron-monitor
-    tag: 1.6.0
+    tag: 1.8.0
     repositoryDomainMap:
       public: public.ecr.aws/neuron
   resources:


### PR DESCRIPTION
*Issue #, if available:*

1. The current way to pass args via NeuronMonitor crd is problematic. It will causes the neuron-monitor daemonset pod to be immediately terminated after launch, recreated, and then go through a couple of these cycles before finally reaching a RUNNING state.

    ```
    args:
        port: "{{ .Values.neuronMonitor.service.port }}"
        cert-file: "/etc/amazon-cloudwatch-observability-neuron-cert/server.crt"
        key-file: "/etc/amazon-cloudwatch-observability-neuron-cert/server.key"
    ```
2. Update the neuron-monitor pod image from version `1.6.0` to `1.8.0`.

3. Add `neuron-monitor-blocker` volume as an additional readonly volume mount in the neuron-monitor pod.

*Description of changes:*

1. **neuron-monitor daemonset manifest**: Removed `args` field and merged it to a unified `command` field with all the args

2. Updated the neuron-monitor version tag from `1.6.0` to `1.8.0`
3. Add the `neuron-monitor-blocker` volume and volume mount

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.