### PR TITLE
minor fixes

### DIFF
--- a/charts/amazon-cloudwatch-observability/crds/cloudwatch.aws.amazon.com_instrumentations.yaml
+++ b/charts/amazon-cloudwatch-observability/crds/cloudwatch.aws.amazon.com_instrumentations.yaml
@@ -1153,7 +1153,7 @@ spec:
                       type: array
                     configFile:
                       description: Location of Nginx configuration file. Needed only
-                        if different from default "/etx/nginx/nginx.conf"
+                        if different from default "/etc/nginx/nginx.conf"
                       type: string
                     env:
                       description: 'Env defines Nginx specific env vars. There are four

--- a/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
@@ -62,7 +62,7 @@ Helper function to modify cloudwatch-agent config
 {{- $configCopy := deepCopy .Config }}
 
 {{- $agent := pluck "agent" $configCopy | first }}
-{{- if and (empty $agent) (empty $agent.region) }}
+{{- if or (empty $agent) (empty $agent.region) }}
 {{- $agentRegion := dict "region" .Values.region }}
 {{- $agent := set $configCopy "agent" $agentRegion }}
 {{- end }}

--- a/charts/amazon-cloudwatch-observability/templates/certmanager.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/certmanager.yaml
@@ -59,9 +59,9 @@ spec:
     - {{( printf "%s-target-allocator-service" $customAgent.name )}}
     {{- end }}
     - "dcgm-exporter-service"
-    - "dcgm-exporter-service.amazon-cloudwatch.svc"
+    - "dcgm-exporter-service.{{ .Release.Namespace }}.svc"
     - "neuron-monitor-service"
-    - "neuron-monitor-service.amazon-cloudwatch.svc"
+    - "neuron-monitor-service.{{ .Release.Namespace }}.svc"
   issuerRef:
     kind: Issuer
     name: "agent-ca"
@@ -78,7 +78,7 @@ spec:
   commonName: "agent-server"
   dnsNames:
     - "cloudwatch-agent"
-    - "cloudwatch-agent.amazon-cloudwatch.svc"
+    - "cloudwatch-agent.{{ .Release.Namespace }}.svc"
   issuerRef:
     kind: Issuer
     name: "agent-ca"

--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
@@ -6,10 +6,10 @@
 {{- end }}
 {{- $agentAltNames := list ( printf "%s" (include "cloudwatch-agent.name" .) ) ( printf "%s.%s.svc" (include "cloudwatch-agent.name" .) .Release.Namespace ) -}}
 {{- $ca := genCA ("agent-ca")  ( .Values.agent.autoGenerateCert.expiryDays | int ) -}}
-{{- $cert := genSignedCert ("agent") nil $altNames ( .Values.admissionWebhooks.autoGenerateCert.expiryDays | int ) $ca -}}
-{{- $serverCert := genSignedCert ("agent-server") nil $agentAltNames ( .Values.admissionWebhooks.autoGenerateCert.expiryDays | int ) $ca -}}
-{{- $clientCert := genSignedCert ("agent-client") nil nil ( .Values.admissionWebhooks.autoGenerateCert.expiryDays | int ) $ca -}}
-{{- $agentTAClientCert := genSignedCert ("agent-ta-client") nil nil ( .Values.admissionWebhooks.autoGenerateCert.expiryDays | int ) $ca -}}
+{{- $cert := genSignedCert ("agent") nil $altNames ( .Values.agent.autoGenerateCert.expiryDays | int ) $ca -}}
+{{- $serverCert := genSignedCert ("agent-server") nil $agentAltNames ( .Values.agent.autoGenerateCert.expiryDays | int ) $ca -}}
+{{- $clientCert := genSignedCert ("agent-client") nil nil ( .Values.agent.autoGenerateCert.expiryDays | int ) $ca -}}
+{{- $agentTAClientCert := genSignedCert ("agent-ta-client") nil nil ( .Values.agent.autoGenerateCert.expiryDays | int ) $ca -}}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION

*Description of changes:*
- Fixed `_helpers.tpl` region injection logic from and to or so the region is set when either the agent section or its region field is missing.
- Replaced 3 hardcoded `amazon-cloudwatch` namespace references in `certmanager.yaml` with `{{ .Release.Namespace }}` so TLS SANs match when installed in a non-default namespace.
- Changed 4 genSignedCert calls in `cloudwatch-agent-custom-resource.yaml` from .`Values.admissionWebhooks.autoGenerateCert.expiryDays` to `.Values.agent.autoGenerateCert.expiryDays` so agent certs use the agent's own expiry config.
- Fixed `/etx/nginx/nginx.conf` typo to `/etc/nginx/nginx.conf` in the instrumentations CRD description.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

