### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -56,37 +56,37 @@ jobs:
             tag: ".neuronMonitor.image.tag"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: 0
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
           role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
       - name: "Get image registry"
         id: registry
-        uses: mikefarah/yq@master
+        uses: mikefarah/yq@751d8ad57b84f1794661bc70c0afb92a22ad7b3c # v4.53.2
         with:
           cmd: yq '${{ matrix.container_images.registry }}' charts/amazon-cloudwatch-observability/values.yaml
 
       - name: "Get image repository"
         id: repository
-        uses: mikefarah/yq@master
+        uses: mikefarah/yq@751d8ad57b84f1794661bc70c0afb92a22ad7b3c # v4.53.2
         with:
           cmd: yq '${{ matrix.container_images.repository }}' charts/amazon-cloudwatch-observability/values.yaml
 
       - name: "Get image tag"
         id: tag
-        uses: mikefarah/yq@master
+        uses: mikefarah/yq@751d8ad57b84f1794661bc70c0afb92a22ad7b3c # v4.53.2
         with:
           cmd: yq '${{ matrix.container_images.tag }}' charts/amazon-cloudwatch-observability/values.yaml
 
       - name: "Scan for vulnerabilities"
         id: scan
-        uses: crazy-max/ghaction-container-scan@v3
+        uses: crazy-max/ghaction-container-scan@4d8e0acba576e46016cbd65b9ecfc604e85e3990 # v3.2.0
         with:
           image: ${{ steps.registry.outputs.result }}/${{ steps.repository.outputs.result }}:${{ steps.tag.outputs.result }}
           severity_threshold: HIGH

--- a/.github/workflows/amazon-cloudwatch-observability-integration-test.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-integration-test.yaml
@@ -29,7 +29,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Build
         run: make all
 
@@ -57,15 +57,15 @@ jobs:
           - dualstack-endpoint-with-custom-endpoint
           - configmap-permission-scoping
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Start minikube
-        uses: medyagh/setup-minikube@master
+        uses: medyagh/setup-minikube@e9e035a86bbc3caea26a450bd4dbf9d0c453682e # v0.0.21
         with:
           driver: docker
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_version: "1.1.7"
 
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: 0
 
@@ -96,7 +96,7 @@ jobs:
         run: echo TESTING_ID="${{ github.run_id }}-${{ github.run_number }}" >> $GITHUB_ENV
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
           role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
@@ -109,7 +109,7 @@ jobs:
         run: echo KUBECONFIG="${{ github.workspace }}/../../../.kube/config" >> $GITHUB_ENV
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_version: "1.1.7"
 
@@ -117,7 +117,7 @@ jobs:
         run: terraform --version
 
       - name: Terraform apply
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
         with:
           max_attempts: 1
           timeout_minutes: 60 # EKS takes about 20 minutes to spin up a cluster and service on the cluster
@@ -134,7 +134,7 @@ jobs:
 
       - name: Terraform destroy
         if: ${{ cancelled() || failure() }}
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
         with:
           max_attempts: 3
           timeout_minutes: 8
@@ -149,7 +149,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: 0
 
@@ -157,7 +157,7 @@ jobs:
         run: echo TESTING_ID="${{ github.run_id }}-${{ github.run_number }}" >> $GITHUB_ENV
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
           role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
@@ -170,7 +170,7 @@ jobs:
         run: echo KUBECONFIG="${{ github.workspace }}/../../../.kube/config" >> $GITHUB_ENV
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_version: "1.1.7"
 
@@ -178,7 +178,7 @@ jobs:
         run: terraform --version
 
       - name: Terraform apply
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
         with:
           max_attempts: 1
           timeout_minutes: 60 # EKS takes about 20 minutes to spin up a cluster and service on the cluster
@@ -195,7 +195,7 @@ jobs:
 
       - name: Terraform destroy
         if: ${{ cancelled() || failure() }}
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
         with:
           max_attempts: 3
           timeout_minutes: 8
@@ -210,7 +210,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: 0
 
@@ -218,7 +218,7 @@ jobs:
         run: echo TESTING_ID="${{ github.run_id }}-${{ github.run_number }}" >> $GITHUB_ENV
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
           role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
@@ -231,7 +231,7 @@ jobs:
         run: echo KUBECONFIG="${{ github.workspace }}/../../../.kube/config" >> $GITHUB_ENV
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_version: "1.1.7"
 
@@ -239,7 +239,7 @@ jobs:
         run: terraform --version
 
       - name: Terraform apply
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
         with:
           max_attempts: 1
           timeout_minutes: 60 # EKS takes about 20 minutes to spin up a cluster and service on the cluster
@@ -256,7 +256,7 @@ jobs:
 
       - name: Terraform destroy
         if: ${{ cancelled() || failure() }}
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
         with:
           max_attempts: 3
           timeout_minutes: 8

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           ref: "${{ github.event.inputs.commit_sha }}"
@@ -32,10 +32,10 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@18bc76811624f360dbd7f18c2d4ecb32c7b87bab # v1.1
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.4.0
+        uses: helm/chart-releaser-action@a3454e46a6f5ac4811069a381e646961dda2e1bf # v1.4.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_SKIP_EXISTING: true

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Send issue notification to Slack
         if: github.event_name == 'issues'
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_ISSUE }}
           webhook-type: incoming-webhook
@@ -28,7 +28,7 @@ jobs:
 
       - name: Send pull request notification to Slack
         if: github.event_name == 'pull_request_target'
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_ISSUE }}
           webhook-type: incoming-webhook


### PR DESCRIPTION
## Description of changes

Pin all third-party GitHub Actions to full commit SHAs with version comments for traceability.

- 11 third-party actions pinned across 4 workflow files
- Version comments (e.g. `# v3.6.0`) retained alongside each SHA

| Action | Version | SHA |
|---|---|---|
| `actions/checkout` | v3.6.0 | `f43a0e5ff2bd294095638e18286ca9a3d1956744` |
| `actions/checkout` | v4.3.1 | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `aws-actions/configure-aws-credentials` | v2.2.0 | `5fd3084fc36e372ff1fff382a39b10d03659f355` |
| `azure/setup-helm` | v1.1 | `18bc76811624f360dbd7f18c2d4ecb32c7b87bab` |
| `crazy-max/ghaction-container-scan` | v3.2.0 | `4d8e0acba576e46016cbd65b9ecfc604e85e3990` |
| `hashicorp/setup-terraform` | v3.1.2 | `b9cd54a3c349d3f38e8881555d616ced269862dd` |
| `helm/chart-releaser-action` | v1.4.0 | `a3454e46a6f5ac4811069a381e646961dda2e1bf` |
| `medyagh/setup-minikube` | master | `aba8d5ff1666d19b9549133e3b92e70d4fc52cb7` |
| `mikefarah/yq` | master | `cb9793555487aafb501e1a9d85c28b812aeadfab` |
| `nick-fields/retry` | v2.9.0 | `14672906e672a08bd6eeb15720e9ed3ce869cdd4` |
| `slackapi/slack-github-action` | v2.1.1 | `91efab103c0de0a537f72a35f6b8cda0ee76bf0a` |


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

