### PR TITLE
Add Karpenter metrics integration to OTEL Container Insights

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-cluster-scraper-config.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-cluster-scraper-config.tpl
@@ -74,6 +74,12 @@ receivers:
               target_label: namespace
             - source_labels: [__meta_kubernetes_pod_node_name]
               target_label: node
+          metric_relabel_configs:
+            # In HA deployments (2+ replicas), only the leader pod actively processes work.
+            # Drop metrics from standby pods to avoid duplicate/stale time series in CloudWatch.
+            - source_labels: [leader_election_master_status]
+              regex: "0"
+              action: drop
 {{- end }}
 
 processors:

--- a/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-cluster-scraper-config.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-cluster-scraper-config.tpl
@@ -190,6 +190,10 @@ processors:
           - set(attributes["k8s.pod.name"], attributes["pod"]) where attributes["pod"] != nil
           - set(attributes["k8s.namespace.name"], attributes["namespace"]) where attributes["namespace"] != nil
           - set(attributes["k8s.node.name"], attributes["node"]) where attributes["node"] != nil
+          # Remove deprecated/unwanted attributes auto-injected by the Prometheus receiver.
+          - delete_key(attributes, "net.host.name") where attributes["net.host.name"] != nil
+          - delete_key(attributes, "net.host.port") where attributes["net.host.port"] != nil
+          - delete_key(attributes, "url.scheme") where attributes["url.scheme"] != nil
       - context: datapoint
         statements:
           - set(attributes["pod"], resource.attributes["pod"]) where resource.attributes["pod"] != nil

--- a/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-cluster-scraper-config.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-cluster-scraper-config.tpl
@@ -48,7 +48,7 @@ receivers:
                 - {{ include "kube-state-metrics.name" . }}.{{ .Release.Namespace }}.svc:{{ .Values.kubeStateMetrics.service.port }}
 {{- end }}
 
-{{- if .Values.otelContainerInsights.integrations.karpenter.enabled }}
+{{- if and .Values.otelContainerInsights.solutions.enabled .Values.otelContainerInsights.solutions.karpenter.enabled }}
   prometheus/cw_k8s_ci_v0_karpenter:
     config:
       scrape_configs:
@@ -60,7 +60,7 @@ receivers:
             - role: pod
               namespaces:
                 names:
-                  - {{ .Values.otelContainerInsights.integrations.karpenter.namespace }}
+                  - {{ .Values.otelContainerInsights.solutions.karpenter.namespace }}
           relabel_configs:
             - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
               regex: karpenter
@@ -162,7 +162,7 @@ processors:
           - set(attributes["cloudwatch.pipeline"], "kube-state-metrics")
 {{- end }}
 
-{{- if .Values.otelContainerInsights.integrations.karpenter.enabled }}
+{{- if and .Values.otelContainerInsights.solutions.enabled .Values.otelContainerInsights.solutions.karpenter.enabled }}
   transform/cw_k8s_ci_v0_set_scope_karpenter:
     error_mode: ignore
     metric_statements:
@@ -488,7 +488,7 @@ service:
       exporters:
         - otlphttp/cw_k8s_ci_v0_cwotel
 {{- end }}
-{{- if .Values.otelContainerInsights.integrations.karpenter.enabled }}
+{{- if and .Values.otelContainerInsights.solutions.enabled .Values.otelContainerInsights.solutions.karpenter.enabled }}
     metrics/cw_k8s_ci_v0_karpenter:
       receivers: [prometheus/cw_k8s_ci_v0_karpenter]
       processors:

--- a/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-cluster-scraper-config.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-cluster-scraper-config.tpl
@@ -74,12 +74,6 @@ receivers:
               target_label: namespace
             - source_labels: [__meta_kubernetes_pod_node_name]
               target_label: node
-          metric_relabel_configs:
-            # In HA deployments (2+ replicas), only the leader pod actively processes work.
-            # Drop metrics from standby pods to avoid duplicate/stale time series in CloudWatch.
-            - source_labels: [leader_election_master_status]
-              regex: "0"
-              action: drop
 {{- end }}
 
 processors:

