### PR TITLE
Fix agent.config bleed-through into cluster-scraper deployment

### DIFF
--- a/.github/workflows/amazon-cloudwatch-observability-integration-test.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-integration-test.yaml
@@ -56,6 +56,18 @@ jobs:
           - dualstack-endpoint-enabled
           - dualstack-endpoint-with-custom-endpoint
           - configmap-permission-scoping
+          - feature-targeted-default
+          - feature-targeted-appsignals-disabled
+          - feature-targeted-ci-disabled
+          - feature-targeted-both-disabled
+          - feature-targeted-otlp-disabled
+          - feature-targeted-multi-agent
+          - feature-targeted-split-features
+          - feature-targeted-custom-otel-config
+          - feature-targeted-user-config-override
+          - feature-targeted-agent-config-override
+          - otlp-custom-otel-config
+          - otlp-disabled
     steps:
       - uses: actions/checkout@v3
 

--- a/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
@@ -38,9 +38,9 @@ Helper function to modify auto-monitor config based on agent configurations
 {{- $autoMonitorConfig := deepCopy .Values.manager.applicationSignals.autoMonitor -}}
 {{- $hasAppSignals := false -}}
 {{- range .Values.agents -}}
-  {{- $agent := merge . (deepCopy $.Values.agent) -}}
+  {{- $agent := mergeOverwrite (deepCopy $.Values.agent) . -}}
   {{- if and $.Values.applicationSignals.enabled (eq $.Values.applicationSignals.targetAgent $agent.name) -}}
-    {{- if $agent.config -}}
+    {{- if and $agent.config (ne ($agent.config | toString) "default") -}}
       {{- $agentConfig := $agent.config -}}
       {{- if or (and (hasKey $agentConfig "logs") (hasKey $agentConfig.logs "metrics_collected") (hasKey $agentConfig.logs.metrics_collected "application_signals")) (and (hasKey $agentConfig "traces") (hasKey $agentConfig.traces "traces_collected") (hasKey $agentConfig.traces.traces_collected "application_signals")) -}}
         {{- $hasAppSignals = true -}}
@@ -380,8 +380,11 @@ Set DCGM_EXPORTER_INTERVAL environment variable for dcgmExporter if accelerated_
 {{- $intervalFound := false -}}
 {{- $intervalValue := 0 -}}
 {{- range .Values.agents -}}
-  {{- $agent := merge . (deepCopy $.Values.agent) -}}
-  {{- $agentConfig := $agent.config | default dict -}}
+  {{- $agent := mergeOverwrite (deepCopy $.Values.agent) . -}}
+  {{- $agentConfig := $agent.config -}}
+  {{- if or (not $agentConfig) (eq ($agentConfig | toString) "default") -}}
+    {{- $agentConfig = dict -}}
+  {{- end -}}
   {{- if and (hasKey $agentConfig "logs") (hasKey $agentConfig.logs "metrics_collected") (hasKey $agentConfig.logs.metrics_collected "kubernetes") (hasKey $agentConfig.logs.metrics_collected.kubernetes "accelerated_compute_gpu_metrics_collection_interval") -}}
     {{- $intervalFound = true -}}
     {{- $intervalValue = $agentConfig.logs.metrics_collected.kubernetes.accelerated_compute_gpu_metrics_collection_interval -}}

--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
@@ -64,7 +64,7 @@ data:
 {{- $region := .Values.region | required ".Values.region is required." -}}
 {{- $isROSA := eq $.Values.k8sMode "ROSA" -}}
 {{- range .Values.agents }}
-{{- $agent := merge . (deepCopy $.Values.agent) }}
+{{- $agent := mergeOverwrite (deepCopy $.Values.agent) . }}
 {{/* Skip cluster-scraper agent when otelContainerInsights is disabled */}}
 {{- if or $.Values.otelContainerInsights.enabled (ne $agent.name $.Values.otelContainerInsights.clusterScraperAgent) }}
 apiVersion: cloudwatch.aws.amazon.com/v1alpha1
