### PR TITLE
[amazon-cloudwatch-observability] feat: add ServiceMonitor/PodMonitor v2 OTLP scraping path

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
@@ -151,6 +151,20 @@ Logic:
 {{- end -}}
 
 {{/*
+Returns "true" when otelContainerInsights-driven ServiceMonitor/PodMonitor scraping
+applies to the given agent. True when otelContainerInsights is enabled, the agent is
+the configured targetAgent, and at least one of serviceMonitor/podMonitor is enabled.
+Accepts a dict with "agentName" (string) and "context" (root context $).
+*/}}
+{{- define "cloudwatch-agent.otelCIScrapeEnabled" -}}
+{{- $ctx := .context -}}
+{{- $agentName := .agentName -}}
+{{- if and $ctx.Values.otelContainerInsights.enabled (eq $agentName $ctx.Values.otelContainerInsights.targetAgent) (or $ctx.Values.otelContainerInsights.serviceMonitor.enabled $ctx.Values.otelContainerInsights.podMonitor.enabled) -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
 Helper function to modify cloudwatch-agent config
 */}}
 {{- define "cloudwatch-agent.config-modifier" -}}

--- a/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-cluster-scraper-config.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-cluster-scraper-config.tpl
@@ -231,7 +231,8 @@ processors:
         - k8s.job.name
         - k8s.cronjob.name
       labels:
-        # $$$1 is Helm escaping: $$$ → $$ (Helm) → $ (OTel env resolver) → literal $1 backreference
+        # $$$1 -> literal $1 backreference (group 1 = label key). The agent's OTel confmap
+        # resolves it twice (expandconverter + resolver), each collapsing $$->$; Helm leaves it as-is.
         - tag_name: "k8s.pod.label.$$$1"
           key_regex: "(.*)"
           from: pod

--- a/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-config.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-config.tpl
@@ -43,6 +43,23 @@ receivers:
             - targets:
                 - ${env:HOST_IP}:10250
 
+{{- if or .Values.otelContainerInsights.serviceMonitor.enabled .Values.otelContainerInsights.podMonitor.enabled }}
+  # ServiceMonitor/PodMonitor scraping via the Target Allocator (prometheusCR discovery).
+  # The Target Allocator deployed for the targetAgent serves the scrape jobs derived from
+  # ServiceMonitor/PodMonitor CRs; this receiver pulls this collector's assigned shard and
+  # routes the series into the v2 OTLP pipeline (-> CloudWatch/Zeus). Requires the Target
+  # Allocator + prometheusCR to be enabled for the targetAgent and the POD_NAME env (set below).
+  prometheus/cw_k8s_ci_v0_prometheuscr:
+    target_allocator:
+      endpoint: https://{{ .Values.otelContainerInsights.targetAgent }}-target-allocator-service:80
+      interval: {{ .Values.otelContainerInsights.metricResolution }}
+      collector_id: ${env:POD_NAME}
+      tls:
+        ca_file: /etc/amazon-cloudwatch-observability-agent-cert/tls-ca.crt
+        cert_file: /etc/amazon-cloudwatch-observability-agent-ta-client-cert/client.crt
+        key_file: /etc/amazon-cloudwatch-observability-agent-ta-client-cert/client.key
+{{- end }}
+
   {{- if .Values.dcgmExporter.enabled }}
   prometheus/cw_k8s_ci_v0_dcgm:
     config:
@@ -328,6 +345,16 @@ processors:
           - set(attributes["cloudwatch.source"], "cloudwatch-agent")
           - set(attributes["cloudwatch.solution"], "k8s-otel-container-insights")
           - set(attributes["cloudwatch.pipeline"], "efa")
+
+  transform/cw_k8s_ci_v0_set_scope_prometheuscr:
+    error_mode: ignore
+    metric_statements:
+      - context: scope
+        statements:
+          - set(scope.schema_url, "")
+          - set(attributes["cloudwatch.source"], "cloudwatch-agent")
+          - set(attributes["cloudwatch.solution"], "k8s-otel-container-insights")
+          - set(attributes["cloudwatch.pipeline"], "prometheus-cr")
 
   transform/cw_k8s_ci_v0_set_scope_ebs_csi:
     error_mode: ignore
