### PR TITLE
Update featuregate IDs to match operator dependency bump

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -37,7 +37,7 @@ spec:
         - "--auto-instrumentation-dotnet-image={{ template "auto-instrumentation-dotnet.image" . }}"
         - "--auto-instrumentation-nodejs-image={{ template "auto-instrumentation-nodejs.image" . }}"
         - "--target-allocator-image={{ template "target-allocator.image" (merge .Values.agent.prometheus.targetAllocator.image (dict "region" $.Values.region)) }}"
-        - "--feature-gates=operator.autoinstrumentation.multi-instrumentation,operator.autoinstrumentation.multi-instrumentation.skip-container-validation"
+        - "--feature-gates=operator.autoinstrumentation.multiinstrumentation,operator.autoinstrumentation.multiinstrumentation.skipcontainervalidation"
         command:
         - /manager
         name: manager

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -463,10 +463,10 @@ containerLogs:
 manager:
   name:
   image:
-    repository: cloudwatch-agent-operator-dev
-    tag: bump-deps
+    repository: cloudwatch-agent-operator
+    tag: 3.4.2
     repositoryDomainMap:
-      public: 576881538829.dkr.ecr.us-east-1.amazonaws.com
+      public: public.ecr.aws/cloudwatch-agent
       cn-north-1: 934860584483.dkr.ecr.cn-north-1.amazonaws.com.cn
       cn-northwest-1: 934860584483.dkr.ecr.cn-northwest-1.amazonaws.com.cn
       us-gov-east-1: 743662458514.dkr.ecr.us-gov-east-1.amazonaws.com

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -463,10 +463,10 @@ containerLogs:
 manager:
   name:
   image:
-    repository: cloudwatch-agent-operator
-    tag: 3.4.2
+    repository: cloudwatch-agent-operator-dev
+    tag: bump-deps
     repositoryDomainMap:
-      public: public.ecr.aws/cloudwatch-agent
+      public: 576881538829.dkr.ecr.us-east-1.amazonaws.com
       cn-north-1: 934860584483.dkr.ecr.cn-north-1.amazonaws.com.cn
       cn-northwest-1: 934860584483.dkr.ecr.cn-northwest-1.amazonaws.com.cn
       us-gov-east-1: 743662458514.dkr.ecr.us-gov-east-1.amazonaws.com


### PR DESCRIPTION
## Summary

Updates the operator deployment template to use the new featuregate ID format (alphanumeric + dots only, no hyphens).

The OTel collector featuregate library (v1.54+) now rejects hyphens in gate IDs. The operator has renamed its gates accordingly.

## Changes

```diff
- --feature-gates=operator.autoinstrumentation.multi-instrumentation,operator.autoinstrumentation.multi-instrumentation.skip-container-validation
+ --feature-gates=operator.autoinstrumentation.multiinstrumentation,operator.autoinstrumentation.multiinstrumentation.skipcontainervalidation
```

## Dependency

This PR is dependent on the operator PR: https://github.com/aws/amazon-cloudwatch-agent-operator/pull/383

Both PRs must be merged and released together — the new operator binary expects the new IDs, and the helm chart must pass the new IDs.