### PR TITLE
Add multi-agent leader election minikube test; tidy CI check names

### DIFF
--- a/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-image-scan.yaml
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-name: Image Scan for Amazon CloudWatch Observability
+name: Image Scan
 
 on:
   schedule:

--- a/.github/workflows/amazon-cloudwatch-observability-integration-test.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-integration-test.yaml
@@ -63,6 +63,7 @@ jobs:
           - feature-targeted-ci-and-appsignals-disabled
           - feature-targeted-otlp-disabled
           - feature-targeted-multi-agent
+          - multi-agent-leader-election
           - feature-targeted-split-features
           - feature-targeted-custom-otel-config
           - feature-targeted-user-config-override

--- a/.github/workflows/amazon-cloudwatch-observability-integration-test.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-integration-test.yaml
@@ -41,8 +41,7 @@ jobs:
     strategy:
       matrix:
         # TODO: add webhooks-disabled
-        # Keep sorted alphabetically. Names are prefixed by functionality,
-        # so alphabetical order groups related scenarios together.
+        # Keep sorted alphabetically.
         scenario:
           - agent-config-merge-isolation
           - appsignals-disabled

--- a/.github/workflows/amazon-cloudwatch-observability-integration-test.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-integration-test.yaml
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-name: Integration Test for Amazon CloudWatch Observability
+name: Integ Test
 on:
   push:
     branches:
@@ -114,7 +114,7 @@ jobs:
           terraform destroy -auto-approve || true
 
   EKS-IntegrationTest:
-    name: EKS-IntegrationTest
+    name: EKS
     needs: [ Minikube-IntegrationTests ]
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -175,7 +175,7 @@ jobs:
             terraform destroy --auto-approve
 
   EKS-IntegrationTest-Win2022:
-    name: EKS-IntegrationTest-Win2022
+    name: EKS Win2022
     needs: [ Minikube-IntegrationTests ]
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -236,7 +236,7 @@ jobs:
             terraform destroy --auto-approve
 
   EKS-IntegrationTest-Win2019:
-    name: EKS-IntegrationTest-Win2019
+    name: EKS Win2019
     needs: [ Minikube-IntegrationTests ]
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/amazon-cloudwatch-observability-integration-test.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-integration-test.yaml
@@ -41,40 +41,42 @@ jobs:
     strategy:
       matrix:
         # TODO: add webhooks-disabled
+        # Keep sorted alphabetically. Names are prefixed by functionality,
+        # so alphabetical order groups related scenarios together.
         scenario:
-          - default
+          - agent-config-merge-isolation
           - appsignals-disabled
           - appsignals-disabled-multi-agents
           - appsignals-enabled-multi-agents
           - appsignals-unsupported
-          - service-events-unsupported
-          - webhooks-partially-enabled
-          - webhooks-configured
-          - deployment-rolling-enabled
-          - deployment-rolling-disabled
-          - certificate-recreate-enabled
           - certificate-recreate-disabled
+          - certificate-recreate-enabled
+          - configmap-permission-scoping
+          - default
+          - deployment-rolling-disabled
+          - deployment-rolling-enabled
           - dualstack-endpoint-enabled
           - dualstack-endpoint-with-custom-endpoint
-          - configmap-permission-scoping
-          - feature-targeted-default
-          - feature-targeted-appsignals-disabled
-          - feature-targeted-ci-disabled
-          - feature-targeted-ci-and-appsignals-disabled
-          - feature-targeted-otlp-disabled
-          - feature-targeted-multi-agent
-          - multi-agent-leader-election
-          - feature-targeted-split-features
-          - feature-targeted-custom-otel-config
-          - feature-targeted-user-config-override
           - feature-targeted-agent-config-override
+          - feature-targeted-appsignals-disabled
+          - feature-targeted-ci-and-appsignals-disabled
+          - feature-targeted-ci-disabled
+          - feature-targeted-custom-otel-config
+          - feature-targeted-default
+          - feature-targeted-multi-agent
+          - feature-targeted-otlp-disabled
+          - feature-targeted-split-features
+          - feature-targeted-user-config-override
+          - multi-agent-leader-election
           - otlp-custom-otel-config
           - otlp-disabled
