### PR TITLE
Add LIS CSI metrics support to OTEL container insights

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-config.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-config.tpl
@@ -90,6 +90,28 @@ receivers:
               regex: metrics
               action: keep
 
+  prometheus/cw_k8s_ci_v0_lis_csi_node:
+    config:
+      scrape_configs:
+        - job_name: lis-csi-node
+          scrape_interval: {{ .Values.otelContainerInsights.metricResolution }}
+          scrape_timeout: {{ include "otel-container-insights.scrapeTimeout" . }}
+          kubernetes_sd_configs:
+            - role: pod
+              namespaces:
+                names:
+                  - kube-system
+          relabel_configs:
+            - source_labels: [__meta_kubernetes_pod_label_app]
+              regex: ec2-instance-store-plugin
+              action: keep
+            - source_labels: [__meta_kubernetes_pod_node_name]
+              regex: ${env:K8S_NODE_NAME}
+              action: keep
+            - source_labels: [__meta_kubernetes_pod_container_port_name]
+              regex: metrics
+              action: keep
+
   kubeletstats/cw_k8s_ci_v0:
     auth_type: serviceAccount
     collection_interval: {{ .Values.otelContainerInsights.metricResolution }}
@@ -258,6 +280,16 @@ processors:
           - set(attributes["cloudwatch.source"], "cloudwatch-agent")
           - set(attributes["cloudwatch.solution"], "k8s-otel-container-insights")
           - set(attributes["cloudwatch.pipeline"], "ebs-csi")
+
+  transform/cw_k8s_ci_v0_set_scope_lis_csi:
+    error_mode: ignore
+    metric_statements:
+      - context: scope
+        statements:
+          - set(scope.schema_url, "")
+          - set(attributes["cloudwatch.source"], "cloudwatch-agent")
+          - set(attributes["cloudwatch.solution"], "k8s-otel-container-insights")
+          - set(attributes["cloudwatch.pipeline"], "lis-csi")
 
   transform/cw_k8s_ci_v0_set_scope_kubeletstats:
     error_mode: ignore
@@ -540,6 +572,16 @@ processors:
           - delete_key(attributes, "instance_id") where attributes["instance_id"] != nil
           - delete_key(attributes, "volume_id") where attributes["volume_id"] != nil
 
+  transform/cw_k8s_ci_v0_lis_csi_promote:
+    error_mode: ignore
+    metric_statements:
+      - context: datapoint
+        statements:
+          - set(resource.attributes["instance_id"], attributes["instance_id"]) where attributes["instance_id"] != nil
+          - set(resource.attributes["volume_id"], attributes["volume_id"]) where attributes["volume_id"] != nil
+          - delete_key(attributes, "instance_id") where attributes["instance_id"] != nil
+          - delete_key(attributes, "volume_id") where attributes["volume_id"] != nil
+
 exporters:
   otlphttp/cw_k8s_ci_v0_metrics_dest:
     endpoint: {{ if .Values.otelContainerInsights.cloudwatchMetricsEndpoint }}{{ .Values.otelContainerInsights.cloudwatchMetricsEndpoint | quote }}{{ else }}"https://monitoring.{{ .Values.region }}.amazonaws.com:443"{{ end }}
@@ -672,6 +714,27 @@ service:
         - transform/cw_k8s_ci_v0_set_cloud_resource_id
         - k8sattributes/cw_k8s_ci_v0_node
         - transform/cw_k8s_ci_v0_set_scope_ebs_csi
+        - transform/cw_k8s_ci_v0_clear_schema_url
+        - transform/cw_k8s_ci_v0_set_workload
+        - awsattributelimit/cw_k8s_ci_v0
+        - batch/cw_k8s_ci_v0_metrics_dest
+      exporters:
+        - otlphttp/cw_k8s_ci_v0_metrics_dest
+
+    metrics/cw_k8s_ci_v0_lis_csi_node:
+      receivers: [prometheus/cw_k8s_ci_v0_lis_csi_node]
+      processors:
+        - filter/cw_k8s_ci_v0_scrape_metadata
+        - transform/cw_k8s_ci_v0_set_unit
+        - metricstarttime/cw_k8s_ci_v0
+        - transform/cw_k8s_ci_v0_set_cluster_name
+        - transform/cw_k8s_ci_v0_lis_csi_promote
+        - transform/cw_k8s_ci_v0_set_node_name
+        - transform/cw_k8s_ci_v0_promote_node_name
+        - resourcedetection/cw_k8s_ci_v0
+        - transform/cw_k8s_ci_v0_set_cloud_resource_id
+        - k8sattributes/cw_k8s_ci_v0_node
+        - transform/cw_k8s_ci_v0_set_scope_lis_csi
         - transform/cw_k8s_ci_v0_clear_schema_url
         - transform/cw_k8s_ci_v0_set_workload
         - awsattributelimit/cw_k8s_ci_v0