@@ -828,6 +855,23 @@ service:
         - batch/cw_k8s_ci_v0_metrics_dest
       exporters:
         - otlphttp/cw_k8s_ci_v0_metrics_dest
+
+{{- if or .Values.otelContainerInsights.serviceMonitor.enabled .Values.otelContainerInsights.podMonitor.enabled }}
+    metrics/cw_k8s_ci_v0_prometheuscr:
+      receivers: [prometheus/cw_k8s_ci_v0_prometheuscr]
+      # Phase 1: minimal chain to get ServiceMonitor/PodMonitor series flowing to v2.
+      # Richer OTel label/metadata enrichment (k8sattributes pod/node, workload, etc.)
+      # is intentionally deferred to the Phase 3 enrichment work.
+      processors:
+        - filter/cw_k8s_ci_v0_scrape_metadata
+        - metricstarttime/cw_k8s_ci_v0
+        - transform/cw_k8s_ci_v0_set_cluster_name
+        - transform/cw_k8s_ci_v0_set_scope_prometheuscr
+        - resourcedetection/cw_k8s_ci_v0
+        - batch/cw_k8s_ci_v0_metrics_dest
+      exporters:
+        - otlphttp/cw_k8s_ci_v0_metrics_dest
+{{- end }}
 
     {{- if .Values.dcgmExporter.enabled }}
     metrics/cw_k8s_ci_v0_dcgm:

--- a/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-config.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-config.tpl
@@ -454,6 +454,8 @@ processors:
         - k8s.job.name
         - k8s.cronjob.name
       labels:
+        # $$$1 -> literal $1 backreference (group 1 = label key). The agent's OTel confmap
+        # resolves it twice (expandconverter + resolver), each collapsing $$->$; Helm leaves it as-is.
         - tag_name: "k8s.pod.label.$$$1"
           key_regex: "(.*)"
           from: pod

--- a/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-config.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-config.tpl
@@ -346,6 +346,7 @@ processors:
           - set(attributes["cloudwatch.solution"], "k8s-otel-container-insights")
           - set(attributes["cloudwatch.pipeline"], "efa")
 
+{{- if or .Values.otelContainerInsights.serviceMonitor.enabled .Values.otelContainerInsights.podMonitor.enabled }}
   transform/cw_k8s_ci_v0_set_scope_prometheuscr:
     error_mode: ignore
     metric_statements:
@@ -355,6 +356,7 @@ processors:
           - set(attributes["cloudwatch.source"], "cloudwatch-agent")
           - set(attributes["cloudwatch.solution"], "k8s-otel-container-insights")
           - set(attributes["cloudwatch.pipeline"], "prometheus-cr")
+{{- end }}
 
   transform/cw_k8s_ci_v0_set_scope_ebs_csi:
     error_mode: ignore

--- a/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-config.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-config.tpl
@@ -863,15 +863,20 @@ service:
 {{- if or .Values.otelContainerInsights.serviceMonitor.enabled .Values.otelContainerInsights.podMonitor.enabled }}
     metrics/cw_k8s_ci_v0_prometheuscr:
       receivers: [prometheus/cw_k8s_ci_v0_prometheuscr]
-      # Phase 1: minimal chain to get ServiceMonitor/PodMonitor series flowing to v2.
-      # Richer OTel label/metadata enrichment (k8sattributes pod/node, workload, etc.)
-      # is intentionally deferred to the Phase 3 enrichment work.
+      # Phase 1 chain to get ServiceMonitor/PodMonitor series flowing to v2, plus the
+      # shared normalization/cap every other CI metrics pipeline applies before batch
+      # (cloud resource id, schema-url clear, attribute limit) so SM/PM metrics are
+      # normalized and bounded the same way. Richer OTel enrichment (k8sattributes
+      # pod/node, workload, etc.) is intentionally deferred to the Phase 3 enrichment work.
       processors:
         - filter/cw_k8s_ci_v0_scrape_metadata
         - metricstarttime/cw_k8s_ci_v0
         - transform/cw_k8s_ci_v0_set_cluster_name
         - transform/cw_k8s_ci_v0_set_scope_prometheuscr
         - resourcedetection/cw_k8s_ci_v0
