### PR TITLE
Support OTel Container Insights on AKS

### DIFF
--- a/.github/workflows/amazon-cloudwatch-observability-integration-test.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-integration-test.yaml
@@ -44,6 +44,7 @@ jobs:
         # Keep sorted alphabetically.
         scenario:
           - agent-config-merge-isolation
+          - aks-otel-container-insights
           - appsignals-disabled
           - appsignals-disabled-multi-agents
           - appsignals-enabled-multi-agents

--- a/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-cluster-scraper-config.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-cluster-scraper-config.tpl
@@ -291,6 +291,26 @@ processors:
           - set(resource.attributes["k8s.component.name"], attributes["component"])
 
   resourcedetection/cw_k8s_ci_v0:
+    {{- if eq .Values.k8sMode "AKS" }}
+    detectors: [aks, azure]
+    aks:
+      resource_attributes:
+        cloud.platform: { enabled: true }
+        cloud.provider: { enabled: true }
+        k8s.cluster.name: { enabled: false }
+    azure:
+      resource_attributes:
+        azure.resourcegroup.name: { enabled: true }
+        azure.vm.name: { enabled: false }
+        azure.vm.scaleset.name: { enabled: false }
+        azure.vm.size: { enabled: false }
+        cloud.account.id: { enabled: true }
+        cloud.platform: { enabled: true }
+        cloud.provider: { enabled: true }
+        cloud.region: { enabled: true }
+        host.id: { enabled: false }
+        host.name: { enabled: false }
+    {{- else }}
     detectors: [eks, ec2]
     ec2:
       resource_attributes:
@@ -303,6 +323,7 @@ processors:
         cloud.region: { enabled: true }
         cloud.availability_zone: { enabled: true }
         cloud.account.id: { enabled: true }
+    {{- end }}
 
   nodemetadataenricher/cw_k8s_ci_v0: {}
 
@@ -340,8 +361,19 @@ processors:
     metric_statements:
       - context: resource
         statements:
+          {{- if eq .Values.k8sMode "AKS" }}
+          {{/* azure.resourcegroup.name is the node's group, not the cluster's: AKS nodes live in an
+               auto-generated MC_<clusterResourceGroup>_<cluster>_<region> group. */}}
+          - set(resource.attributes["_tmp.azure.resourcegroup.name"], resource.attributes["azure.resourcegroup.name"])
+            where resource.attributes["azure.resourcegroup.name"] != nil
+          - replace_pattern(resource.attributes["_tmp.azure.resourcegroup.name"], "^MC_(.+)_{{ .Values.clusterName }}_[^_]+$", "$$$1")
+          - set(resource.attributes["cloud.resource_id"], Concat(["/subscriptions/", resource.attributes["cloud.account.id"], "/resourceGroups/", resource.attributes["_tmp.azure.resourcegroup.name"], "/providers/Microsoft.ContainerService/managedClusters/", resource.attributes["k8s.cluster.name"]], ""))
+            where resource.attributes["cloud.account.id"] != nil and resource.attributes["_tmp.azure.resourcegroup.name"] != nil and resource.attributes["k8s.cluster.name"] != nil
+          - delete_key(resource.attributes, "_tmp.azure.resourcegroup.name")
+          {{- else }}
           - set(resource.attributes["cloud.resource_id"], Concat(["arn:aws:eks:", resource.attributes["cloud.region"], ":", resource.attributes["cloud.account.id"], ":cluster/", resource.attributes["k8s.cluster.name"]], ""))
             where resource.attributes["cloud.region"] != nil and resource.attributes["cloud.account.id"] != nil and resource.attributes["k8s.cluster.name"] != nil
+          {{- end }}
 
   batch/cw_k8s_ci_v0_cwotel:
     send_batch_size: 500

--- a/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-config.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-config.tpl
@@ -374,6 +374,26 @@ processors:
           - set(resource.attributes["k8s.node.name"], attributes["node_name"]) where attributes["node_name"] != nil
 
   resourcedetection/cw_k8s_ci_v0:
