### PR TITLE
Align SPDX license headers with the repo's Apache-2.0 license

### DIFF
--- a/charts/amazon-cloudwatch-observability/tests/flag_matrix.sh
+++ b/charts/amazon-cloudwatch-observability/tests/flag_matrix.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: Apache-2.0
 #
 # Validates the 3-flag OTEL CI gating matrix by exhaustively rendering
 # `helm template` across all 8 combinations of:

--- a/integration-tests/amazon-cloudwatch-observability/terraform/common/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/common/main.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 resource "random_id" "testing_id" {
   byte_length = 8

--- a/integration-tests/amazon-cloudwatch-observability/terraform/common/output.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/common/output.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 output "testing_id" {
   value = random_id.testing_id.hex

--- a/integration-tests/amazon-cloudwatch-observability/terraform/eks/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/eks/main.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 module "common" {
   source = "../common"

--- a/integration-tests/amazon-cloudwatch-observability/terraform/eks/providers.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/eks/providers.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 provider "aws" {
   region = var.region

--- a/integration-tests/amazon-cloudwatch-observability/terraform/eks/variables.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/eks/variables.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 variable "region" {
   type    = string

--- a/integration-tests/amazon-cloudwatch-observability/terraform/eks/windows/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/eks/windows/main.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 module "common" {
   source = "../../common"

--- a/integration-tests/amazon-cloudwatch-observability/terraform/eks/windows/providers.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/eks/windows/providers.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 provider "aws" {
   region = var.region

--- a/integration-tests/amazon-cloudwatch-observability/terraform/eks/windows/variables.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/eks/windows/variables.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 variable "region" {
   type    = string

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/main.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 terraform {
   required_providers {

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/agent-config-merge-isolation/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/agent-config-merge-isolation/main.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 module "base" {
   source           = "../.."

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/appsignals-disabled-multi-agents/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/appsignals-disabled-multi-agents/main.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 module "base" {
   source           = "../.."

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/appsignals-disabled/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/appsignals-disabled/main.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 module "base" {
   source           = "../.."

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/appsignals-enabled-multi-agents/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/appsignals-enabled-multi-agents/main.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 module "base" {
   source           = "../.."

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/appsignals-unsupported/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/appsignals-unsupported/main.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 module "base" {
   source           = "../.."

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/certificate-recreate-disabled/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/certificate-recreate-disabled/main.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 module "base" {
   source           = "../.."

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/certificate-recreate-enabled/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/certificate-recreate-enabled/main.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 module "base" {
   source           = "../.."

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/configmap-permission-scoping/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/configmap-permission-scoping/main.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 module "base" {
   source           = "../.."

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/default/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/default/main.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 module "base" {
   source           = "../.."

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/deployment-rolling-disabled/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/deployment-rolling-disabled/main.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 module "base" {
   source           = "../.."

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/deployment-rolling-enabled/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/deployment-rolling-enabled/main.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 module "base" {
   source           = "../.."

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/dualstack-endpoint-enabled/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/dualstack-endpoint-enabled/main.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 module "base" {
   source           = "../.."

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/dualstack-endpoint-with-custom-endpoint/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/dualstack-endpoint-with-custom-endpoint/main.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 module "base" {
   source           = "../.."

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/feature-targeted-agent-config-override/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/feature-targeted-agent-config-override/main.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 module "base" {
   source           = "../.."

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/feature-targeted-appsignals-disabled/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/feature-targeted-appsignals-disabled/main.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 module "base" {
   source           = "../.."

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/feature-targeted-ci-and-appsignals-disabled/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/feature-targeted-ci-and-appsignals-disabled/main.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 module "base" {
   source           = "../.."

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/feature-targeted-ci-disabled/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/feature-targeted-ci-disabled/main.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 module "base" {
   source           = "../.."

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/feature-targeted-custom-otel-config/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/feature-targeted-custom-otel-config/main.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 module "base" {
   source           = "../.."

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/feature-targeted-default/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/feature-targeted-default/main.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 module "base" {
   source           = "../.."

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/feature-targeted-multi-agent/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/feature-targeted-multi-agent/main.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 module "base" {
   source           = "../.."

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/feature-targeted-otlp-disabled/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/feature-targeted-otlp-disabled/main.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 module "base" {
   source           = "../.."

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/feature-targeted-split-features/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/feature-targeted-split-features/main.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 module "base" {
   source           = "../.."

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/feature-targeted-user-config-override/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/feature-targeted-user-config-override/main.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 module "base" {
   source           = "../.."

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/multi-agent-leader-election/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/multi-agent-leader-election/main.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 module "base" {
   source           = "../.."

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/otlp-custom-otel-config/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/otlp-custom-otel-config/main.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 module "base" {
   source           = "../.."

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/otlp-disabled/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/otlp-disabled/main.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 module "base" {
   source           = "../.."

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/otlp-hybrid-metrics-fluentbit/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/otlp-hybrid-metrics-fluentbit/main.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 module "base" {
   source           = "../.."

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/otlp-logs-disabled/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/otlp-logs-disabled/main.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 module "base" {
   source           = "../.."

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/otlp-logs-dual-publish/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/otlp-logs-dual-publish/main.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 module "base" {
   source           = "../.."

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/otlp-logs-otel-only/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/otlp-logs-otel-only/main.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 module "base" {
   source           = "../.."

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/service-events-unsupported/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/service-events-unsupported/main.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 module "base" {
   source           = "../.."

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/webhooks-configured/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/webhooks-configured/main.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 module "base" {
   source           = "../.."

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/webhooks-disabled/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/webhooks-disabled/main.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 module "base" {
   source           = "../.."

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/webhooks-partially-enabled/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/webhooks-partially-enabled/main.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 module "base" {
   source           = "../.."

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/variables.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/variables.tf
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 variable "k8s_version" {
   type    = string


### PR DESCRIPTION
## Description
The repo is licensed Apache-2.0 (LICENSE file, README, and GitHub license detection all agree), but 45 files — the terraform integration-test tree and chart test scripts — carried `SPDX-License-Identifier: MIT` headers, propagated by copying from the original test scaffolding. This PR updates every SPDX header to `Apache-2.0`.

Header-comment-only change; no functional changes.

## Verification
- `grep -rl 'SPDX-License-Identifier: MIT'` now returns zero files; all 86 SPDX headers read Apache-2.0
- Diff audited: every changed line is an SPDX header line
- `make helm-flag-matrix` still passes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.