@@ -99,7 +99,7 @@ spec:
   affinity: {{- toYaml . | nindent 4 }}
   {{- end }}
   hostNetwork: {{ $agent.hostNetwork }}
-  {{- if $agent.config }}
+  {{- if and $agent.config (ne ($agent.config | toString) "default") }}
   config: {{ include "cloudwatch-agent.modify-config" (merge (dict "Config" $agent.config) $ ) }}
   {{- else }}
   config: {{ include "cloudwatch-agent.modify-config" (merge (dict "Config" (include "cloudwatch-agent.build-default-config" (dict "agentName" $agent.name "context" $) | fromJson)) $ ) }}

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -854,7 +854,7 @@ agents:
   - name: cloudwatch-agent
   - name: cloudwatch-agent-cluster-scraper
     mode: deployment
-    config: "default"
+    config: "default" # the reserved string "default" indicates building the default config dynamically
     replicas: 1
     hostNetwork: true
 agent:
@@ -919,7 +919,7 @@ agent:
     issuerAnnotations: {}
   serviceAccount:
     name: # override agent service account name
-  config: # optional config that can be provided to override the build-default-config output
+  config: # optional config that can be provided to override the default config
   otelConfig: # optional YAML config that can be provided to combine with the build-default-otel-config output
   prometheus:
     config:

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -854,6 +854,7 @@ agents:
   - name: cloudwatch-agent
   - name: cloudwatch-agent-cluster-scraper
     mode: deployment
+    config: "default"
     replicas: 1
     hostNetwork: true
 agent:

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/feature-targeted-agent-config-override/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/feature-targeted-agent-config-override/main.tf
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+module "base" {
+  source           = "../.."
+  helm_values_file = "${path.module}/values.yaml"
+  helm_dir         = var.helm_dir
+}
+
+resource "null_resource" "validator" {
+  depends_on = [module.base.helm_release]
+
+  provisioner "local-exec" {
+    command = "go test ${var.test_dir} -v -run=TestFeatureTargetedAgentConfigOverride"
+  }
+}
+
+variable "test_dir" {
+  type    = string
+  default = "../../../../validations/minikube/scenarios"
+}
+
+variable "helm_dir" {
+  type    = string
+  default = "../../../../../../charts/amazon-cloudwatch-observability"
+}

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/feature-targeted-agent-config-override/values.yaml
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/feature-targeted-agent-config-override/values.yaml
@@ -1,0 +1,8 @@
+region: us-west-2
+clusterName: minikube
+agent:
+  config:
+    logs:
+      metrics_collected:
+        kubernetes:
+          enhanced_container_insights: true