+    {{- if eq .Values.k8sMode "AKS" }}
+    detectors: [aks, azure]
+    aks:
+      resource_attributes:
+        cloud.platform: { enabled: true }
+        cloud.provider: { enabled: true }
+        k8s.cluster.name: { enabled: false }
+    azure:
+      resource_attributes:
+        azure.resourcegroup.name: { enabled: true }
+        azure.vm.name: { enabled: true }
+        azure.vm.scaleset.name: { enabled: true }
+        azure.vm.size: { enabled: true }
+        cloud.account.id: { enabled: true }
+        cloud.platform: { enabled: true }
+        cloud.provider: { enabled: true }
+        cloud.region: { enabled: true }
+        host.id: { enabled: true }
+        host.name: { enabled: true }
+    {{- else }}
     detectors: [eks, ec2]
     ec2:
       resource_attributes:
@@ -386,6 +406,7 @@ processors:
         cloud.region: { enabled: true }
         cloud.availability_zone: { enabled: true }
         cloud.account.id: { enabled: true }
+    {{- end }}
 
   transform/cw_k8s_ci_v0_clear_schema_url:
     error_mode: ignore
@@ -464,8 +485,19 @@ processors:
     metric_statements:
       - context: resource
         statements:
+          {{- if eq .Values.k8sMode "AKS" }}
+          {{/* azure.resourcegroup.name is the node's group, not the cluster's: AKS nodes live in an
+               auto-generated MC_<clusterResourceGroup>_<cluster>_<region> group. */}}
+          - set(resource.attributes["_tmp.azure.resourcegroup.name"], resource.attributes["azure.resourcegroup.name"])
+            where resource.attributes["azure.resourcegroup.name"] != nil
+          - replace_pattern(resource.attributes["_tmp.azure.resourcegroup.name"], "^MC_(.+)_{{ .Values.clusterName }}_[^_]+$", "$$$1")
+          - set(resource.attributes["cloud.resource_id"], Concat(["/subscriptions/", resource.attributes["cloud.account.id"], "/resourceGroups/", resource.attributes["_tmp.azure.resourcegroup.name"], "/providers/Microsoft.ContainerService/managedClusters/", resource.attributes["k8s.cluster.name"]], ""))
+            where resource.attributes["cloud.account.id"] != nil and resource.attributes["_tmp.azure.resourcegroup.name"] != nil and resource.attributes["k8s.cluster.name"] != nil
+          - delete_key(resource.attributes, "_tmp.azure.resourcegroup.name")
+          {{- else }}
           - set(resource.attributes["cloud.resource_id"], Concat(["arn:aws:eks:", resource.attributes["cloud.region"], ":", resource.attributes["cloud.account.id"], ":cluster/", resource.attributes["k8s.cluster.name"]], ""))
             where resource.attributes["cloud.region"] != nil and resource.attributes["cloud.account.id"] != nil and resource.attributes["k8s.cluster.name"] != nil
+          {{- end }}
 
   metricstarttime/cw_k8s_ci_v0:
 
@@ -486,6 +518,11 @@ processors:
           - set(resource.attributes["k8s.workload.type"], "CronJob") where resource.attributes["k8s.cronjob.name"] != nil and resource.attributes["k8s.workload.type"] == nil
           - set(resource.attributes["k8s.workload.name"], resource.attributes["k8s.replicaset.name"]) where resource.attributes["k8s.workload.name"] == nil and resource.attributes["k8s.replicaset.name"] != nil
           - set(resource.attributes["k8s.workload.type"], "ReplicaSet") where resource.attributes["k8s.replicaset.name"] != nil and resource.attributes["k8s.workload.type"] == nil