--- a/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-cluster-scraper-config.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-cluster-scraper-config.tpl
@@ -48,6 +48,28 @@ receivers:
                 - {{ include "kube-state-metrics.name" . }}.{{ .Release.Namespace }}.svc:{{ .Values.kubeStateMetrics.service.port }}
 {{- end }}
 
+{{- if .Values.otelContainerInsights.integrations.karpenter.enabled }}
+  prometheus/cw_k8s_ci_v0_karpenter:
+    config:
+      scrape_configs:
+        - job_name: karpenter
+          scrape_interval: {{ .Values.otelContainerInsights.metricResolution }}
+          scrape_timeout: {{ include "otel-container-insights.scrapeTimeout" . }}
+          metrics_path: {{ .Values.otelContainerInsights.integrations.karpenter.metricsPath }}
+          kubernetes_sd_configs:
+            - role: pod
+              namespaces:
+                names:
+                  - {{ .Values.otelContainerInsights.integrations.karpenter.namespace }}
+          relabel_configs:
+            - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+              regex: karpenter
+              action: keep
+            - source_labels: [__meta_kubernetes_pod_container_port_name]
+              regex: http-metrics
+              action: keep
+{{- end }}
+
 processors:
   filter/cw_k8s_ci_v0_scrape_metadata:
     error_mode: ignore
@@ -132,6 +154,19 @@ processors:
           - set(attributes["cloudwatch.source"], "cloudwatch-agent")
           - set(attributes["cloudwatch.solution"], "k8s-otel-container-insights")
           - set(attributes["cloudwatch.pipeline"], "kube-state-metrics")
+{{- end }}
+
+{{- if .Values.otelContainerInsights.integrations.karpenter.enabled }}
+  transform/cw_k8s_ci_v0_set_scope_karpenter:
+    error_mode: ignore
+    metric_statements:
+      - context: scope
+        statements:
+          - set(scope.name, "github.com/aws/karpenter")
+          - set(scope.schema_url, "")
+          - set(attributes["cloudwatch.source"], "cloudwatch-agent")
+          - set(attributes["cloudwatch.solution"], "k8s-otel-container-insights")
+          - set(attributes["cloudwatch.pipeline"], "karpenter")
 {{- end }}
 
   transform/cw_k8s_ci_v0_set_cluster_name:
@@ -398,6 +433,23 @@ service:
         - transform/cw_k8s_ci_v0_set_workload
         - resourcedetection/cw_k8s_ci_v0
         - nodemetadataenricher/cw_k8s_ci_v0
+        - transform/cw_k8s_ci_v0_clear_schema_url
+        - transform/cw_k8s_ci_v0_set_cloud_resource_id
+        - awsattributelimit/cw_k8s_ci_v0
+        - batch/cw_k8s_ci_v0_cwotel
+      exporters:
+        - otlphttp/cw_k8s_ci_v0_cwotel
+{{- end }}
+{{- if .Values.otelContainerInsights.integrations.karpenter.enabled }}
+    metrics/cw_k8s_ci_v0_karpenter:
+      receivers: [prometheus/cw_k8s_ci_v0_karpenter]
+      processors:
+        - filter/cw_k8s_ci_v0_scrape_metadata
+        - transform/cw_k8s_ci_v0_set_unit
+        - metricstarttime/cw_k8s_ci_v0
+        - transform/cw_k8s_ci_v0_set_scope_karpenter
+        - transform/cw_k8s_ci_v0_set_cluster_name
+        - resourcedetection/cw_k8s_ci_v0
         - transform/cw_k8s_ci_v0_clear_schema_url
         - transform/cw_k8s_ci_v0_set_cloud_resource_id
         - awsattributelimit/cw_k8s_ci_v0

--- a/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-cluster-scraper-config.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-cluster-scraper-config.tpl
@@ -55,7 +55,7 @@ receivers:
         - job_name: karpenter
           scrape_interval: {{ .Values.otelContainerInsights.metricResolution }}
           scrape_timeout: {{ include "otel-container-insights.scrapeTimeout" . }}
-          metrics_path: {{ .Values.otelContainerInsights.integrations.karpenter.metricsPath }}
+          metrics_path: /metrics
           kubernetes_sd_configs:
             - role: pod
               namespaces:
