### PR TITLE
feat(observability): pass K8S_MODE to the operator for SDK Environment prefix

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -41,6 +41,13 @@ spec:
         command:
         - /manager
         name: manager
+        env:
+        # K8S_MODE drives the eks: vs k8s: Environment prefix the operator injects into
+        # instrumented pods (k8s.cluster.name [+ cloud.platform=aws_eks on EKS]), mirroring
+        # the CloudWatch agent's KubernetesMode so AppSignals and ServiceEvents/Dynamic
+        # Instrumentation resolve a consistent Environment.
+        - name: K8S_MODE
+          value: {{ .Values.k8sMode | quote }}
         ports:
         - containerPort: {{ .Values.manager.ports.containerPort }}
           name: webhook-server


### PR DESCRIPTION
K8S_MODE (from .Values.k8sMode: EKS | ROSA | K8S) drives the eks: vs k8s: prefix the operator injects into instrumented pods (k8s.cluster.name [+ cloud.platform=aws_eks on EKS]), mirroring the CloudWatch agent's KubernetesMode so Application Signals and ServiceEvents / Dynamic Instrumentation resolve a consistent aws.local.environment.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