+        - transform/cw_k8s_ci_v0_set_cloud_resource_id
+        - transform/cw_k8s_ci_v0_clear_schema_url
+        - awsattributelimit/cw_k8s_ci_v0
         - batch/cw_k8s_ci_v0_metrics_dest
       exporters:
         - otlphttp/cw_k8s_ci_v0_metrics_dest

--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
@@ -110,21 +110,46 @@ spec:
   {{- else if ne (trimAll " \n\t" $generatedOtelConfig) "{}" }}
   otelConfig: {{ include "cloudwatch-agent.modify-otel-config" (merge (dict "OtelConfig" $generatedOtelConfig) $) }}
   {{- end }}
+  {{- $otelCIScrape := eq (include "cloudwatch-agent.otelCIScrapeEnabled" (dict "agentName" $agent.name "context" $)) "true" }}
+  {{- $taEnabled := or $agent.prometheus.targetAllocator.enabled $otelCIScrape }}
   {{- if $agent.prometheus.config }}
   prometheus:
     {{- with $agent.prometheus.config }}
     config:
       {{- toYaml . | nindent 6 }}
     {{- end }}
+  {{- else if $taEnabled }}
+  # The operator builds the Target Allocator config from spec.prometheus and requires
+  # a prometheus.config containing a scrape_configs key (see operator
+  # targetallocator/adapters GetPromConfig). With prometheusCR (ServiceMonitor/
+  # PodMonitor) discovery the static scrape list is empty -- the Target Allocator
+  # discovers targets from ServiceMonitor/PodMonitor CRs.
+  prometheus:
+    config:
+      scrape_configs: []
   {{- end }}
-  {{- if $agent.prometheus.targetAllocator.enabled }}
+  {{- if $taEnabled }}
   targetAllocator:
-    enabled: {{ $agent.prometheus.targetAllocator.enabled | default false }}
+    enabled: true
     image: {{ template "target-allocator.image" (merge $agent.prometheus.targetAllocator.image (dict "region" $.Values.region)) }}
     allocationStrategy: "consistent-hashing"
-    {{- if $agent.prometheus.targetAllocator.prometheusCR.enabled }}
+    {{- if or $agent.prometheus.targetAllocator.prometheusCR.enabled $otelCIScrape }}
     prometheusCR:
-      enabled: {{ $agent.prometheus.targetAllocator.prometheusCR.enabled | default false }}
+      enabled: true
+      {{- if $otelCIScrape }}
+      scrapeInterval: {{ $.Values.otelContainerInsights.metricResolution | quote }}
+      {{- if not $.Values.otelContainerInsights.serviceMonitor.enabled }}
+      # serviceMonitor.enabled=false: select a label no real ServiceMonitor carries,
+      # so the Target Allocator discovers no ServiceMonitors.
+      serviceMonitorSelector:
+        amazon-cloudwatch-observability.aws/otel-ci-scrape: disabled
+      {{- end }}
+      {{- if not $.Values.otelContainerInsights.podMonitor.enabled }}
+      # podMonitor.enabled=false: select a label no real PodMonitor carries.
+      podMonitorSelector:
+        amazon-cloudwatch-observability.aws/otel-ci-scrape: disabled
+      {{- end }}
+      {{- end }}
     {{- end }}
   {{- end }}
   {{- with $agent.resources }}
@@ -281,6 +306,12 @@ spec:
   {{- if $.Values.otelContainerInsights.enabled }}
   - name: OTEL_CI_VERSION
     value: "1.0.0"
+  # POD_NAME is used as the Target Allocator collector_id by the prometheusCR
+  # receiver (otel-container-insights.config) so each agent pulls its own shard.
+  - name: POD_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.name
   {{- end }}
   {{- with $agent.env }}
   {{- . | toYaml | nindent 2 }}

--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -37,7 +37,7 @@ spec:
         - "--auto-instrumentation-dotnet-image={{ template "auto-instrumentation-dotnet.image" . }}"
         - "--auto-instrumentation-nodejs-image={{ template "auto-instrumentation-nodejs.image" . }}"
         - "--target-allocator-image={{ template "target-allocator.image" (merge .Values.agent.prometheus.targetAllocator.image (dict "region" $.Values.region)) }}"
