### PR TITLE
Add ClusterIP Service for node-exporter and use service DNS for scraping

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/certmanager.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/certmanager.yaml
@@ -62,6 +62,8 @@ spec:
     - "dcgm-exporter-service.amazon-cloudwatch.svc"
     - "neuron-monitor-service"
     - "neuron-monitor-service.amazon-cloudwatch.svc"
+    - "node-exporter-service"
+    - "node-exporter-service.amazon-cloudwatch.svc"
   issuerRef:
     kind: Issuer
     name: "agent-ca"

--- a/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-config.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-config.tpl
@@ -15,6 +15,7 @@ receivers:
           scheme: https
           tls_config:
             ca_file: /etc/amazon-cloudwatch-observability-agent-client-cert/tls-ca.crt
+            insecure_skip_verify: true
           static_configs:
             - targets:
                 - ${env:HOST_IP}:9487

--- a/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-config.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-config.tpl
@@ -15,10 +15,9 @@ receivers:
           scheme: https
           tls_config:
             ca_file: /etc/amazon-cloudwatch-observability-agent-client-cert/tls-ca.crt
-            insecure_skip_verify: true
           static_configs:
             - targets:
-                - ${env:HOST_IP}:9487
+                - {{ include "node-exporter.name" . }}-service:9487
 {{- end }}
 
   prometheus/cw_k8s_ci_v0_cadvisor:

--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.agent.enabled }}
 {{- if and (.Values.agent.autoGenerateCert.enabled) (not .Values.agent.certManager.enabled) -}}
-{{- $altNames := list ( printf "%s-service" (include "dcgm-exporter.name" .) ) ( printf "%s-service" (include "neuron-monitor.name" .) ) ( printf "%s-service.%s.svc" (include "dcgm-exporter.name" .) .Release.Namespace ) ( printf "%s-service.%s.svc" (include "neuron-monitor.name" .) .Release.Namespace ) ( include "kube-state-metrics.name" . ) ( printf "%s.%s.svc" (include "kube-state-metrics.name" .) .Release.Namespace ) -}}
+{{- $altNames := list ( printf "%s-service" (include "dcgm-exporter.name" .) ) ( printf "%s-service" (include "neuron-monitor.name" .) ) ( printf "%s-service.%s.svc" (include "dcgm-exporter.name" .) .Release.Namespace ) ( printf "%s-service.%s.svc" (include "neuron-monitor.name" .) .Release.Namespace ) ( printf "%s-service" (include "node-exporter.name" .) ) ( printf "%s-service.%s.svc" (include "node-exporter.name" .) .Release.Namespace ) ( include "kube-state-metrics.name" . ) ( printf "%s.%s.svc" (include "kube-state-metrics.name" .) .Release.Namespace ) -}}
 {{- range $i, $customAgent := .Values.agents }}
 {{ $altNames = append $altNames ( printf "%s-target-allocator-service" $customAgent.name )}}
 {{- end }}

--- a/charts/amazon-cloudwatch-observability/templates/linux/node-exporter-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/node-exporter-daemonset.yaml
@@ -94,6 +94,25 @@ spec:
             name: {{ include "node-exporter.name" . }}-web-config
 ---
 apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "node-exporter.name" . }}-service
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "amazon-cloudwatch-observability.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ include "node-exporter.name" . }}
+spec:
+  type: ClusterIP
+  internalTrafficPolicy: Local
+  ports:
+    - name: metrics
+      port: 9487
+      targetPort: metrics
+      protocol: TCP
+  selector:
+    k8s-app: {{ include "node-exporter.name" . }}
+---
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "node-exporter.name" . }}-web-config


### PR DESCRIPTION
*Description of changes:*

[PR #297](https://github.com/aws-observability/helm-charts/pull/297) removed `insecure_skip_verify: true` from the `node-exporter` Prometheus scrape config, which broke `node-exporter` metric collection due to TLS handshake error.

Fix:
 
- Add a ClusterIP Service with `internalTrafficPolicy: Local` for node-exporter to enable scraping via service DNS name
- Update OTEL prometheus config to target service name instead of HOST_IP 
- Add node-exporter-service SANs to both cert-manager and auto-generated TLS certificates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

