### PR TITLE
Honor null values on the agent container resources

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
@@ -784,3 +784,20 @@ winning on key collision.
 {{- end -}}
 {{- $merged | toYaml -}}
 {{- end -}}
+
+{{/* Recursively drop nil leaves so a user-supplied `cpu: null` removes the limit instead of emitting literal null. mergeOverwrite keeps nil values from the default, so prune after merge. */}}
+{{- define "cloudwatch-agent.pruneNulls" -}}
+{{- $in := . -}}
+{{- $out := dict -}}
+{{- range $k, $v := $in -}}
+  {{- if kindIs "map" $v -}}
+    {{- $nested := include "cloudwatch-agent.pruneNulls" $v | fromYaml -}}
+    {{- if $nested -}}
+      {{- $_ := set $out $k $nested -}}
+    {{- end -}}
+  {{- else if not (kindIs "invalid" $v) -}}
+    {{- $_ := set $out $k $v -}}
+  {{- end -}}
+{{- end -}}
+{{- $out | toYaml -}}
+{{- end -}}

--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
@@ -127,7 +127,8 @@ spec:
       enabled: {{ $agent.prometheus.targetAllocator.prometheusCR.enabled | default false }}
     {{- end }}
   {{- end }}
-  {{- with $agent.resources }}
+  {{- $prunedResources := include "cloudwatch-agent.pruneNulls" $agent.resources | fromYaml }}
+  {{- with $prunedResources }}
   resources: {{- toYaml . | nindent 4}}
   {{- end }}
   volumeMounts:


### PR DESCRIPTION
#### Issue
`cpu:null` on `agents[].resources.limits` was rendering into the AmazonCloudWatchAgent CR as a literal `cpu: null`, which is invalid under the CRD. The agent resources go through `mergeOverwrite` over the chart defaults, and `mergeOverwrite` keeps nil source values, so the null survived into the merged map.

#### Change
Add a `cloudwatch-agent.pruneNulls` helper that strips nil leaves from the merged resources map before rendering, so `cpu:null` removes the limit (matching how the fluent-bit DS, which never merges over a default, already behaves).

#### Test
```
# BEFORE - CRD-invalid literal null leaks through:
  resources:
    limits:
      cpu: null          # invalid under the CRD (quantity can't be null)
      memory: 512Mi
    requests:
      cpu: 250m
      memory: 128Mi

#AFTER - cpu key dropped, memory kept:
  resources:
    limits:
      memory: 512Mi      # ← cpu limit removed, as intended
    requests:
      cpu: 250m
      memory: 128Mi

# default install (no override)
  resources:
    limits:
      cpu: 500m          # default preserved on the fix branch
      memory: 512Mi
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