-        - "--feature-gates=operator.autoinstrumentation.multi-instrumentation,operator.autoinstrumentation.multi-instrumentation.skip-container-validation"
+        - "--feature-gates=operator.autoinstrumentation.multiinstrumentation,operator.autoinstrumentation.multiinstrumentation.skipcontainervalidation"
         command:
         - /manager
         name: manager

--- a/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/operator-deployment.yaml
@@ -37,7 +37,7 @@ spec:
         - "--auto-instrumentation-dotnet-image={{ template "auto-instrumentation-dotnet.image" . }}"
         - "--auto-instrumentation-nodejs-image={{ template "auto-instrumentation-nodejs.image" . }}"
         - "--target-allocator-image={{ template "target-allocator.image" (merge .Values.agent.prometheus.targetAllocator.image (dict "region" $.Values.region)) }}"
-        - "--feature-gates=operator.autoinstrumentation.multiinstrumentation,operator.autoinstrumentation.multiinstrumentation.skipcontainervalidation"
+        - "--feature-gates=operator.autoinstrumentation.multi-instrumentation,operator.autoinstrumentation.multi-instrumentation.skip-container-validation"
         command:
         - /manager
         name: manager

--- a/charts/amazon-cloudwatch-observability/templates/target-allocator-clusterrole.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/target-allocator-clusterrole.yaml
@@ -1,7 +1,22 @@
 {{- if .Values.agent.enabled }}
+{{- /*
+  All Target Allocators (targetAgent and clusterScraperAgent) default to the same
+  ServiceAccount (target-allocator-service-acct; see operator serviceaccount.go), so a single
+  ClusterRole covers every TA. Pre-scan the agents to decide whether any TA (and any
+  prometheusCR discovery) is enabled, then render exactly once to avoid duplicate-name objects.
+*/}}
+{{- $needsTA := false }}
+{{- $needsCR := false }}
 {{- range $i, $customAgent := .Values.agents }}
 {{- $otelCIScrape := eq (include "cloudwatch-agent.otelCIScrapeEnabled" (dict "agentName" $customAgent.name "context" $)) "true" }}
 {{- if or (and (hasKey ($customAgent.prometheus) "targetAllocator") (hasKey ($customAgent.prometheus.targetAllocator) "enabled") $customAgent.prometheus.targetAllocator.enabled) $otelCIScrape }}
+{{- $needsTA = true }}
+{{- end }}
+{{- if or (and (hasKey ($customAgent.prometheus) "targetAllocator") (hasKey ($customAgent.prometheus.targetAllocator) "prometheusCR") $customAgent.prometheus.targetAllocator.prometheusCR.enabled) $otelCIScrape }}
+{{- $needsCR = true }}
+{{- end }}
+{{- end }}
+{{- if $needsTA }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -23,7 +38,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - nonResourceURLs: ["/metrics"]
     verbs: ["get"]
-  {{- if or (and (hasKey ($customAgent.prometheus) "targetAllocator") (hasKey ($customAgent.prometheus.targetAllocator) "prometheusCR") $customAgent.prometheus.targetAllocator.prometheusCR.enabled) $otelCIScrape }}
+  {{- if $needsCR }}
   - apiGroups: [ "monitoring.coreos.com"]
     resources: ["podmonitors", "servicemonitors"]
     verbs: ["get", "list", "watch"]
@@ -32,7 +47,5 @@ rules:
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "watch"]
   {{- end }}
-{{- end }}
----
 {{- end }}
 {{- end }}

--- a/charts/amazon-cloudwatch-observability/templates/target-allocator-clusterrole.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/target-allocator-clusterrole.yaml
@@ -27,6 +27,10 @@ rules:
   - apiGroups: [ "monitoring.coreos.com"]
     resources: ["podmonitors", "servicemonitors"]
     verbs: ["get", "list", "watch"]
+  # TA watches the SM/PM CRDs to start/stop informers as they appear or disappear (read-only).
+  - apiGroups: [ "apiextensions.k8s.io" ]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch"]
   {{- end }}
 {{- end }}
 ---

--- a/charts/amazon-cloudwatch-observability/templates/target-allocator-clusterrole.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/target-allocator-clusterrole.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.agent.enabled }}
 {{- range $i, $customAgent := .Values.agents }}
