### PR TITLE
Update image versions, add release notes, set dev version on main

### DIFF
--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -30,11 +30,11 @@ jobs:
         if: github.event_name == 'pull_request_target'
         uses: slackapi/slack-github-action@v2.1.1
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL_PR }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_ISSUE }}
           webhook-type: incoming-webhook
           payload: |
             {
               "action": "${{ github.event.action }}",
-              "url": "${{ github.event.pull_request.html_url }}"
+              "url": "${{ github.event.pull_request.html_url }}",
               "title": "${{ github.event.pull_request.title }}"
             }

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,4 +1,66 @@
 =======================================================================
+amazon-cloudwatch-observability v5.2.3 (2026-03-20)
+=======================================================================
+Enhancements:
+* Upgrade Fluent Bit to v3.2.4
+
+=======================================================================
+amazon-cloudwatch-observability v5.2.2 (2026-03-16)
+=======================================================================
+Enhancements:
+* Upgrade Fluent Bit to v3.2.3
+* Upgrade Neuron Monitor to v1.8.0
+
+=======================================================================
+amazon-cloudwatch-observability v5.2.1 (2026-02-16)
+=======================================================================
+Enhancements:
+* Upgrade CWAgent to v1.300064.1b1344
+* Upgrade CWAgent Operator to v3.3.2
+* Upgrade Fluent Bit to v3.2.2
+* Upgrade DCGM Exporter to 4.5.2-4.8.1-ubuntu22.04
+
+=======================================================================
+amazon-cloudwatch-observability v5.2.0 (2026-01-26)
+=======================================================================
+Enhancements:
+* All enhancements from v4.10.0
+
+=======================================================================
+amazon-cloudwatch-observability v5.1.0 (2026-01-15)
+=======================================================================
+Enhancements:
+* All enhancements from v4.9.0
+
+=======================================================================
+amazon-cloudwatch-observability v5.0.0 (2025-10-16)
+=======================================================================
+Enhancements:
+* Enable Application Signals AutoMonitor by default
+
+=======================================================================
+amazon-cloudwatch-observability v4.10.3 (2026-03-18)
+=======================================================================
+Enhancements:
+* Upgrade Fluent Bit to v3.2.4
+
+=======================================================================
+amazon-cloudwatch-observability v4.10.2 (2026-03-16)
+=======================================================================
+Enhancements:
+* Upgrade Fluent Bit to v3.2.3
+* Upgrade Neuron Monitor to v1.8.0
+
+=======================================================================
+amazon-cloudwatch-observability v4.10.1 (2026-02-16)
+=======================================================================
+Enhancements:
+* Upgrade CWAgent to v1.300064.1b1344
+* Upgrade CWAgent Operator to v3.3.2
+* Upgrade Fluent Bit to v3.2.2
+* Upgrade DCGM Exporter to 4.5.2-4.8.1-ubuntu22.04
+
+=======================================================================
 amazon-cloudwatch-observability v4.8.0 (2025-11-12)
 =======================================================================
 Enhancements:

--- a/charts/amazon-cloudwatch-observability/Chart.yaml
+++ b/charts/amazon-cloudwatch-observability/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: amazon-cloudwatch-observability
-version: 4.8.0
+version: 0.0.0-dev # This is a placeholder used on the main branch. If installing, please reference a release branch.
 appVersion: 1.0.0
 description: A Helm chart for Amazon CloudWatch Observability
 type: application

--- a/charts/amazon-cloudwatch-observability/Chart.yaml
+++ b/charts/amazon-cloudwatch-observability/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: amazon-cloudwatch-observability
-version: 0.0.0-dev # This is a placeholder used on the main branch. If installing, please reference a release branch.
+version: 4.8.0
 appVersion: 1.0.0
 description: A Helm chart for Amazon CloudWatch Observability
 type: application

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -29,7 +29,7 @@ containerLogs:
   fluentBit:
     image:
       repository: aws-for-fluent-bit
