### PR TITLE
feat(otel): Add k8sattributes processor node filter to daemonset

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-config.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-config.tpl
@@ -339,6 +339,8 @@ processors:
   k8sattributes/cw_k8s_ci_v0_node:
     auth_type: serviceAccount
     passthrough: false
+    filter:
+      node_from_env_var: K8S_NODE_NAME
     extract:
       metadata:
         - k8s.node.name
@@ -354,6 +356,8 @@ processors:
   k8sattributes/cw_k8s_ci_v0_pod:
     auth_type: serviceAccount
     passthrough: false
+    filter:
+      node_from_env_var: K8S_NODE_NAME
     extract:
       metadata:
         - k8s.pod.uid


### PR DESCRIPTION


*Issue #, if available:*
N/A

*Description of changes:*
Add filter.node_from_env_var=K8S_NODE_NAME directly to both k8sattributes processors in the container insights config template so the daemonset only collects metadata for pods on its own node.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