-{{- if and (and (hasKey ($customAgent.prometheus) "targetAllocator") (hasKey ($customAgent.prometheus.targetAllocator) "enabled")) $customAgent.prometheus.targetAllocator.enabled }}
+{{- $otelCIScrape := eq (include "cloudwatch-agent.otelCIScrapeEnabled" (dict "agentName" $customAgent.name "context" $)) "true" }}
+{{- if or (and (hasKey ($customAgent.prometheus) "targetAllocator") (hasKey ($customAgent.prometheus.targetAllocator) "enabled") $customAgent.prometheus.targetAllocator.enabled) $otelCIScrape }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -22,7 +23,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - nonResourceURLs: ["/metrics"]
     verbs: ["get"]
-  {{- if and (hasKey ($customAgent.prometheus.targetAllocator) "prometheusCR") $customAgent.prometheus.targetAllocator.prometheusCR.enabled }}
+  {{- if or (and (hasKey ($customAgent.prometheus) "targetAllocator") (hasKey ($customAgent.prometheus.targetAllocator) "prometheusCR") $customAgent.prometheus.targetAllocator.prometheusCR.enabled) $otelCIScrape }}
   - apiGroups: [ "monitoring.coreos.com"]
     resources: ["podmonitors", "servicemonitors"]
     verbs: ["get", "list", "watch"]

--- a/charts/amazon-cloudwatch-observability/templates/target-allocator-clusterrole.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/target-allocator-clusterrole.yaml
@@ -8,6 +8,11 @@
 {{- $needsTA := false }}
 {{- $needsCR := false }}
 {{- range $i, $customAgent := .Values.agents }}
+{{- /* Merge the singular .Values.agent block (where prometheus.targetAllocator.* lives)
+       into each agents entry, mirroring the CR template, so enabling discovery via the
+       singular agent (agent.prometheus.targetAllocator.prometheusCR.enabled) also grants
+       the TA RBAC below -- not just enabling it on an agents entry. */}}
+{{- $customAgent := mergeOverwrite (deepCopy $.Values.agent) $customAgent }}
 {{- $otelCIScrape := eq (include "cloudwatch-agent.otelCIScrapeEnabled" (dict "agentName" $customAgent.name "context" $)) "true" }}
 {{- if or (and (hasKey ($customAgent.prometheus) "targetAllocator") (hasKey ($customAgent.prometheus.targetAllocator) "enabled") $customAgent.prometheus.targetAllocator.enabled) $otelCIScrape }}
 {{- $needsTA = true }}

--- a/charts/amazon-cloudwatch-observability/templates/target-allocator-clusterrolebinding.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/target-allocator-clusterrolebinding.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.agent.enabled }}
 {{- range $i, $customAgent := .Values.agents }}
-{{- if and (and (hasKey ($customAgent.prometheus) "targetAllocator") (hasKey ($customAgent.prometheus.targetAllocator) "enabled")) $customAgent.prometheus.targetAllocator.enabled }}
+{{- $otelCIScrape := eq (include "cloudwatch-agent.otelCIScrapeEnabled" (dict "agentName" $customAgent.name "context" $)) "true" }}
+{{- if or (and (hasKey ($customAgent.prometheus) "targetAllocator") (hasKey ($customAgent.prometheus.targetAllocator) "enabled") $customAgent.prometheus.targetAllocator.enabled) $otelCIScrape }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/amazon-cloudwatch-observability/templates/target-allocator-clusterrolebinding.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/target-allocator-clusterrolebinding.yaml
@@ -1,7 +1,17 @@
 {{- if .Values.agent.enabled }}
+{{- /*
+  Render a single ClusterRoleBinding for the shared Target Allocator ServiceAccount
+  (target-allocator-service-acct), used by every TA (targetAgent and clusterScraperAgent).
+  Pre-scan the agents to decide whether any TA is enabled, then render exactly once.
+*/}}
+{{- $needsTA := false }}
 {{- range $i, $customAgent := .Values.agents }}
 {{- $otelCIScrape := eq (include "cloudwatch-agent.otelCIScrapeEnabled" (dict "agentName" $customAgent.name "context" $)) "true" }}
 {{- if or (and (hasKey ($customAgent.prometheus) "targetAllocator") (hasKey ($customAgent.prometheus.targetAllocator) "enabled") $customAgent.prometheus.targetAllocator.enabled) $otelCIScrape }}
+{{- $needsTA = true }}
+{{- end }}
+{{- end }}
+{{- if $needsTA }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -16,7 +26,5 @@ subjects:
 - kind: ServiceAccount
   name: "target-allocator-service-acct"
   namespace: {{ $.Release.Namespace }}
-{{- end }}
----
 {{- end }}
 {{- end }}

--- a/charts/amazon-cloudwatch-observability/templates/target-allocator-clusterrolebinding.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/target-allocator-clusterrolebinding.yaml
@@ -6,6 +6,9 @@
 */}}
 {{- $needsTA := false }}
 {{- range $i, $customAgent := .Values.agents }}
