### PR TITLE
feat(observability): grant Target Allocator CRD watch RBAC

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/target-allocator-clusterrole.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/target-allocator-clusterrole.yaml
@@ -26,6 +26,12 @@ rules:
   - apiGroups: [ "monitoring.coreos.com"]
     resources: ["podmonitors", "servicemonitors"]
     verbs: ["get", "list", "watch"]
+  # The Target Allocator watches the ServiceMonitor/PodMonitor CustomResourceDefinitions
+  # so it can start/stop each informer as the CRD appears or disappears, letting it
+  # run healthily regardless of whether the CRDs are installed (read-only, cluster-scoped).
+  - apiGroups: [ "apiextensions.k8s.io" ]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch"]
   {{- end }}
 {{- end }}
 ---


### PR DESCRIPTION
 ## Summary
  Grant the Target Allocator (TA) `get;list;watch` on `customresourcedefinitions`
  (`apiextensions.k8s.io`), scoped under the existing prometheus-CR RBAC gate

  > **Companion to operator PR <https://github.com/aws/amazon-cloudwatch-agent-operator/pull/394>** ("target-allocator: tolerate missing
  > ServiceMonitor/PodMonitor CRDs"). That change makes the TA watch the SM/PM
  > CustomResourceDefinitions so it can start/stop each monitor informer as the CRD
  > appears or disappears. This PR supplies the RBAC that watch requires.
  
  ## Why
  The operator-side change adds an informer over `CustomResourceDefinition` objects.
  Without a grant on `customresourcedefinitions`, that informer is denied at runtime:
  
  Failed to watch *v1.CustomResourceDefinition: customresourcedefinitions.apiextensions.k8s.io is forbidden:
  User "system:serviceaccount:amazon-cloudwatch:cloudwatch-agent-target-allocator" cannot list resource "customresourcedefinitions"
  
  The grant is read-only and cluster-scoped (CRDs are cluster-scoped), the minimum
  required for the watch.
  
  ## Scope / gating
  Added inside the existing `prometheusCR.enabled` gate, right beside the SM/PM
  (`monitoring.coreos.com`) rule — so it renders only when the prometheus-CR scraping
  path is enabled, and is inert otherwise. No dependency on the CRD-bundling or flag
  work; this slots into the RBAC gate already present on `main`.
  
  ## Testing
  `helm template` on the TA ClusterRole:
  - **prometheusCR enabled** → clusterrole includes both the `monitoring.coreos.com`
    (podmonitors/servicemonitors) rule **and** the new `apiextensions.k8s.io`
    (customresourcedefinitions) rule.
  - **prometheusCR disabled** (TA still enabled, control) → clusterrole renders with
    **neither** rule (`customresourcedefinitions: 0`, `podmonitors: 0`) — correctly gated.
  
