### PR TITLE
Add default Prometheus EMF metric_declaration when target allocator is enabled

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
@@ -89,6 +89,19 @@ Logic:
   {{- $needsLogs = true -}}
   {{- $_ := set $metricsCollected "kubernetes" (dict "enhanced_container_insights" true) -}}
 {{- end -}}
+{{/* Prometheus EMF: inject metric_declarations when Target Allocator is enabled */}}
+{{- if $ctx.Values.agent.prometheus.targetAllocator.enabled -}}
+  {{- $emf := $ctx.Values.agent.prometheus.emfProcessor -}}
+  {{- if and $emf $emf.metricDeclarations -}}
+    {{- $needsLogs = true -}}
+    {{/* metric_declaration is the correct key (singular); plural is rejected by config-translator. */}}
+    {{- $emfProcessor := dict "metric_declaration" $emf.metricDeclarations -}}
+    {{- if $emf.metricNamespace -}}
+      {{- $_ := set $emfProcessor "metric_namespace" $emf.metricNamespace -}}
+    {{- end -}}
+    {{- $_ := set $metricsCollected "prometheus" (dict "emf_processor" $emfProcessor) -}}
+  {{- end -}}
+{{- end -}}
 {{- if $needsLogs -}}
   {{- $_ := set $config "logs" (dict "metrics_collected" $metricsCollected) -}}
 {{- end -}}

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -763,6 +763,33 @@ agent:
   otelConfig: # optional YAML config that can be provided to combine with the build-default-otel-config output
   prometheus:
     config:
+    ## EMF processor config for Prometheus metrics when Target Allocator is enabled.
+    ## Without metric_declarations, scraped values produce no CloudWatch metrics.
+    emfProcessor:
+      metricNamespace: ContainerInsights/Prometheus
+      metricDeclarations:
+        # node-exporter (PodMonitor "node-exporter") — host CPU/memory/disk/network
+        - source_labels: ["job"]
+          label_matcher: ".*node-exporter.*"
+          dimensions:
+            - ["ClusterName"]
+            - ["ClusterName", "Namespace"]
+          metric_selectors:
+            - "^node_cpu_seconds_total$"
+            - "^node_memory_MemAvailable_bytes$"
+            - "^node_memory_MemTotal_bytes$"
+            - "^node_filesystem_avail_bytes$"
+            - "^node_filesystem_size_bytes$"
+            - "^node_network_receive_bytes_total$"
+            - "^node_network_transmit_bytes_total$"
+        # nginx (ServiceMonitor "nginx") — application request/connection metrics
+        - source_labels: ["job"]
+          label_matcher: ".*nginx.*"
+          dimensions:
+            - ["ClusterName"]
+            - ["ClusterName", "Namespace"]
+          metric_selectors:
+            - "^nginx_.*$"
     targetAllocator:
       enabled: false
       image:


### PR DESCRIPTION
## Summary

When the Target Allocator is enabled (`agent.prometheus.targetAllocator.enabled=true`), the chart renders `.spec.prometheus` with only `scrape_configs` and no EMF metric-extraction block. The agent scrapes targets but produces **0 CloudWatch metrics** — without `metric_declaration`, there's no instruction telling the agent which series to export.

This change injects a default `emf_processor.metric_declaration` block gated behind the TA toggle. Default behavior for non-TA users is unchanged.

## Changes

- `templates/_helpers.tpl` — render `prometheus.emf_processor.metric_declaration` when TA enabled and `emfProcessor` declarations are present
- `values.yaml` — add default `agent.prometheus.emfProcessor` with `metricNamespace` + `metricDeclarations` for node-exporter and nginx

## Test Output

### helm lint:
```
$ helm lint charts/amazon-cloudwatch-observability --set clusterName=test-cluster --set region=us-west-2
==> Linting charts/amazon-cloudwatch-observability
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
```

### Gating proof (EMF block renders only when TA enabled):
```
$ helm template ... --set agent.prometheus.targetAllocator.enabled=true | grep -c metric_declaration
1
$ helm template ... --set agent.prometheus.targetAllocator.enabled=false | grep -c metric_declaration
0
```

### CloudWatch metrics before/after:
```
ContainerInsights/Prometheus metrics (Helm path):   0 → 7
Same default on add-on install path:                0 → 7
```

### OTEL CI flag matrix (no regression):
```
$ bash charts/amazon-cloudwatch-observability/tests/flag_matrix.sh
[State #1] enabled=false logs=false containerLogs=false  PASS
[State #2] enabled=false logs=false containerLogs=true   PASS
[State #3] enabled=false logs=true  containerLogs=false  PASS
[State #4] enabled=false logs=true  containerLogs=true   PASS
[State #5] enabled=true  logs=false containerLogs=false  PASS
[State #6] enabled=true  logs=false containerLogs=true   PASS
[State #7] enabled=true  logs=true  containerLogs=false  PASS
[State #8] enabled=true  logs=true  containerLogs=true   PASS
All 8 cases passed.
```

## Related

- aws/amazon-cloudwatch-agent-operator#386 — TA startup crash fix + pod restart on config change
- aws/amazon-cloudwatch-agent#2157 — agent-side fix for spurious TA warning
