### PR TITLE
Update CloudWatch Agent image tag to 1.300066.0b1367

### DIFF
--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -858,7 +858,7 @@ agent:
   replicas: 1 # The total number non-terminated pods targeted by this AmazonCloudWatchAgent's deployment or statefulSet.
   image:
     repository: cloudwatch-agent
-    tag: 1.300064.1b1344
+    tag: 1.300066.0b1367
     repositoryDomainMap:
       public: public.ecr.aws/cloudwatch-agent
       cn-north-1: 934860584483.dkr.ecr.cn-north-1.amazonaws.com.cn


### PR DESCRIPTION
Updated the Amazon CloudWatch Agent image tag to the```1.300066.0b1367``` version.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