### PR DESCRIPTION
## Summary

Add Local Instance Store (LIS) CSI driver metrics support to the OTEL container insights pipeline, mirroring the existing EBS CSI pattern. This enables the OTEL collector to scrape LIS CSI metrics and export them with proper OTEL attributes via the OTLP endpoint.

## Changes

Added 4 components to `_otel-container-insights-config.tpl`:

1. **Receiver** (`prometheus/cw_k8s_ci_v0_lis_csi_node`) — Prometheus scrape config targeting pods with label `app=ec2-instance-store-plugin` in `kube-system` namespace, filtered to the current node and the `metrics` port (8101).

2. **Scope Transform** (`transform/cw_k8s_ci_v0_set_scope_lis_csi`) — Sets instrumentation scope attributes:
   - `cloudwatch.pipeline = "lis-csi"`
   - `cloudwatch.solution = "k8s-otel-container-insights"`
   - `cloudwatch.source = "cloudwatch-agent"`

3. **Attribute Promote Transform** (`transform/cw_k8s_ci_v0_lis_csi_promote`) — Promotes `instance_id` and `volume_id` from datapoint attributes to resource attributes (same as EBS CSI, since LIS CSI uses the same dimension sets).

4. **Pipeline** (`metrics/cw_k8s_ci_v0_lis_csi_node`) — Wires the receiver through the standard processor chain: scrape metadata filter → set unit → metric start time → cluster name → lis_csi promote → node name → resource detection → cloud resource ID → k8s node attributes → lis_csi scope → clear schema → workload → attribute limit → batch → OTLP export.

## Metrics Collected (13 metrics)

The LIS CSI driver exposes these raw Prometheus metrics (scraped as-is by the OTEL pipeline):

| Metric | Type |
|--------|------|
| `aws_ec2_instance_store_csi_read_bytes_total` | Counter |
| `aws_ec2_instance_store_csi_write_bytes_total` | Counter |
| `aws_ec2_instance_store_csi_read_ops_total` | Counter |
| `aws_ec2_instance_store_csi_write_ops_total` | Counter |
| `aws_ec2_instance_store_csi_read_seconds_total` | Counter |
| `aws_ec2_instance_store_csi_write_seconds_total` | Counter |
| `aws_ec2_instance_store_csi_ec2_exceeded_iops_seconds_total` | Counter |
| `aws_ec2_instance_store_csi_ec2_exceeded_tp_seconds_total` | Counter |
| `aws_ec2_instance_store_csi_volume_queue_length` | Gauge |
| `aws_ec2_instance_store_csi_read_io_latency_seconds` | Histogram |
| `aws_ec2_instance_store_csi_write_io_latency_seconds` | Histogram |
| `aws_ec2_instance_store_csi_nvme_collector_errors_total` | Counter (collector-internal) |
| `aws_ec2_instance_store_csi_nvme_collector_scrapes_total` | Counter (collector-internal) |

> **Note on metric names**: The OTEL pipeline passes through the raw Prometheus metric names (`aws_ec2_instance_store_csi_*`) as-is. This differs from the enhanced container insights (EMF) pipeline which renames them to `node_diskio_instance_store_*` via a `metricstransform` processor.
> **Note on collector-internal metrics**: nvme_collector_errors_total and nvme_collector_scrapes_total are included for exporter health observability. They are low-cardinality and follow the same _total → unit "1" convention.


## Testing

End-to-end validated on EKS cluster `cwa-liscsi-test-arm64` (arm64 nodes).

### Setup
- Installed `aws-ec2-local-instance-store-csi-driver` EKS addon with `{"metrics":{"enabled":true}}`
- Installed `eks-pod-identity-agent` EKS addon
- Created Pod Identity association for CloudWatch agent service account
- Deployed test PVC (`ec2-instance-store-sc`) and pod generating continuous disk I/O
- Installed helm chart from this branch with `agent.image.tag=latest`

### Validation
Queried the OTLP PromQL API at `https://monitoring.us-west-2.amazonaws.com/api/v1/query` with SigV4 signing:

**All 13 metrics returned results** ✅

**Attribute validations** ✅
- `@resource.instance_id` present, starts with `i-` (promoted from datapoint to resource scope)
- `@resource.volume_id` present (promoted from datapoint to resource scope)
- `instance_id` absent from datapoint scope (confirms promotion)
- `volume_id` absent from datapoint scope (confirms promotion)
- `@instrumentation.cloudwatch.pipeline` = `lis-csi`
- `@instrumentation.cloudwatch.solution` = `k8s-otel-container-insights`
- `@resource.k8s.cluster.name` = `cwa-liscsi-test-arm64`
- `@resource.service.name` = `lis-csi-node`