+          {{- if eq .Values.k8sMode "AKS" }}
+          - set(resource.attributes["service.name"], resource.attributes["k8s.workload.name"]) where resource.attributes["service.name"] == nil and resource.attributes["k8s.workload.name"] != nil
+          - set(resource.attributes["service.namespace"], resource.attributes["k8s.namespace.name"]) where resource.attributes["service.namespace"] == nil and resource.attributes["k8s.namespace.name"] != nil
+          - set(resource.attributes["deployment.environment.name"], Concat([resource.attributes["cloud.platform"], Concat([resource.attributes["k8s.cluster.name"], resource.attributes["k8s.namespace.name"]], "/")], ":")) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["cloud.platform"] != nil and resource.attributes["k8s.cluster.name"] != nil and resource.attributes["k8s.namespace.name"] != nil
+          {{- end }}
 
   batch/cw_k8s_ci_v0_metrics_dest:
     send_batch_size: 500
@@ -667,8 +704,13 @@ processors:
           - set(attributes["k8s.workload.name"], attributes["k8s.replicaset.name"]) where attributes["k8s.workload.name"] == nil and attributes["k8s.replicaset.name"] != nil
           - set(attributes["k8s.workload.type"], "ReplicaSet") where attributes["k8s.replicaset.name"] != nil and attributes["k8s.workload.type"] == nil
           # Derive service.name from k8s.workload.name (OTEL logs semconv).
-          # Logs need service.name; metrics use k8s.workload.name directly.
+          # Logs need service.name; metrics use k8s.workload.name directly, except on
+          # AKS — see transform/cw_k8s_ci_v0_set_workload.
           - set(attributes["service.name"], attributes["k8s.workload.name"]) where attributes["service.name"] == nil and attributes["k8s.workload.name"] != nil
+          {{- if eq .Values.k8sMode "AKS" }}
+          - set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where attributes["service.namespace"] == nil and attributes["k8s.namespace.name"] != nil
+          - set(attributes["deployment.environment.name"], Concat([attributes["cloud.platform"], Concat([attributes["k8s.cluster.name"], attributes["k8s.namespace.name"]], "/")], ":")) where attributes["deployment.environment.name"] == nil and attributes["cloud.platform"] != nil and attributes["k8s.cluster.name"] != nil and attributes["k8s.namespace.name"] != nil
+          {{- end }}
 
   transform/cw_k8s_ci_v0_logs_set_cluster_and_node:
     error_mode: ignore
@@ -683,8 +725,18 @@ processors:
     log_statements:
       - context: resource
         statements:
+          {{- if eq .Values.k8sMode "AKS" }}
+          {{/* Node group -> cluster group, as in transform/cw_k8s_ci_v0_set_cloud_resource_id. */}}
+          - set(attributes["_tmp.azure.resourcegroup.name"], attributes["azure.resourcegroup.name"])
+            where attributes["azure.resourcegroup.name"] != nil
+          - replace_pattern(attributes["_tmp.azure.resourcegroup.name"], "^MC_(.+)_{{ .Values.clusterName }}_[^_]+$", "$$$1")
+          - set(attributes["cloud.resource_id"], Concat(["/subscriptions/", attributes["cloud.account.id"], "/resourceGroups/", attributes["_tmp.azure.resourcegroup.name"], "/providers/Microsoft.ContainerService/managedClusters/", attributes["k8s.cluster.name"]], ""))
+            where attributes["cloud.account.id"] != nil and attributes["_tmp.azure.resourcegroup.name"] != nil and attributes["k8s.cluster.name"] != nil
+          - delete_key(attributes, "_tmp.azure.resourcegroup.name")
+          {{- else }}
           - set(attributes["cloud.resource_id"], Concat(["arn:aws:eks:", attributes["cloud.region"], ":", attributes["cloud.account.id"], ":cluster/", attributes["k8s.cluster.name"]], ""))
             where attributes["cloud.region"] != nil and attributes["cloud.account.id"] != nil and attributes["k8s.cluster.name"] != nil