+{{- /* Merge the singular .Values.agent block into each agents entry (see clusterrole)
+       so the binding renders whenever the singular-agent TA config enables discovery. */}}
+{{- $customAgent := mergeOverwrite (deepCopy $.Values.agent) $customAgent }}
 {{- $otelCIScrape := eq (include "cloudwatch-agent.otelCIScrapeEnabled" (dict "agentName" $customAgent.name "context" $)) "true" }}
 {{- if or (and (hasKey ($customAgent.prometheus) "targetAllocator") (hasKey ($customAgent.prometheus.targetAllocator) "enabled") $customAgent.prometheus.targetAllocator.enabled) $otelCIScrape }}
 {{- $needsTA = true }}

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -1140,6 +1140,17 @@ otelContainerInsights:
   ## Only takes effect when otelContainerInsights.enabled is true.
   logs:
     enabled: true
+  ## Prometheus ServiceMonitor scraping (monitoring.coreos.com/v1) via the Target
+  ## Allocator's prometheusCR discovery. Defaults to true: when
+  ## otelContainerInsights is enabled, ServiceMonitor scraping is on unless
+  ## explicitly disabled here. Only takes effect when otelContainerInsights.enabled is true.
+  serviceMonitor:
+    enabled: true
+  ## Prometheus PodMonitor scraping (monitoring.coreos.com/v1) via the Target
+  ## Allocator's prometheusCR discovery. Defaults to true (see serviceMonitor note).
+  ## Only takes effect when otelContainerInsights.enabled is true.
+  podMonitor:
+    enabled: true
   ## The agent in the agents array that receives node-level OTEL Container Insights config.
   targetAgent: "cloudwatch-agent"
   ## The agent in the agents array that receives cluster-level OTEL Container Insights config (apiserver, kube-state-metrics scraping).


### PR DESCRIPTION
## Summary
Add the ServiceMonitor/PodMonitor **v2 OTLP scraping path** to the chart: a `prometheuscr`
receiver + pipeline driven by the Target Allocator's PrometheusCR discovery, plus the
enablement flags and gating helper. This is the foundation that lets the CloudWatch Agent
scrape community `monitoring.coreos.com` ServiceMonitor/PodMonitor CRs into CloudWatch via
the OTEL Container Insights path.

## What this enables
When `otelContainerInsights.enabled` is set, the chart wires the Target Allocator +
`prometheuscr` receiver so SM/PM CRs are discovered and scraped (default consistent-hashing
allocation). ServiceMonitor and PodMonitor discovery can each be toggled via
`otelContainerInsights.serviceMonitor.enabled` / `podMonitor.enabled` (default on).

## Scope
- `prometheuscr` receiver + metrics pipeline in the OTEL Container Insights config
- `otelCIScrape` gating helper
- `otelContainerInsights.serviceMonitor/podMonitor.enabled` values (only take effect when
  `otelContainerInsights.enabled`)
- Read-only clusterrole additions for the discovery path

This is the **base of a small stack**; per-node allocation + node-enrichment transforms land
in a follow-up that builds on this path.

## Testing
`helm template`:
- `otelContainerInsights.enabled=true` → the `prometheuscr` receiver/pipeline renders.
- default (disabled) → the path does not render (0 references).

`helm lint` clean (pre-existing `fluent-bit-windows` region warning is unrelated).