-      tag: 3.1.1
+      tag: 3.2.4
       tagWindows: 2.31.12-windowsservercore
       repositoryDomainMap:
         public: public.ecr.aws/aws-observability
@@ -622,7 +622,7 @@ manager:
   name:
   image:
     repository: cloudwatch-agent-operator
-    tag: 3.3.1
+    tag: 3.3.2
     repositoryDomainMap:
       public: public.ecr.aws/cloudwatch-agent
       cn-north-1: 934860584483.dkr.ecr.cn-north-1.amazonaws.com.cn
@@ -633,19 +633,19 @@ manager:
     java:
       repositoryDomain: public.ecr.aws/aws-observability
       repository: adot-autoinstrumentation-java
-      tag: v2.11.5
+      tag: v2.25.1
     python:
       repositoryDomain: public.ecr.aws/aws-observability
       repository: adot-autoinstrumentation-python
-      tag: v0.12.1
+      tag: v0.16.0
     dotnet:
       repositoryDomain: public.ecr.aws/aws-observability
       repository: adot-autoinstrumentation-dotnet
-      tag: v1.9.1
+      tag: v1.11.1
     nodejs:
       repositoryDomain: public.ecr.aws/aws-observability
       repository: adot-autoinstrumentation-node
-      tag: v0.7.0
+      tag: v0.9.0
   applicationSignals:
     autoMonitor:
       # monitorAllServices: true; Defaults to true for regions where AppSignals is supported, false otherwise
@@ -858,7 +858,7 @@ agent:
   replicas: 1 # The total number non-terminated pods targeted by this AmazonCloudWatchAgent's deployment or statefulSet.
   image:
     repository: cloudwatch-agent
-    tag: 1.300063.0b1323
+    tag: 1.300064.1b1344
     repositoryDomainMap:
       public: public.ecr.aws/cloudwatch-agent
       cn-north-1: 934860584483.dkr.ecr.cn-north-1.amazonaws.com.cn
@@ -951,7 +951,7 @@ dcgmExporter:
   name:
   image:
     repository: dcgm-exporter
-    tag: 4.4.0-4.5.0-ubuntu22.04
+    tag: 4.5.2-4.8.1-ubuntu22.04
     repositoryDomainMap:
       public: nvcr.io/nvidia/k8s
       cn-north-1: 934860584483.dkr.ecr.cn-north-1.amazonaws.com.cn


### PR DESCRIPTION
## Description

Update main branch with latest image versions and release notes.

### Chart.yaml
- ~~Set version to `0.0.0-dev` placeholder on main (releases are cut from release branches)~~

### Image Updates (values.yaml)
| Component | Old | New |
|-----------|-----|-----|
| aws-for-fluent-bit | 3.1.1 | 3.2.4 |
| cloudwatch-agent-operator | 3.3.1 | 3.3.2 |
| cloudwatch-agent | 1.300063.0b1323 | 1.300064.1b1344 |
| dcgm-exporter | 4.4.0-4.5.0-ubuntu22.04 | 4.5.2-4.8.1-ubuntu22.04 |
| adot-autoinstrumentation-java | v2.11.5 | v2.25.1 |
| adot-autoinstrumentation-python | v0.12.1 | v0.16.0 |
| adot-autoinstrumentation-dotnet | v1.9.1 | v1.11.1 |
| adot-autoinstrumentation-node | v0.7.0 | v0.9.0 |

### Release Notes
Added entries for:
- v5.2.3, v5.2.2, v5.2.1, v5.2.0, v5.1.0, v5.0.0 (not yet released via helm)
- v4.10.3, v4.10.2, v4.10.1

### Bug Fixes
- `slack-notification.yml`: Use `SLACK_WEBHOOK_URL_ISSUE` instead of `SLACK_WEBHOOK_URL_PR` for PR notifications
- `slack-notification.yml`: Fix missing comma in JSON payload for PR notification


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

