### PR TITLE
fix(integration-test): include node-exporter-service in EKS resource counts

### DIFF
--- a/integration-tests/amazon-cloudwatch-observability/validations/eks/resource_counts_linuxonly.go
+++ b/integration-tests/amazon-cloudwatch-observability/validations/eks/resource_counts_linuxonly.go
@@ -11,11 +11,12 @@ const (
 	// - cloudwatch-agent
 	// - cloudwatch-agent-headless
 	// - cloudwatch-agent-monitoring
-	// - dcgm-exporter-service
-	// - neuron-monitor-service
-	// - kube-state-metrics
 	// - cloudwatch-agent-cluster-scraper-monitoring
-	serviceCountLinux = 8
+	// - dcgm-exporter-service
+	// - kube-state-metrics
+	// - neuron-monitor-service
+	// - node-exporter-service
+	serviceCountLinux = 9
 
 	// Services count on Windows:
 	// - cloudwatch-agent-windows

--- a/integration-tests/amazon-cloudwatch-observability/validations/eks/resource_counts_windowslinux.go
+++ b/integration-tests/amazon-cloudwatch-observability/validations/eks/resource_counts_windowslinux.go
@@ -11,11 +11,12 @@ const (
 	// - cloudwatch-agent
 	// - cloudwatch-agent-headless
 	// - cloudwatch-agent-monitoring
-	// - dcgm-exporter-service
-	// - neuron-monitor-service
-	// - kube-state-metrics
 	// - cloudwatch-agent-cluster-scraper-monitoring
-	serviceCountLinux = 8
+	// - dcgm-exporter-service
+	// - kube-state-metrics
+	// - neuron-monitor-service
+	// - node-exporter-service
+	serviceCountLinux = 9
 
 	// Services count on Windows:
 	// - cloudwatch-agent-windows

--- a/integration-tests/amazon-cloudwatch-observability/validations/eks/resources_generated_test.go
+++ b/integration-tests/amazon-cloudwatch-observability/validations/eks/resources_generated_test.go
@@ -29,7 +29,7 @@ const (
 	clusterScraperName   = "cloudwatch-agent-cluster-scraper"
 	nodeExporterName     = "node-exporter"
 	podNameRegex         = "(" + agentName + "|" + agentNameWindows + "|" + operatorName + "|" + fluentBitName + "|" + fluentBitNameWindows + "|" + kubeStateMetricsName + "|" + clusterScraperName + "|" + nodeExporterName + ")-*"
-	serviceNameRegex     = agentName + "(-headless|-monitoring)?|" + agentNameWindows + "(-headless|-monitoring)?|" + addOnName + "-webhook-service|" + dcgmExporterName + "-service|" + neuronMonitor + "-service|" + kubeStateMetricsName + "|" + clusterScraperName + "-monitoring"
+	serviceNameRegex     = agentName + "(-headless|-monitoring)?|" + agentNameWindows + "(-headless|-monitoring)?|" + addOnName + "-webhook-service|" + dcgmExporterName + "-service|" + neuronMonitor + "-service|" + kubeStateMetricsName + "|" + clusterScraperName + "-monitoring|" + nodeExporterName + "-service"
 	daemonSetNameRegex   = agentName + "|" + agentNameWindows + "|" + fluentBitName + "|" + fluentBitNameWindows + "|" + dcgmExporterName + "|" + neuronMonitor + "|" + nodeExporterName
 )
 


### PR DESCRIPTION
# Description of the issue

[PR #304](https://github.com/aws-observability/helm-charts/pull/304) ("Add ClusterIP Service for node-exporter and use service DNS for scraping", merged April 30) added a ClusterIP Service for node-exporter to the helm chart, gated by `nodeExporter.enabled && otelContainerInsights.enabled` (both default `true` on `release-6.2.0`).

PR #304 itself merged with a CI infrastructure failure (exit 127, the test never ran), so the missing test update slipped through. Every PR merged into `release-6.2.0` since then has had a red `EKS-IntegrationTest` job failing the same way:

```
TestResourcesGenerated
Error: should have 12 item(s), but has 13
       service is not created correctly
```

The 13th service is `node-exporter-service`, which is now created on default deployments but isn't in the test's expected list.

Examples of PRs that merged through this failure:
- #308 (LIS CSI metrics support, May 11) — EKS-IntegrationTest FAILURE
- #311 (k8sattributes node filter, May 13) — EKS-IntegrationTest FAILURE

# Description of changes

Updates the EKS integration test's expected counts and regex to match the helm chart's actual default deployment.

- `resource_counts_linuxonly.go`: `serviceCountLinux` 8 → 9, comment list updated
- `resource_counts_windowslinux.go`: same
- `resources_generated_test.go`: added `nodeExporterName + "-service"` to `serviceNameRegex` so the service passes the regex match assertion

# License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests

- `go build -tags windowslinux ./...` and `go build -tags linuxonly ./...` clean
- `go vet` clean
- The full `EKS-IntegrationTest` will run on this PR; once it passes, all subsequent PRs targeting `release-6.2.0` (e.g. #300 taints, #301 events) will see green checks again.