@@ -68,6 +68,12 @@ receivers:
             - source_labels: [__meta_kubernetes_pod_container_port_name]
               regex: http-metrics
               action: keep
+            - source_labels: [__meta_kubernetes_pod_name]
+              target_label: pod
+            - source_labels: [__meta_kubernetes_namespace]
+              target_label: namespace
+            - source_labels: [__meta_kubernetes_pod_node_name]
+              target_label: node
 {{- end }}
 
 processors:
@@ -167,6 +173,44 @@ processors:
           - set(attributes["cloudwatch.source"], "cloudwatch-agent")
           - set(attributes["cloudwatch.solution"], "k8s-otel-container-insights")
           - set(attributes["cloudwatch.pipeline"], "karpenter")
+
+  # Promote scraped pod/namespace/node labels to OTel K8s resource attributes.
+  # This allows the shared k8sattributes processor to enrich with deployment/workload info.
+  groupbyattrs/cw_k8s_ci_v0_karpenter:
+    keys:
+      - pod
+      - namespace
+      - node
+
+  transform/cw_k8s_ci_v0_karpenter_promote:
+    error_mode: ignore
+    metric_statements:
+      - context: resource
+        statements:
+          - set(attributes["k8s.pod.name"], attributes["pod"]) where attributes["pod"] != nil
+          - set(attributes["k8s.namespace.name"], attributes["namespace"]) where attributes["namespace"] != nil
+          - set(attributes["k8s.node.name"], attributes["node"]) where attributes["node"] != nil
+      - context: datapoint
+        statements:
+          - set(attributes["pod"], resource.attributes["pod"]) where resource.attributes["pod"] != nil
+          - set(attributes["namespace"], resource.attributes["namespace"]) where resource.attributes["namespace"] != nil
+          - set(attributes["node"], resource.attributes["node"]) where resource.attributes["node"] != nil
+
+  # Karpenter-specific resource detection: only cloud-level attributes (region, account).
+  # No host/AZ attributes — those would incorrectly reflect the scraper's node, not Karpenter's.
+  resourcedetection/cw_k8s_ci_v0_karpenter:
+    detectors: [eks, ec2]
+    ec2:
+      resource_attributes:
+        host.id: { enabled: false }
+        host.type: { enabled: false }
+        host.name: { enabled: false }
+        host.image.id: { enabled: false }
+        cloud.provider: { enabled: true }
+        cloud.platform: { enabled: true }
+        cloud.region: { enabled: true }
+        cloud.availability_zone: { enabled: false }
+        cloud.account.id: { enabled: true }
 {{- end }}
 
   transform/cw_k8s_ci_v0_set_cluster_name:
@@ -449,7 +493,11 @@ service:
         - metricstarttime/cw_k8s_ci_v0
         - transform/cw_k8s_ci_v0_set_scope_karpenter
         - transform/cw_k8s_ci_v0_set_cluster_name
-        - resourcedetection/cw_k8s_ci_v0
+        - groupbyattrs/cw_k8s_ci_v0_karpenter
+        - transform/cw_k8s_ci_v0_karpenter_promote
+        - k8sattributes/cw_k8s_ci_v0_pod
+        - transform/cw_k8s_ci_v0_set_workload
+        - resourcedetection/cw_k8s_ci_v0_karpenter
         - transform/cw_k8s_ci_v0_clear_schema_url
         - transform/cw_k8s_ci_v0_set_cloud_resource_id
         - awsattributelimit/cw_k8s_ci_v0

--- a/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-cluster-scraper-config.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-cluster-scraper-config.tpl
@@ -300,6 +300,22 @@ processors:
           - set(attributes["owner_name"], resource.attributes["owner_name"]) where resource.attributes["owner_name"] != nil
           - set(attributes["owner_kind"], resource.attributes["owner_kind"]) where resource.attributes["owner_kind"] != nil
 
