### PR TITLE
Add AKS as a supported k8sMode

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
@@ -63,6 +63,8 @@ data:
 {{- $clusterName := .Values.clusterName | required ".Values.clusterName is required." -}}
 {{- $region := .Values.region | required ".Values.region is required." -}}
 {{- $isROSA := eq $.Values.k8sMode "ROSA" -}}
+{{- $isAKS := eq $.Values.k8sMode "AKS" -}}
+{{- if $isAKS }}{{- $_ := $.Values.roleArn | required ".Values.roleArn is required when k8sMode is AKS." -}}{{- end }}
 {{- range .Values.agents }}
 {{- $agent := mergeOverwrite (deepCopy $.Values.agent) . }}
 {{/* Skip cluster-scraper agent when otelContainerInsights is disabled */}}
@@ -185,6 +187,11 @@ spec:
     name: kubelet-ca
     readOnly: true
     {{ end }}
+    {{ if $isAKS }}
+  - mountPath: /var/run/secrets/aws
+    name: aws-iam-token
+    readOnly: true
+    {{ end }}
   volumes:
   - name: kubelet-podresources
     hostPath:
@@ -255,6 +262,15 @@ spec:
     hostPath:
       path: /etc/kubernetes/kubelet-ca.crt
   {{end }}
+  {{ if $isAKS }}
+  - name: aws-iam-token
+    projected:
+      sources:
+      - serviceAccountToken:
+          audience: sts.amazonaws.com
+          expirationSeconds: 3600
+          path: token
+  {{ end }}
   env:
   - name: K8S_NODE_NAME
     valueFrom:
@@ -275,6 +291,14 @@ spec:
   {{ if $isROSA }}
   - name: RUN_IN_ROSA
     value: "True"
+  {{ end }}
+  {{ if $isAKS }}
+  - name: RUN_IN_AKS
+    value: "True"
+  - name: AWS_WEB_IDENTITY_TOKEN_FILE
+    value: /var/run/secrets/aws/token
+  - name: AWS_ROLE_ARN
+    value: {{ $.Values.roleArn | quote }}
   {{ end }}
   - name: K8S_CLUSTER_NAME
     value: {{ $.Values.clusterName | quote }}

--- a/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.containerLogs.enabled }}
 {{- $clusterName := .Values.clusterName | required ".Values.clusterName is required." -}}
 {{- $region := .Values.region | required ".Values.region is required." -}}
+{{- $isAKS := eq .Values.k8sMode "AKS" -}}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -54,6 +55,12 @@ spec:
               fieldPath: metadata.name
         - name: CI_VERSION
           value: "k8s/1.3.17"
+        {{- if $isAKS }}
+        - name: AWS_WEB_IDENTITY_TOKEN_FILE
+          value: /var/run/secrets/aws/token
+        - name: AWS_ROLE_ARN
+          value: {{ .Values.roleArn | quote }}
+        {{- end }}
         {{- with .Values.containerLogs.fluentBit.resources }}
         resources: {{- toYaml . | nindent 10}}
         {{- end }}
@@ -85,6 +92,11 @@ spec:
         - mountPath: /etc/amazon-cloudwatch-observability-agent-server-cert
           name: agentservertls
           readOnly: true
+        {{- if $isAKS }}
+        - mountPath: /var/run/secrets/aws
+          name: aws-iam-token
+          readOnly: true
+        {{- end }}
       terminationGracePeriodSeconds: 10
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
@@ -122,6 +134,15 @@ spec:
           items:
             - key: ca.crt
               path: tls-ca.crt
+      {{- if $isAKS }}
+      - name: aws-iam-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: sts.amazonaws.com
+              expirationSeconds: 3600
+              path: token
+      {{- end }}
       serviceAccountName: {{ template "cloudwatch-agent.serviceAccountName" . }}
       {{- with .Values.containerLogs.fluentBit.affinity }}
       affinity: {{- toYaml . | nindent 8 }}

--- a/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
@@ -2,6 +2,7 @@
 {{- $clusterName := .Values.clusterName | required ".Values.clusterName is required." -}}
 {{- $region := .Values.region | required ".Values.region is required." -}}
 {{- $isAKS := eq .Values.k8sMode "AKS" -}}
+{{- if $isAKS }}{{- $_ := .Values.roleArn | required ".Values.roleArn is required when k8sMode is AKS." -}}{{- end }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -18,7 +18,9 @@ adcEndpointOverrides:
   eusc-de-east-1: amazonaws.eu
 ## Provide the Region (this is a required parameter)
 region:
-k8sMode: EKS # can be EKS | ROSA | K8S
+k8sMode: EKS # can be EKS | ROSA | K8S | AKS
+## IAM role ARN for AKS workload-identity federation (required when k8sMode is AKS)
+roleArn:
 ## Enable dualstack endpoints for IPv6 support (default: false)
 useDualstackEndpoint: false
 ## Provide default tolerations


### PR DESCRIPTION
## Summary
Adds AKS to k8sMode (EKS | ROSA | K8S | AKS). AKS has no EC2 instance role, so the agent and fluent-bit authenticate to AWS via workload-identity federation:

- Project an SA token (aud sts.amazonaws.com) at /var/run/secrets/aws/token via the aws-iam-token volume
- Set AWS_WEB_IDENTITY_TOKEN_FILE + AWS_ROLE_ARN for the SDK's AssumeRoleWithWebIdentity
- Set RUN_IN_AKS=True for agent platform detection
- New roleArn value, required when k8sMode: AKS
- Wired into both the AmazonCloudWatchAgent CR and the fluent-bit DaemonSet, gated behind $isAKS (mirrors $isROSA).

## Testing
- helm lint clean; EKS/ROSA/K8S renders semantically identical to main
- roleArn guard fails the render when AKS mode has no roleArn
- AKS (live, k8s 1.35, OIDC + workload identity): agent + fluent-bit 1/1 Running, zero auth errors; CI metrics and container logs landing in CloudWatch
- EKS (live, test-mc): upgraded with no regression — agent + fluent-bit unaffected (no AKS wiring), all signals (CI metrics, App Signals, X-Ray, logs) still flowing

Requires the paired agent change that skips the oidctoken path on AKS https://github.com/aws/amazon-cloudwatch-agent/pull/2183. Operator prereq: IAM OIDC provider + role trust-scoped to system:serviceaccount:<ns>:cloudwatch-agent / aud=sts.amazonaws.com, passed as roleArn.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