-          - otlp-logs-disabled
           - otlp-hybrid-metrics-fluentbit
+          - otlp-logs-disabled
           - otlp-logs-dual-publish
           - otlp-logs-otel-only
-          - agent-config-merge-isolation
+          - service-events-unsupported
+          - webhooks-configured
+          - webhooks-partially-enabled
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/multi-agent-leader-election/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/multi-agent-leader-election/main.tf
@@ -7,8 +7,11 @@ module "base" {
   helm_dir         = var.helm_dir
 }
 
-// The leader agent's nodeAffinity requires workload-tier=system. Label the
-// minikube node(s) so the leader deployment can schedule.
+// For the purposes of this test scenario, the leader agent's values pin it
+// to nodes labeled workload-tier=system (an arbitrary label chosen to
+// exercise nodeAffinity propagation — not a requirement of the feature).
+// Label the minikube node(s) accordingly so the leader deployment can
+// schedule.
 resource "null_resource" "label_nodes" {
   depends_on = [module.base.helm_release]
 

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/multi-agent-leader-election/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/multi-agent-leader-election/main.tf
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+module "base" {
+  source           = "../.."
+  helm_values_file = "${path.module}/values.yaml"
+  helm_dir         = var.helm_dir
+}
+
+// The leader agent's nodeAffinity requires workload-tier=system. Label the
+// minikube node(s) so the leader deployment can schedule.
+resource "null_resource" "label_nodes" {
+  depends_on = [module.base.helm_release]
+
+  provisioner "local-exec" {
+    command = "kubectl label nodes --all workload-tier=system --overwrite"
+  }
+}
+
+resource "null_resource" "validator" {
+  depends_on = [null_resource.label_nodes]
+
+  provisioner "local-exec" {
+    command = "go test ${var.test_dir} -v -run=TestMultiAgentLeaderElection"
+  }
+}
+
+variable "test_dir" {
+  type    = string
+  default = "../../../../validations/minikube/scenarios"
+}
+
+variable "helm_dir" {
+  type    = string
+  default = "../../../../../../charts/amazon-cloudwatch-observability"
+}

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/multi-agent-leader-election/values.yaml
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/multi-agent-leader-election/values.yaml
@@ -1,12 +1,15 @@
 # Multi-agent node/leader split for Container Insights.
 #
-# Generalized from a real-world production pattern: a daemonset agent on
-# every node (CI_NODE) plus a single deployment agent (CI_LEADER) pinned to
-# dedicated nodes, with the default CPU limit removed, per-agent resources,
-# scheduling controls, and rollout tuning.
+# Mirrors the documented setup for large Kubernetes clusters (see
+# "Considerations for large Kubernetes clusters" in the CloudWatch
+# Observability EKS add-on install guide): a daemonset agent on every node
+# (CWAGENT_ROLE=NODE) plus a single deployment agent (CWAGENT_ROLE=LEADER),
+# here with the default CPU limit removed, per-agent resources, scheduling
+# controls, and rollout tuning layered on top.
 #
-# The leader affinity uses a generic `workload-tier=system` label which the
-# scenario's terraform applies to the minikube node.
+# The leader nodeAffinity below uses an arbitrary `workload-tier=system`
+# label purely to exercise affinity propagation in this scenario; the
+# scenario's terraform applies that label to the minikube node.
 region: us-west-2
 clusterName: minikube
 
@@ -20,7 +23,7 @@ agents:
   - name: cloudwatch-agent
     env:
       - name: CWAGENT_ROLE
-        value: CI_NODE
+        value: NODE
     resources:
       limits:
         memory: 768Mi
@@ -38,12 +41,12 @@ agents:
     updateStrategy:
       rollingUpdate:
         maxUnavailable: 5%
-  - name: cloudwatch-agent-leader
+  - name: cloudwatch-agent-ci-leader
     mode: deployment
     replicas: 1
     env:
       - name: CWAGENT_ROLE
-        value: CI_LEADER
+        value: LEADER
     resources:
       limits:
         memory: 512Mi

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/multi-agent-leader-election/values.yaml
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/multi-agent-leader-election/values.yaml
@@ -10,14 +10,13 @@
 # The leader nodeAffinity below uses an arbitrary `workload-tier=system`
 # label purely to exercise affinity propagation in this scenario; the
 # scenario's terraform applies that label to the minikube node.
+#
+# NOTE: the `cpu: null` limits inside the agents[] entries intentionally use
+# the pattern fixed by PR #334. Before that fix, the null renders as a
+# CRD-invalid literal and the install fails — this scenario acts as its
+# regression gate and is expected to fail until #334 merges.
 region: us-west-2
 clusterName: minikube
-
-# Remove the default CPU limit for all agents (map-level null coalescing).
-agent:
-  resources:
-    limits:
-      cpu: null
 
 agents:
   - name: cloudwatch-agent
@@ -26,6 +25,7 @@ agents:
         value: NODE
     resources:
       limits:
+        cpu: null
         memory: 768Mi
       requests:
         cpu: 100m
@@ -49,6 +49,7 @@ agents:
         value: LEADER
     resources:
       limits:
+        cpu: null
         memory: 512Mi
       requests:
         cpu: 50m

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/multi-agent-leader-election/values.yaml
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/multi-agent-leader-election/values.yaml
@@ -11,10 +11,9 @@
 # label purely to exercise affinity propagation in this scenario; the
 # scenario's terraform applies that label to the minikube node.
 #
-# NOTE: the `cpu: null` limits inside the agents[] entries intentionally use
-# the pattern fixed by PR #334. Before that fix, the null renders as a
-# CRD-invalid literal and the install fails — this scenario acts as its
-# regression gate and is expected to fail until #334 merges.
+# The `cpu: null` limits inside the agents[] entries remove the default CPU
+# limit; this scenario guards the chart's null handling for agents[]
+# entries end to end.
 region: us-west-2
 clusterName: minikube
 

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/multi-agent-leader-election/values.yaml
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/multi-agent-leader-election/values.yaml
@@ -1,0 +1,69 @@
+# Multi-agent node/leader split for Container Insights.
+#
+# Generalized from a real-world production pattern: a daemonset agent on
+# every node (CI_NODE) plus a single deployment agent (CI_LEADER) pinned to
+# dedicated nodes, with the default CPU limit removed, per-agent resources,
+# scheduling controls, and rollout tuning.
+#
+# The leader affinity uses a generic `workload-tier=system` label which the
+# scenario's terraform applies to the minikube node.
+region: us-west-2
+clusterName: minikube
+
+# Remove the default CPU limit for all agents (map-level null coalescing).
+agent:
+  resources:
+    limits:
+      cpu: null
+
+agents:
+  - name: cloudwatch-agent
+    env:
+      - name: CWAGENT_ROLE
+        value: CI_NODE
+    resources:
+      limits:
+        memory: 768Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+    config:
+      logs:
+        metrics_collected:
+          kubernetes:
+            enhanced_container_insights: true
+    priorityClassName: system-node-critical
+    tolerations:
+      - operator: Exists
+    updateStrategy:
+      rollingUpdate:
+        maxUnavailable: 5%
+  - name: cloudwatch-agent-leader
+    mode: deployment
+    replicas: 1
+    env:
+      - name: CWAGENT_ROLE
+        value: CI_LEADER
+    resources:
+      limits:
+        memory: 512Mi
+      requests:
+        cpu: 50m
+        memory: 128Mi
+    config:
+      logs:
+        metrics_collected:
+          kubernetes:
+            enhanced_container_insights: true
+    priorityClassName: system-node-critical
+    tolerations:
+      - operator: Exists
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: workload-tier
+                  operator: In
+                  values:
+                    - system

--- a/integration-tests/amazon-cloudwatch-observability/validations/minikube/scenarios/multi_agent_leader_election_test.go
+++ b/integration-tests/amazon-cloudwatch-observability/validations/minikube/scenarios/multi_agent_leader_election_test.go
@@ -136,8 +136,8 @@ func assertEnvValue(t *testing.T, spec map[string]interface{}, name, value strin
 }
 
 // assertResources verifies the CPU limit was removed (cpu: null inside the
-// agents[] entry — requires the null-handling fix from PR #334) while the
-// per-agent memory limit and CPU request propagated.
+// agents[] entry) while the per-agent memory limit and CPU request
+// propagated.
 func assertResources(t *testing.T, spec map[string]interface{}, memLimit, cpuRequest string) {
 	resources, _ := spec["resources"].(map[string]interface{})
 	if !assert.NotNil(t, resources, "resources should be present") {

--- a/integration-tests/amazon-cloudwatch-observability/validations/minikube/scenarios/multi_agent_leader_election_test.go
+++ b/integration-tests/amazon-cloudwatch-observability/validations/minikube/scenarios/multi_agent_leader_election_test.go
@@ -1,0 +1,214 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package scenarios
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws-observability/helm-charts/integration-tests/amazon-cloudwatch-observability/util"
+	"github.com/aws-observability/helm-charts/integration-tests/amazon-cloudwatch-observability/validations/minikube"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// TestMultiAgentLeaderElection validates the node/leader Container Insights
+// split generalized from a real-world production pattern: a daemonset agent
+// (CWAGENT_ROLE=CI_NODE) plus a deployment agent (CWAGENT_ROLE=CI_LEADER)
+// with per-agent env, resources (default CPU limit removed via null),
+// scheduling controls, and rollout tuning.
+func TestMultiAgentLeaderElection(t *testing.T) {
+	k8sClient, err := util.NewK8sClient()
+	require.NoError(t, err, "failed to create k8s client")
+
+	ns, err := k8sClient.GetNamespace(minikube.Namespace)
+	assert.NoError(t, err)
+	assert.Equal(t, minikube.Namespace, ns.Name)
+
+	dynamicClient, err := k8sClient.GetDynamicClient()
+	require.NoError(t, err, "failed to get dynamic client")
+
+	gvr := schema.GroupVersionResource{
+		Group:    "cloudwatch.aws.amazon.com",
+		Version:  "v1alpha1",
+		Resource: "amazoncloudwatchagents",
+	}
+
+	agentList, err := dynamicClient.Resource(gvr).Namespace(minikube.Namespace).List(
+		context.Background(), metav1.ListOptions{},
+	)
+	require.NoError(t, err, "failed to list AmazonCloudWatchAgent CRs")
+
+	agentMap := make(map[string]unstructured.Unstructured)
+	for _, agent := range agentList.Items {
+		agentMap[agent.GetName()] = agent
+	}
+
+	assert.Contains(t, agentMap, "cloudwatch-agent", "node agent CR should exist")
+	assert.Contains(t, agentMap, "cloudwatch-agent-leader", "leader agent CR should exist")
+
+	t.Run("NodeAgentSpec", func(t *testing.T) {
+		validateNodeAgentSpec(t, agentMap)
+	})
+
+	t.Run("LeaderAgentSpec", func(t *testing.T) {
+		validateLeaderAgentSpec(t, agentMap)
+	})
+
+	t.Run("LeaderPodScheduled", func(t *testing.T) {
+		validateLeaderPodRunning(t, k8sClient)
+	})
+}
+
+func validateNodeAgentSpec(t *testing.T, agentMap map[string]unstructured.Unstructured) {
+	agent, exists := agentMap["cloudwatch-agent"]
+	if !assert.True(t, exists, "cloudwatch-agent CR should exist") {
+		return
+	}
+	spec, ok := agent.Object["spec"].(map[string]interface{})
+	require.True(t, ok, "spec should be a map")
+
+	mode, _ := spec["mode"].(string)
+	assert.Equal(t, "daemonset", mode, "node agent should be a daemonset")
+
+	assertEnvValue(t, spec, "CWAGENT_ROLE", "CI_NODE")
+	assertResources(t, spec, "768Mi", "100m")
+	assertSchedulingControls(t, spec)
+
+	// updateStrategy rollingUpdate maxUnavailable propagated.
+	updateStrategy, _ := spec["updateStrategy"].(map[string]interface{})
+	if assert.NotNil(t, updateStrategy, "updateStrategy should be present") {
+		rollingUpdate, _ := updateStrategy["rollingUpdate"].(map[string]interface{})
+		if assert.NotNil(t, rollingUpdate, "rollingUpdate should be present") {
+			assert.Equal(t, "5%", rollingUpdate["maxUnavailable"], "maxUnavailable override should propagate")
+		}
+	}
+
+	assertEnhancedContainerInsights(t, spec)
+}
+
+func validateLeaderAgentSpec(t *testing.T, agentMap map[string]unstructured.Unstructured) {
+	agent, exists := agentMap["cloudwatch-agent-leader"]
+	if !assert.True(t, exists, "cloudwatch-agent-leader CR should exist") {
+		return
+	}
+	spec, ok := agent.Object["spec"].(map[string]interface{})
+	require.True(t, ok, "spec should be a map")
+
+	mode, _ := spec["mode"].(string)
+	assert.Equal(t, "deployment", mode, "leader agent should be a deployment")
+
+	replicas, _ := spec["replicas"].(int64)
+	assert.EqualValues(t, 1, replicas, "leader should have 1 replica")
+
+	assertEnvValue(t, spec, "CWAGENT_ROLE", "CI_LEADER")
+	assertResources(t, spec, "512Mi", "50m")
+	assertSchedulingControls(t, spec)
+
+	// Custom nodeAffinity propagated (generic workload-tier label).
+	affinityJSON, err := json.Marshal(spec["affinity"])
+	require.NoError(t, err)
+	assert.Contains(t, string(affinityJSON), "workload-tier",
+		"leader nodeAffinity should require the workload-tier label")
+
+	assertEnhancedContainerInsights(t, spec)
+}
+
+// assertEnvValue verifies spec.env contains the given name/value pair.
+func assertEnvValue(t *testing.T, spec map[string]interface{}, name, value string) {
+	env, _ := spec["env"].([]interface{})
+	for _, e := range env {
+		entry, _ := e.(map[string]interface{})
+		if entry["name"] == name {
+			assert.Equal(t, value, entry["value"], "env var %s should be %s", name, value)
+			return
+		}
+	}
+	assert.Failf(t, "env var not found", "env var %s should be present in spec.env", name)
+}
+
+// assertResources verifies the CPU limit was removed (cpu: null at the
+// top-level agent key) while the per-agent memory limit and CPU request
+// propagated.
+func assertResources(t *testing.T, spec map[string]interface{}, memLimit, cpuRequest string) {
+	resources, _ := spec["resources"].(map[string]interface{})
+	if !assert.NotNil(t, resources, "resources should be present") {
+		return
+	}
+
+	limits, _ := resources["limits"].(map[string]interface{})
+	if assert.NotNil(t, limits, "limits should be present") {
+		_, hasCPU := limits["cpu"]
+		assert.False(t, hasCPU, "cpu limit should be removed (cpu: null in values)")
+		assert.Equal(t, memLimit, limits["memory"], "memory limit override should propagate")
+	}
+
+	requests, _ := resources["requests"].(map[string]interface{})
+	if assert.NotNil(t, requests, "requests should be present") {
+		assert.Equal(t, cpuRequest, requests["cpu"], "cpu request override should propagate")
+	}
+}
+
+// assertSchedulingControls verifies priorityClassName and the blanket
+// toleration propagated into the CR spec.
+func assertSchedulingControls(t *testing.T, spec map[string]interface{}) {
+	assert.Equal(t, "system-node-critical", spec["priorityClassName"],
+		"priorityClassName should propagate")
+
+	tolerations, _ := spec["tolerations"].([]interface{})
+	found := false
+	for _, tol := range tolerations {
+		entry, _ := tol.(map[string]interface{})
+		if entry["operator"] == "Exists" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "blanket Exists toleration should propagate")
+}
+
+// assertEnhancedContainerInsights verifies the per-agent config override
+// merged into the rendered agent config.
+func assertEnhancedContainerInsights(t *testing.T, spec map[string]interface{}) {
+	configStr, _ := spec["config"].(string)
+	if !assert.NotEmpty(t, configStr, "config should be present") {
+		return
+	}
+	assert.Contains(t, configStr, "enhanced_container_insights",
+		"per-agent enhanced_container_insights config should merge into rendered config")
+}
+
+// validateLeaderPodRunning polls until the leader deployment's pod is
+// Running, proving the workload-tier affinity is satisfiable after the
+// scenario labels the node. Operator reconciliation is async, so retry.
+func validateLeaderPodRunning(t *testing.T, k8sClient *util.K8sClient) {
+	deadline := time.Now().Add(3 * time.Minute)
+	var lastState string
+
+	for time.Now().Before(deadline) {
+		pods, err := k8sClient.ListPods(minikube.Namespace)
+		if err == nil {
+			for _, pod := range pods.Items {
+				if strings.HasPrefix(pod.Name, "cloudwatch-agent-leader") {
+					lastState = string(pod.Status.Phase)
+					if pod.Status.Phase == corev1.PodRunning {
+						t.Logf("leader pod %s is Running", pod.Name)
+						return
+					}
+				}
+			}
+		}
+		time.Sleep(10 * time.Second)
+	}
+
+	assert.Failf(t, "leader pod not running",
+		"cloudwatch-agent-leader pod did not reach Running within timeout (last state: %q)", lastState)
+}

--- a/integration-tests/amazon-cloudwatch-observability/validations/minikube/scenarios/multi_agent_leader_election_test.go
+++ b/integration-tests/amazon-cloudwatch-observability/validations/minikube/scenarios/multi_agent_leader_election_test.go
@@ -22,7 +22,7 @@ import (
 
 // TestMultiAgentLeaderElection validates the node/leader Container Insights
 // split generalized from a real-world production pattern: a daemonset agent
-// (CWAGENT_ROLE=CI_NODE) plus a deployment agent (CWAGENT_ROLE=CI_LEADER)
+// (CWAGENT_ROLE=NODE) plus a deployment agent (CWAGENT_ROLE=LEADER)
 // with per-agent env, resources (default CPU limit removed via null),
 // scheduling controls, and rollout tuning.
 func TestMultiAgentLeaderElection(t *testing.T) {
@@ -53,7 +53,7 @@ func TestMultiAgentLeaderElection(t *testing.T) {
 	}
 
 	assert.Contains(t, agentMap, "cloudwatch-agent", "node agent CR should exist")
-	assert.Contains(t, agentMap, "cloudwatch-agent-leader", "leader agent CR should exist")
+	assert.Contains(t, agentMap, "cloudwatch-agent-ci-leader", "leader agent CR should exist")
 
 	t.Run("NodeAgentSpec", func(t *testing.T) {
 		validateNodeAgentSpec(t, agentMap)
@@ -79,7 +79,7 @@ func validateNodeAgentSpec(t *testing.T, agentMap map[string]unstructured.Unstru
 	mode, _ := spec["mode"].(string)
 	assert.Equal(t, "daemonset", mode, "node agent should be a daemonset")
 
-	assertEnvValue(t, spec, "CWAGENT_ROLE", "CI_NODE")
+	assertEnvValue(t, spec, "CWAGENT_ROLE", "NODE")
 	assertResources(t, spec, "768Mi", "100m")
 	assertSchedulingControls(t, spec)
 
@@ -96,8 +96,8 @@ func validateNodeAgentSpec(t *testing.T, agentMap map[string]unstructured.Unstru
 }
 
 func validateLeaderAgentSpec(t *testing.T, agentMap map[string]unstructured.Unstructured) {
-	agent, exists := agentMap["cloudwatch-agent-leader"]
-	if !assert.True(t, exists, "cloudwatch-agent-leader CR should exist") {
+	agent, exists := agentMap["cloudwatch-agent-ci-leader"]
+	if !assert.True(t, exists, "cloudwatch-agent-ci-leader CR should exist") {
 		return
 	}
 	spec, ok := agent.Object["spec"].(map[string]interface{})
@@ -109,7 +109,7 @@ func validateLeaderAgentSpec(t *testing.T, agentMap map[string]unstructured.Unst
 	replicas, _ := spec["replicas"].(int64)
 	assert.EqualValues(t, 1, replicas, "leader should have 1 replica")
 
-	assertEnvValue(t, spec, "CWAGENT_ROLE", "CI_LEADER")
+	assertEnvValue(t, spec, "CWAGENT_ROLE", "LEADER")
 	assertResources(t, spec, "512Mi", "50m")
 	assertSchedulingControls(t, spec)
 
@@ -197,7 +197,7 @@ func validateLeaderPodRunning(t *testing.T, k8sClient *util.K8sClient) {
 		pods, err := k8sClient.ListPods(minikube.Namespace)
 		if err == nil {
 			for _, pod := range pods.Items {
-				if strings.HasPrefix(pod.Name, "cloudwatch-agent-leader") {
+				if strings.HasPrefix(pod.Name, "cloudwatch-agent-ci-leader") {
 					lastState = string(pod.Status.Phase)
 					if pod.Status.Phase == corev1.PodRunning {
 						t.Logf("leader pod %s is Running", pod.Name)
@@ -210,5 +210,5 @@ func validateLeaderPodRunning(t *testing.T, k8sClient *util.K8sClient) {
 	}
 
 	assert.Failf(t, "leader pod not running",
-		"cloudwatch-agent-leader pod did not reach Running within timeout (last state: %q)", lastState)
+		"cloudwatch-agent-ci-leader pod did not reach Running within timeout (last state: %q)", lastState)
 }

--- a/integration-tests/amazon-cloudwatch-observability/validations/minikube/scenarios/multi_agent_leader_election_test.go
+++ b/integration-tests/amazon-cloudwatch-observability/validations/minikube/scenarios/multi_agent_leader_election_test.go
@@ -135,9 +135,9 @@ func assertEnvValue(t *testing.T, spec map[string]interface{}, name, value strin
 	assert.Failf(t, "env var not found", "env var %s should be present in spec.env", name)
 }
 
-// assertResources verifies the CPU limit was removed (cpu: null at the
-// top-level agent key) while the per-agent memory limit and CPU request
-// propagated.
+// assertResources verifies the CPU limit was removed (cpu: null inside the
+// agents[] entry — requires the null-handling fix from PR #334) while the
+// per-agent memory limit and CPU request propagated.
 func assertResources(t *testing.T, spec map[string]interface{}, memLimit, cpuRequest string) {
 	resources, _ := spec["resources"].(map[string]interface{})
 	if !assert.NotNil(t, resources, "resources should be present") {


### PR DESCRIPTION
## Description
- New minikube scenario **multi-agent-leader-election**: a daemonset agent (CWAGENT_ROLE=CI_NODE) plus a deployment leader (CWAGENT_ROLE=CI_LEADER) with the default CPU limit removed via agent-level cpu:null, per-agent resources, scheduling controls, updateStrategy tuning, and a nodeAffinity on a generic workload-tier label applied to the minikube node by the scenario terraform. Validates both CR specs and polls until the leader pod is Running.
- Shorten workflow/job display names so the matrix scenario is visible in check names ('Integ Test / Minikube (<scenario>)' instead of truncation).
- Sort the scenario matrix alphabetically with a documented convention.

## Testing
- go vet + gofmt clean; scenario values render-verified through the chart
- Matrix verified sorted (33 entries) and YAML validated
- No required status check contexts reference the old check names

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

## Dependency
⚠️ **Blocked on #334.** The scenario removes CPU limits via `cpu: null` inside the `agents[]` entries — the configuration users naturally write. On the current chart this renders a CRD-invalid literal null and the helm install fails, so the Minikube (multi-agent-leader-election) check is **expected to fail until #334 merges**. Once it does, this scenario is #334's end-to-end regression gate.