+  k8sattributes/cw_k8s_ci_v0_node:
+    auth_type: serviceAccount
+    passthrough: false
+    extract:
+      metadata:
+        - k8s.node.name
+      labels:
+        - tag_name: "k8s.node.label.$$$1"
+          key_regex: "(.*)"
+          from: node
+    pod_association:
+      - sources:
+          - from: resource_attribute
+            name: k8s.node.name
+{{- end }}
+
   k8sattributes/cw_k8s_ci_v0_pod:
     auth_type: serviceAccount
     passthrough: false
@@ -342,22 +358,6 @@ processors:
           - set(resource.attributes["k8s.workload.type"], "CronJob") where resource.attributes["k8s.workload.type"] == nil and resource.attributes["k8s.cronjob.name"] != nil
           - set(resource.attributes["k8s.workload.name"], resource.attributes["k8s.replicaset.name"]) where resource.attributes["k8s.workload.name"] == nil and resource.attributes["k8s.replicaset.name"] != nil
           - set(resource.attributes["k8s.workload.type"], "ReplicaSet") where resource.attributes["k8s.workload.type"] == nil and resource.attributes["k8s.replicaset.name"] != nil
-
-  k8sattributes/cw_k8s_ci_v0_node:
-    auth_type: serviceAccount
-    passthrough: false
-    extract:
-      metadata:
-        - k8s.node.name
-      labels:
-        - tag_name: "k8s.node.label.$$$1"
-          key_regex: "(.*)"
-          from: node
-    pod_association:
-      - sources:
-          - from: resource_attribute
-            name: k8s.node.name
-{{- end }}
 
   transform/cw_k8s_ci_v0_set_component:
     error_mode: ignore

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -1173,3 +1173,18 @@ otelContainerInsights:
   cloudwatchMetricsEndpoint: ""
   # Override the CloudWatch Logs OTLP endpoint. If empty, defaults to logs.<region>.amazonaws.com.
   cloudwatchLogsEndpoint: ""
+  ## ── Solutions ──────────────────────────────────────────────────────────
+  ## Optional Prometheus metric scraping for well-known cluster components.
+  ## Each solution is gated by its own enabled flag so customers only scrape
+  ## what they actually run. Solutions only take effect when
+  ## otelContainerInsights.enabled is true.
+  solutions:
+    ## Global toggle: set to false to disable ALL solutions at once.
+    ## Individual solutions won't activate even if their own enabled flag is true.
+    enabled: true
+    ## Karpenter — cluster autoscaler for Kubernetes.
+    ## Scrapes the Prometheus metrics endpoint exposed by the Karpenter controller.
+    karpenter:
+      enabled: true
+      ## Namespace where Karpenter is deployed.
+      namespace: "kube-system"


### PR DESCRIPTION
Supersedes #322  (retargeted to release-6.3.0)
This PR adds a Karpenter metrics integration to the OTEL Container Insights pipeline. 
When enabled, the cluster-scraper agent automatically discovers and scrapes Karpenter's 
Prometheus metrics endpoint, enriches them with Kubernetes semantic conventions, and 
exports to CloudWatch via OTLP.

*Description of changes:*
**values.yaml**
- Added `otelContainerInsights.solutions.karpenter` configuration section with 
  `enabled`, `namespace` parameters

**_otel-container-insights-cluster-scraper-config.tpl**
- Added Prometheus receiver using Kubernetes pod service discovery
- Added scope processor for pipeline attribution
- Added groupbyattrs and transform processors for K8s semantic convention enrichment
- Added dedicated resourcedetection instance (cloud-level attributes only, no host/AZ)
- Added pipeline definition wiring receiver through processors to exporter

## Testing

- helm template renders correctly for all flag combinations
- All existing test cases pass (flag_matrix.sh, minikube scenarios)
- Deployed and verified on EKS cluster with Karpenter running
- Metrics confirmed visible in CloudWatch via PromQL
- Integration test PR: https://github.com/aws/amazon-cloudwatch-agent-test/pull/715

CI integration tests passing for Karpenter under eks_daemon:otel_standard_test: https://github.com/aws/amazon-cloudwatch-agent/actions/runs/28984147604/job/86009444350
<img width="1200" height="798" alt="Screenshot 2026-07-09 at 10 58 37" src="https://github.com/user-attachments/assets/ee6a5e5e-55fe-4b8e-a076-9d96a888e929" />
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