--- a/integration-tests/amazon-cloudwatch-observability/validations/minikube/scenarios/feature_targeted_agent_config_override_test.go
+++ b/integration-tests/amazon-cloudwatch-observability/validations/minikube/scenarios/feature_targeted_agent_config_override_test.go
@@ -1,0 +1,119 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package scenarios
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/aws-observability/helm-charts/integration-tests/amazon-cloudwatch-observability/util"
+	"github.com/aws-observability/helm-charts/integration-tests/amazon-cloudwatch-observability/validations/minikube"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// TestFeatureTargetedAgentConfigOverride verifies that when agent.config (singular)
+// is set, the cloudwatch-agent daemonset uses it but the cluster-scraper deployment
+// gets build-default-config output instead (no config bleed-through).
+func TestFeatureTargetedAgentConfigOverride(t *testing.T) {
+	k8sClient, err := util.NewK8sClient()
+	if !assert.NoError(t, err) {
+		t.Fatal("failed to create k8s client")
+	}
+
+	ns, err := k8sClient.GetNamespace(minikube.Namespace)
+	assert.NoError(t, err)
+	assert.Equal(t, minikube.Namespace, ns.Name)
+
+	dynamicClient, err := k8sClient.GetDynamicClient()
+	if !assert.NoError(t, err) {
+		t.Fatal("failed to get dynamic client")
+	}
+
+	gvr := schema.GroupVersionResource{
+		Group:    "cloudwatch.aws.amazon.com",
+		Version:  "v1alpha1",
+		Resource: "amazoncloudwatchagents",
+	}
+
+	agentList, err := dynamicClient.Resource(gvr).Namespace(minikube.Namespace).List(
+		context.Background(), metav1.ListOptions{},
+	)
+	if !assert.NoError(t, err) {
+		t.Fatal("failed to list AmazonCloudWatchAgent CRs")
+	}
+
+	agentMap := make(map[string]unstructured.Unstructured)
+	for _, agent := range agentList.Items {
+		agentMap[agent.GetName()] = agent
+	}
+
+	t.Run("DaemonsetUsesAgentConfig", func(t *testing.T) {
+		agent, exists := agentMap["cloudwatch-agent"]
+		if !assert.True(t, exists, "cloudwatch-agent CR should exist") {
+			return
+		}
+		config := extractAgentCRConfig(t, agent)
+		if config == nil {
+			return
+		}
+
+		// agent.config has logs.metrics_collected.kubernetes — verify it's present
+		logs, ok := config["logs"].(map[string]interface{})
+		assert.True(t, ok, "cloudwatch-agent config should have logs section")
+		if ok {
+			mc, ok := logs["metrics_collected"].(map[string]interface{})
+			assert.True(t, ok, "logs should have metrics_collected")
+			if ok {
+				_, hasK8s := mc["kubernetes"]
+				assert.True(t, hasK8s, "cloudwatch-agent should have kubernetes in metrics_collected from agent.config")
+			}
+		}
+	})
+
+	t.Run("ClusterScraperGetsDefaultConfig", func(t *testing.T) {
+		agent, exists := agentMap["cloudwatch-agent-cluster-scraper"]
+		if !assert.True(t, exists, "cloudwatch-agent-cluster-scraper CR should exist") {
+			return
+		}
+		config := extractAgentCRConfig(t, agent)
+		if config == nil {
+			return
+		}
+
+		// cluster-scraper should get build-default-config: only {"agent":{"region":"..."}}
+		_, hasLogs := config["logs"]
+		assert.False(t, hasLogs, "cluster-scraper should NOT have logs section (config bleed-through)")
+
+		_, hasTraces := config["traces"]
+		assert.False(t, hasTraces, "cluster-scraper should NOT have traces section (config bleed-through)")
+
+		agentSection, hasAgent := config["agent"].(map[string]interface{})
+		assert.True(t, hasAgent, "cluster-scraper should have agent section with region")
+		if hasAgent {
+			_, hasRegion := agentSection["region"]
+			assert.True(t, hasRegion, "cluster-scraper agent section should have region")
+		}
+	})
+}
+
+func extractAgentCRConfig(t *testing.T, cr unstructured.Unstructured) map[string]interface{} {
+	spec, ok := cr.Object["spec"].(map[string]interface{})
+	if !assert.True(t, ok, "spec should be a map") {
+		return nil
+	}
+	configStr, ok := spec["config"].(string)
+	if !assert.True(t, ok, "config should be a string") {
+		return nil
+	}
+	var config map[string]interface{}
+	err := json.Unmarshal([]byte(configStr), &config)
+	if !assert.NoError(t, err, "config should be valid JSON") {
+		return nil
+	}
+	return config
+}


### PR DESCRIPTION
*Issue #, if available:* Fixes https://github.com/aws-observability/helm-charts/issues/290

*Description of changes:*
Set `config: "default"` on the cluster-scraper agents entry to prevent inheriting agent.config via Helm merge. The string type cannot be deep-merged into by Helm's merge functions, so it blocks map inheritance. Template guards treat "default" as unset and fall through to build-default-config which produces the correct minimal config based on feature-flag targeting.

Also adds missing feature-targeted and otlp test scenarios to CI matrix.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

