### PR TITLE
Enable OTel Container Insights in Windows EKS integ test harness

### DIFF
--- a/integration-tests/amazon-cloudwatch-observability/terraform/eks/windows/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/eks/windows/main.tf
@@ -208,6 +208,10 @@ resource "helm_release" "this" {
     {
       name  = "clusterName"
       value = aws_eks_cluster.this.name
+    },
+    {
+      name  = "otelContainerInsights.enabled"
+      value = "true"
     }
   ]
 }
@@ -222,6 +226,9 @@ resource "null_resource" "deployment_wait" {
       chmod +x kubectl
       ./kubectl rollout status daemonset fluent-bit-windows -n amazon-cloudwatch --timeout 1200s
       ./kubectl rollout status daemonset cloudwatch-agent-windows -n amazon-cloudwatch --timeout 1200s
+      ./kubectl rollout status daemonset node-exporter -n amazon-cloudwatch --timeout 1200s
+      ./kubectl rollout status deployment kube-state-metrics -n amazon-cloudwatch --timeout 1200s
+      ./kubectl rollout status deployment cloudwatch-agent-cluster-scraper -n amazon-cloudwatch --timeout 1200s
     EOT
   }
 }


### PR DESCRIPTION
## Description

Fixes the failing **EKS Win2019** / **EKS Win2022** integration-test jobs.

### Root cause
The shared `windowslinux`-tagged validation test (`validations/eks/resources_generated_test.go`) expects the OTel Container Insights resources to be present:
- `kube-state-metrics` (Deployment, Service, ServiceAccount, ClusterRole, ClusterRoleBinding)
- `node-exporter` (DaemonSet, Service, ServiceAccount, Role, RoleBinding)
- `cloudwatch-agent-cluster-scraper` (operator-created Deployment + `-monitoring` Service)

All of these are gated in the chart behind `otelContainerInsights.enabled`, which defaults to `false`. The **Linux** EKS harness (`terraform/eks/main.tf`) sets `otelContainerInsights.enabled=true`, so it passes. The **Windows** harness (`terraform/eks/windows/main.tf`) never set it, so those resources were absent and `TestResourcesGenerated` failed on:
- services: expected 13, got 10
- deployments: expected 3, got 1
- daemonSets: expected 8, got 7
- 6 OTel CI RBAC `Should be true` checks

### Change
- Set `otelContainerInsights.enabled=true` in the Windows `helm_release`, matching the Linux harness.
- Add rollout waits for the newly-enabled workloads (`node-exporter` DaemonSet, `kube-state-metrics` Deployment, `cloudwatch-agent-cluster-scraper` Deployment) before the validator runs.

### Verification
`helm template` with `--set otelContainerInsights.enabled=true` (vs default) renders exactly the missing objects, accounting 1:1 for every failing assertion (+3 services, +2 deployments, +1 daemonset, +6 RBAC objects). Single Windows dir is parameterized by `var.windows_os_version`, so this covers both Win2019 and Win2022 jobs.