+          {{- end }}
 
   transform/cw_k8s_ci_v0_logs_clear_schema_url:
     error_mode: ignore

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/aks-otel-container-insights/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/aks-otel-container-insights/main.tf
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+module "base" {
+  source           = "../.."
+  helm_values_file = "${path.module}/values.yaml"
+  helm_dir         = var.helm_dir
+}
+
+resource "null_resource" "validator" {
+  depends_on = [module.base.helm_release]
+
+  provisioner "local-exec" {
+    command = "go test ${var.test_dir} -v -run=TestAKSOtelContainerInsights"
+  }
+}
+
+variable "test_dir" {
+  type    = string
+  default = "../../../../validations/minikube/scenarios"
+}
+
+variable "helm_dir" {
+  type    = string
+  default = "../../../../../../charts/amazon-cloudwatch-observability"
+}

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/aks-otel-container-insights/values.yaml
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/aks-otel-container-insights/values.yaml
@@ -1,0 +1,14 @@
+k8sMode: AKS
+# roleArn is required when k8sMode is AKS. The agent pods will not become healthy on minikube
+# (no Azure IMDS / workload identity), but the AmazonCloudWatchAgent CRs are rendered by the chart
+# and applied by helm regardless — the operator does not gate the helm release on pod readiness —
+# so the test validates the AKS-specific config baked into the CRs.
+roleArn: arn:aws:iam::123456789012:role/CloudWatchAgentServerRole
+region: us-east-1
+clusterName: minikube
+# Exercise the OTEL CI path (metrics + logs), which is where the AKS resource-detection and
+# cloud.resource_id derivation live.
+otelContainerInsights:
+  enabled: true
+  logs:
+    enabled: true

--- a/integration-tests/amazon-cloudwatch-observability/validations/minikube/scenarios/aks_otel_container_insights_test.go
+++ b/integration-tests/amazon-cloudwatch-observability/validations/minikube/scenarios/aks_otel_container_insights_test.go
@@ -1,0 +1,199 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package scenarios
+
+import (
+	"context"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/aws-observability/helm-charts/integration-tests/amazon-cloudwatch-observability/util"
+	"github.com/aws-observability/helm-charts/integration-tests/amazon-cloudwatch-observability/validations/minikube"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// clusterName matches clusterName in the scenario's values.yaml. The AKS cloud.resource_id
+// derivation templates it into the replace_pattern regex, so the test asserts against it.
+const clusterName = "minikube"
+
+// TestAKSOtelContainerInsights validates that installing with k8sMode=AKS renders the
+// AKS-specific OTEL Container Insights configuration onto the AmazonCloudWatchAgent CRs.
+//
+// This asserts on the rendered CRs rather than on running agents: AKS-mode agent pods do not
+// become healthy on minikube (no Azure IMDS / workload identity), but the CRs are applied by the
+// helm release regardless, so the AKS-specific config they carry is verifiable here.
+func TestAKSOtelContainerInsights(t *testing.T) {
+	k8sClient, err := util.NewK8sClient()
+	require.NoError(t, err, "failed to create k8s client")
+
+	ns, err := k8sClient.GetNamespace(minikube.Namespace)
+	assert.NoError(t, err)
+	assert.Equal(t, minikube.Namespace, ns.Name)
+
+	exists, err := k8sClient.ValidateDeploymentExists(minikube.Namespace, "amazon-cloudwatch-observability-controller-manager")
+	assert.NoError(t, err)
+	assert.True(t, exists, "operator deployment should exist")
+
+	dynamicClient, err := k8sClient.GetDynamicClient()
+	require.NoError(t, err, "failed to get dynamic client")
+
+	gvr := schema.GroupVersionResource{
+		Group:    "cloudwatch.aws.amazon.com",
+		Version:  "v1alpha1",
+		Resource: "amazoncloudwatchagents",
+	}
+	agentList, err := dynamicClient.Resource(gvr).Namespace(minikube.Namespace).List(
+		context.Background(), metav1.ListOptions{},
+	)
+	require.NoError(t, err, "failed to list AmazonCloudWatchAgent CRs")
+
+	agentMap := make(map[string]unstructured.Unstructured)
+	for _, agent := range agentList.Items {
+		agentMap[agent.GetName()] = agent
+	}
+
+	t.Run("NodeAgentAKSConfig", func(t *testing.T) {
+		validateAKSOtelConfig(t, agentMap, "cloudwatch-agent")
+	})
+	t.Run("ClusterScraperAKSConfig", func(t *testing.T) {
+		validateAKSOtelConfig(t, agentMap, "cloudwatch-agent-cluster-scraper")
+	})
+	t.Run("ServiceAttributes", func(t *testing.T) {
+		validateAKSServiceAttributes(t, agentMap)
+	})
+	t.Run("HostAttributes", func(t *testing.T) {
+		validateAKSHostAttributes(t, agentMap)
+	})
+	t.Run("OTELConfigRouting", func(t *testing.T) {
+		validateOTELConfigRoutingAKS(t, agentMap)
+	})
+
+	t.Log("AKS OTEL Container Insights scenario validation passed")
+}
+
+// otelConfigOf returns the CR's spec.otelConfig, failing the test if it is missing.
+func otelConfigOf(t *testing.T, agentMap map[string]unstructured.Unstructured, name string) string {
+	t.Helper()
+	agent, exists := agentMap[name]
+	if !assert.True(t, exists, "%s CR should exist", name) {
+		return ""
+	}
+	spec, ok := agent.Object["spec"].(map[string]interface{})
+	if !assert.True(t, ok, "%s spec should be a map", name) {
+		return ""
+	}
+	otelConfig, ok := spec["otelConfig"].(string)
+	if !assert.True(t, ok, "%s otelConfig should be a string", name) {
+		return ""
+	}
+	assert.NotEmpty(t, otelConfig, "%s otelConfig should not be empty", name)
+	return otelConfig
+}
+
+// validateAKSOtelConfig checks that a CR's otelConfig uses the AKS resource detectors and the
+// Azure cloud.resource_id derivation, and that no EKS/EC2-specific constructs remain.
+func validateAKSOtelConfig(t *testing.T, agentMap map[string]unstructured.Unstructured, name string) {
+	otelConfig := otelConfigOf(t, agentMap, name)
+	if otelConfig == "" {
+		return
+	}
+
+	// AKS resource detectors, not EKS/EC2. Match the list entries ("- aks") so an unrelated
+	// "azure"-prefixed attribute cannot satisfy the check.
+	assert.True(t, strings.Contains(otelConfig, "- aks"),
+		"%s otelConfig should use the aks resource detector", name)
+	assert.True(t, strings.Contains(otelConfig, "- azure"),
+		"%s otelConfig should use the azure resource detector", name)
+	assert.False(t, strings.Contains(otelConfig, "- eks"),
+		"%s otelConfig should NOT use the eks resource detector on AKS", name)
+	assert.False(t, strings.Contains(otelConfig, "- ec2"),
+		"%s otelConfig should NOT use the ec2 resource detector on AKS", name)
+
+	assert.True(t, strings.Contains(otelConfig, "Microsoft.ContainerService/managedClusters"),
+		"%s cloud.resource_id should be an Azure managedClusters id", name)
+	assert.False(t, strings.Contains(otelConfig, "arn:aws:eks:"),
+		"%s cloud.resource_id should NOT be an EKS ARN on AKS", name)
+
+	assert.True(t, strings.Contains(otelConfig, "_tmp.azure.resourcegroup.name"),
+		"%s should derive the cluster resource group via a scratch attribute", name)
+	assert.True(t, strings.Contains(otelConfig, `"^MC_(.+)_`+clusterName+`_[^_]+$"`),
+		"%s replace_pattern regex should anchor on the cluster name", name)
+	// $$$1 survives Helm ($ passthrough) then confmap ($$->$) to reach OTTL as $1; a bare $1 is eaten
+	// as an env-var reference and crashes the agent. Asserted apart from the regex: Helm wraps the
+	// long line between the two replace_pattern args.
+	assert.True(t, strings.Contains(otelConfig, `"$$$1"`),
+		"%s replace_pattern should use the $$$1 backreference", name)
+	assert.True(t, strings.Contains(otelConfig, `delete_key`) &&
+		strings.Contains(otelConfig, `_tmp.azure.resourcegroup.name`),
+		"%s should delete_key the scratch attribute so it does not leak", name)
+}
+
+// validateOTELConfigRoutingAKS verifies the AKS overlay did not disturb the node/cluster pipeline split.
+func validateOTELConfigRoutingAKS(t *testing.T, agentMap map[string]unstructured.Unstructured) {
+	node := otelConfigOf(t, agentMap, "cloudwatch-agent")
+	if node != "" {
+		assert.True(t, strings.Contains(node, "kubeletstats"),
+			"node agent otelConfig should contain the kubeletstats receiver (node-level)")
+		assert.False(t, strings.Contains(node, "cw_k8s_ci_v0_apiserver"),
+			"node agent otelConfig should NOT contain the apiserver receiver (cluster-level)")
+	}
+	scraper := otelConfigOf(t, agentMap, "cloudwatch-agent-cluster-scraper")
+	if scraper != "" {
+		assert.True(t, strings.Contains(scraper, "cw_k8s_ci_v0_apiserver"),
+			"cluster-scraper otelConfig should contain the apiserver receiver (cluster-level)")
+		assert.False(t, strings.Contains(scraper, "kubeletstats"),
+			"cluster-scraper otelConfig should NOT contain the kubeletstats receiver (node-level)")
+	}
+}
+
+// validateAKSServiceAttributes checks the AKS-gated service.*/deployment.environment.name are on the
+// node agent but NOT the cluster-scraper (scraper metrics describe other workloads, not its own).
+func validateAKSServiceAttributes(t *testing.T, agentMap map[string]unstructured.Unstructured) {
+	serviceAttrs := []string{"service.name", "service.namespace", "deployment.environment.name"}
+
+	node := otelConfigOf(t, agentMap, "cloudwatch-agent")
+	if node != "" {
+		for _, a := range serviceAttrs {
+			assert.True(t, strings.Contains(node, a),
+				"node agent otelConfig should set %s on AKS", a)
+		}
+	}
+
+	scraper := otelConfigOf(t, agentMap, "cloudwatch-agent-cluster-scraper")
+	if scraper != "" {
+		for _, a := range serviceAttrs {
+			assert.False(t, strings.Contains(scraper, a),
+				"cluster-scraper otelConfig should NOT set %s (scraper metrics describe other workloads)", a)
+		}
+	}
+}
+
+// validateAKSHostAttributes checks host/VM identity attributes are enabled on the node agent but
+// disabled on the cluster-scraper (a Deployment whose own host is not the node it scrapes).
+func validateAKSHostAttributes(t *testing.T, agentMap map[string]unstructured.Unstructured) {
+	hostAttrs := []string{"host.id", "host.name", "azure.vm.name", "azure.vm.scaleset.name", "azure.vm.size"}
+
+	assertEnabled := func(who, otelConfig string, want bool) {
+		if otelConfig == "" {
+			return
+		}
+		for _, a := range hostAttrs {
+			re := regexp.MustCompile(regexp.QuoteMeta(a) + `:\s*enabled: (true|false)`)
+			m := re.FindStringSubmatch(otelConfig)
+			if !assert.NotNil(t, m, "%s otelConfig should set enabled for %s", who, a) {
+				continue
+			}
+			assert.Equal(t, want, m[1] == "true",
+				"%s otelConfig should have %s enabled=%t", who, a, want)
+		}
+	}
+
+	assertEnabled("node agent", otelConfigOf(t, agentMap, "cloudwatch-agent"), true)
+	assertEnabled("cluster-scraper", otelConfigOf(t, agentMap, "cloudwatch-agent-cluster-scraper"), false)
+}

--- a/integration-tests/amazon-cloudwatch-observability/validations/minikube/scenarios/default_test.go
+++ b/integration-tests/amazon-cloudwatch-observability/validations/minikube/scenarios/default_test.go
@@ -14,10 +14,11 @@ import (
 // TestDefault validates the out-of-box default install behavior.
 //
 // Default flag values (from values.yaml):
-//   containerInsights.enabled       = true  (default)
-//   containerLogs.enabled           = true  (default)
-//   otelContainerInsights.enabled       = false (default — OTEL is opt-in)
-//   otelContainerInsights.logs.enabled  = true  (default, but no-op when enabled=false)
+//
+//	containerInsights.enabled       = true  (default)
+//	containerLogs.enabled           = true  (default)
+//	otelContainerInsights.enabled       = false (default — OTEL is opt-in)
+//	otelContainerInsights.logs.enabled  = true  (default, but no-op when enabled=false)
 //
 // Result: legacy ECI metrics via CloudWatch Agent + FluentBit logs. No OTEL
 // Container Insights resources (cluster-scraper, kube-state-metrics, node-exporter).


### PR DESCRIPTION
### Description of changes

Adds AKS specific configurations for the OTel Container Insights configuration templates. All changes are guarded by the `k8sMode: AKS` check.

When `k8sMode` is AKS:
- The `resourcedetection` processor is updated to detect `aks` and `azure`. For the `aks` detector configuration, all resource attributes are enabled aside from the `k8s.cluster.name` which is provided by the `clusterName` helm chart field.
  - For the `node` configuration, the `azure` detector configuration enables all supported resource attributes.
  - For the `deployment` (scraper) configuration, the `azure` detector configuration disables node specific attributes (`azure.vm.*`, `host.*`).
- The `transform/*set_cloud_resource_id` are updated to derive a `cloud.resource_id` from the subscription, cluster name, and resource group. This matches the ARM ID (e.g. `/subscriptions/<subscription_id>/resourceGroups/<cluster-rg>/providers/Microsoft.ContainerService/managedClusters/<cluster-name>`).
  - The resource group needs to be derived since the cluster's resource group differs from the node's resource group (which is what the resource detection adds). All nodes are created in a generated resource group which follows the `MC_<clusterResourceGroup>_<cluster>_<region>` pattern.
- The `transform/*_set_workload` are updated to support derived `service.name`, `service.namespace`, and `deployment.environment.name`.

### Testing
Rendered the templates for EKS and AKS. No changes for non-AKS `k8sMode`s.

Deployed via helm install to an AKS cluster.
```yaml
k8sMode: AKS
roleArn: arn:aws:iam::<account_id>:role/CloudWatchAgentServerRole
region: us-east-1
clusterName: <cluster-name>

otelContainerInsights:
  enabled: true
  logs:
    enabled: true
applicationSignals:
  enabled: true
containerInsights:
  enabled: false
containerLogs:
  enabled: false
```

Can see the logs being sent to `/aws/otel/containerinsights/<cluster-name>/host` and `/aws/otel/containerinsights/<cluster-name>/application`
```
{
    "resource": {
        "attributes": {
            "k8s.cluster.name": "<cluster-name>",
            "k8s.node.name": "aks-nodepool1-<snip>-vmss000000",
            "cloud.provider": "azure",
            "cloud.platform": "azure_aks",
            "host.name": "aks-nodepool1-<snip>-vmss_0",
            "cloud.region": "eastus",
            "host.id": "<host-id>",
            "cloud.account.id": "<subscription-id>",
            "azure.vm.name": "aks-nodepool1-<snip>-vmss_0",
            "azure.vm.size": "Standard_D2s_v3",
            "azure.vm.scaleset.name": "aks-nodepool1-<snip>-vmss",
            "azure.resourcegroup.name": "MC_<cluster-rg>_<cluster-name>_eastus",
            "cloud.resource_id": "/subscriptions/<subscription-id>/resourceGroups/<cluster-rg>/providers/Microsoft.ContainerService/managedClusters/<cluster-name>",
            "k8s.node.label.storagetier": "Premium_LRS",
            "k8s.node.label.kubernetes.azure.com/network-policy": "none",
            "k8s.node.label.kubernetes.azure.com/node-image-version": "AKSUbuntu-2404gen2containerd-202607.09.0",
            "k8s.node.label.kubernetes.azure.com/role": "agent",
            "k8s.node.label.kubernetes.azure.com/agentpool": "nodepool1",
            "k8s.node.label.kubernetes.azure.com/kubelet-serving-ca": "cluster",
            "k8s.node.label.beta.kubernetes.io/arch": "amd64",
            "k8s.node.label.kubernetes.azure.com/sku-cpu": "2",
            "k8s.node.label.beta.kubernetes.io/os": "linux",
            "k8s.node.label.kubernetes.azure.com/localdns-state": "disabled",
            "k8s.node.label.kubernetes.azure.com/os-sku": "Ubuntu",
            "k8s.node.label.kubernetes.azure.com/nodepool-type": "VirtualMachineScaleSets",
            "k8s.node.label.topology.kubernetes.io/region": "eastus",
            "k8s.node.label.kubernetes.azure.com/os-sku-effective": "Ubuntu2404",
            "k8s.node.label.kubernetes.azure.com/mode": "system",
            "k8s.node.label.kubernetes.io/arch": "amd64",
            "k8s.node.label.failure-domain.beta.kubernetes.io/zone": "0",
            "k8s.node.label.kubernetes.azure.com/priority": "regular",
            "k8s.node.label.kubernetes.azure.com/cluster": "MC_<cluster-rg>_<cluster-name>_eastus",
            "k8s.node.label.kubernetes.azure.com/storageprofile": "managed",
            "k8s.node.label.topology.kubernetes.io/zone": "0",
            "k8s.node.label.kubernetes.azure.com/consolidated-additional-properties": "<snip>",
            "k8s.node.label.failure-domain.beta.kubernetes.io/region": "eastus",
            "k8s.node.label.kubernetes.azure.com/os-sku-requested": "Ubuntu",
            "k8s.node.label.agentpool": "nodepool1",
            "k8s.node.label.kubernetes.io/os": "linux",
            "k8s.node.label.node.kubernetes.io/instance-type": "Standard_D2s_v3",
            "k8s.node.label.kubernetes.azure.com/storagetier": "Premium_LRS",
            "k8s.node.label.kubernetes.azure.com/sku-memory": "8192",
            "k8s.node.label.storageprofile": "managed",
            "k8s.node.label.kubernetes.azure.com/kubelet-identity-client-id": "<kubelet-identity-client-id>",
            "k8s.node.label.kubernetes.io/hostname": "aks-nodepool1-<snip>-vmss000000",
            "k8s.node.label.beta.kubernetes.io/instance-type": "Standard_D2s_v3",
            "k8s.node.uid": "<node-uid>"
        }
    },
    "scope": {
        "attributes": {
            "cloudwatch.source": "cloudwatch-agent",
            "cloudwatch.solution": "k8s-otel-container-insights",
            "cloudwatch.pipeline": "host-logs"
        }
    },
    "timeUnixNano": 0,
    "observedTimeUnixNano": 1785885918357680554,
    "severityNumber": 0,
    "severityText": "",
    "body": "2026-08-04T23:25:18.198007+00:00 aks-nodepool1-<snip>-vmss000000 systemd[1]: aks-log-collector.service: Consumed 1.836s CPU time.",
    "attributes": {
        "log.file.path": "/var/log/messages"
    },
    "traceId": "",
    "spanId": ""
}

```

and verified the metrics from the scraper and node agent pods land in CW.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

