### PR TITLE
Support default:otel agent configuration and fix API server TLS config for AKS

### DIFF
--- a/.github/workflows/amazon-cloudwatch-observability-integration-test.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-integration-test.yaml
@@ -53,6 +53,7 @@ jobs:
           - certificate-recreate-enabled
           - configmap-permission-scoping
           - default
+          - default-otel
           - deployment-rolling-disabled
           - deployment-rolling-enabled
           - dualstack-endpoint-enabled

--- a/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
@@ -81,7 +81,7 @@ Helper function to modify auto-monitor config based on agent configurations
 {{- range .Values.agents -}}
   {{- $agent := mergeOverwrite (deepCopy $.Values.agent) . -}}
   {{- if and $.Values.applicationSignals.enabled (eq $.Values.applicationSignals.targetAgent $agent.name) -}}
-    {{- if and $agent.config (ne ($agent.config | toString) "default") -}}
+    {{- if and $agent.config (not (has ($agent.config | toString) (list "default" "default:otel"))) -}}
       {{- $agentConfig := $agent.config -}}
       {{- if or (and (hasKey $agentConfig "logs") (hasKey $agentConfig.logs "metrics_collected") (hasKey $agentConfig.logs.metrics_collected "application_signals")) (and (hasKey $agentConfig "traces") (hasKey $agentConfig.traces "traces_collected") (hasKey $agentConfig.traces.traces_collected "application_signals")) -}}
         {{- $hasAppSignals = true -}}
@@ -134,6 +134,26 @@ Logic:
   {{- $_ := set $config "logs" (dict "metrics_collected" $metricsCollected) -}}
 {{- end -}}
 {{- $config | toJson -}}
+{{- end -}}
+
+{{/*
+Build the "default:otel" CW Agent JSON config: the default config plus an OTLP receiver.
+Accepts a dict with "agentName" (string) and "context" (root context $).
+Returns a dict serialized to JSON.
+
+Adds otlp to whatever collect block build-default-config produced, rather than replacing it, so an
+otelContainerInsights container_insights section survives alongside it.
+
+Endpoints are set explicitly rather than left to the agent default so the receiver accepts traffic
+from other pods.
+*/}}
+{{- define "cloudwatch-agent.build-config-default-otel" -}}
+{{- $config := include "cloudwatch-agent.build-default-config" . | fromJson -}}
+{{- $otlp := dict "opentelemetry" (dict "collect" (dict "otlp" (dict
+      "span_metrics_enabled" true
+      "grpc_endpoint" "0.0.0.0:4317"
+      "http_endpoint" "0.0.0.0:4318"))) -}}
+{{- mergeOverwrite $config $otlp | toJson -}}
 {{- end -}}
 
 {{/*
@@ -450,7 +470,7 @@ Set DCGM_EXPORTER_INTERVAL environment variable for dcgmExporter if accelerated_
 {{- range .Values.agents -}}
   {{- $agent := mergeOverwrite (deepCopy $.Values.agent) . -}}
   {{- $agentConfig := $agent.config -}}
-  {{- if or (not $agentConfig) (eq ($agentConfig | toString) "default") -}}
+  {{- if or (not $agentConfig) (has ($agentConfig | toString) (list "default" "default:otel")) -}}
     {{- $agentConfig = dict -}}
   {{- end -}}
   {{- if and (hasKey $agentConfig "logs") (hasKey $agentConfig.logs "metrics_collected") (hasKey $agentConfig.logs.metrics_collected "kubernetes") (hasKey $agentConfig.logs.metrics_collected.kubernetes "accelerated_compute_gpu_metrics_collection_interval") -}}

--- a/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-cluster-scraper-config.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-cluster-scraper-config.tpl
@@ -17,6 +17,12 @@ receivers:
           tls_config:
             ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
             insecure_skip_verify: false
+            {{- if eq .Values.k8sMode "AKS" }}
+            # Endpoints SD dials the apiserver by IP. On AKS the managed control-plane endpoint IP is
+            # not in the serving cert's SANs (only DNS names + the ClusterIP are), so verify against a
+            # DNS SAN instead. On EKS the endpoint IPs are in the SANs, so this is not needed there.
+            server_name: kubernetes.default.svc
+            {{- end }}
           bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
           kubernetes_sd_configs:
             - role: endpoints

--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
@@ -101,7 +101,9 @@ spec:
   affinity: {{- toYaml . | nindent 4 }}
   {{- end }}
   hostNetwork: {{ $agent.hostNetwork }}
-  {{- if and $agent.config (ne ($agent.config | toString) "default") }}
+  {{- if eq ($agent.config | toString) "default:otel" }}
+  config: {{ include "cloudwatch-agent.modify-config" (merge (dict "Config" (include "cloudwatch-agent.build-config-default-otel" (dict "agentName" $agent.name "context" $) | fromJson)) $ ) }}
+  {{- else if and $agent.config (ne ($agent.config | toString) "default") }}
   config: {{ include "cloudwatch-agent.modify-config" (merge (dict "Config" $agent.config) $ ) }}
   {{- else }}
   config: {{ include "cloudwatch-agent.modify-config" (merge (dict "Config" (include "cloudwatch-agent.build-default-config" (dict "agentName" $agent.name "context" $) | fromJson)) $ ) }}

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/default-otel/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/default-otel/main.tf
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+module "base" {
+  source           = "../.."
+  helm_values_file = "${path.module}/values.yaml"
+  helm_dir         = var.helm_dir
+}
+
+resource "null_resource" "validator" {
+  depends_on = [module.base.helm_release]
+
+  provisioner "local-exec" {
+    command = "go test ${var.test_dir} -v -run=TestDefaultOtel"
+  }
+}
+
+variable "test_dir" {
+  type    = string
+  default = "../../../../validations/minikube/scenarios"
+}
+
+variable "helm_dir" {
+  type    = string
+  default = "../../../../../../charts/amazon-cloudwatch-observability"
+}

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/default-otel/values.yaml
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/default-otel/values.yaml
@@ -1,0 +1,15 @@
+region: us-west-2
+clusterName: minikube
+# Exercise config: "default:otel": the node agent gets the default CW Agent JSON config plus an
+# OTLP receiver (0.0.0.0:4317/4318), while the cluster-scraper keeps "default".
+# The agents array is respecified in full because --set/list-merge would otherwise clobber it.
+agents:
+  - name: cloudwatch-agent
+    config: "default:otel"
+  - name: cloudwatch-agent-cluster-scraper
+    mode: deployment
+    config: "default"
+# OTEL CI on so the cluster-scraper CR is rendered (it is gated on otelContainerInsights.enabled),
+# letting the test assert the scraper does NOT pick up the OTLP receiver.
+otelContainerInsights:
+  enabled: true

--- a/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/default/main.tf
+++ b/integration-tests/amazon-cloudwatch-observability/terraform/minikube/scenarios/default/main.tf
@@ -11,7 +11,8 @@ resource "null_resource" "validator" {
   depends_on = [module.base.helm_release]
 
   provisioner "local-exec" {
-    command = "go test ${var.test_dir} -v -run=TestDefault"
+    # Anchored so it does not also match TestDefault*.
+    command = "go test ${var.test_dir} -v -run='TestDefault$'"
   }
 }
 

--- a/integration-tests/amazon-cloudwatch-observability/validations/minikube/scenarios/aks_otel_container_insights_test.go
+++ b/integration-tests/amazon-cloudwatch-observability/validations/minikube/scenarios/aks_otel_container_insights_test.go
@@ -76,6 +76,9 @@ func TestAKSOtelContainerInsights(t *testing.T) {
 	t.Run("WebhookEnforcerDisabled", func(t *testing.T) {
 		validateAKSWebhookEnforcerDisabled(t, k8sClient)
 	})
+	t.Run("ApiserverTLSServerName", func(t *testing.T) {
+		validateAKSApiserverTLSServerName(t, agentMap)
+	})
 
 	t.Log("AKS OTEL Container Insights scenario validation passed")
 }
@@ -153,6 +156,18 @@ func validateOTELConfigRoutingAKS(t *testing.T, agentMap map[string]unstructured
 		assert.False(t, strings.Contains(scraper, "kubeletstats"),
 			"cluster-scraper otelConfig should NOT contain the kubeletstats receiver (node-level)")
 	}
+}
+
+// validateAKSApiserverTLSServerName checks the apiserver scrape verifies TLS against a DNS SAN. On
+// AKS, endpoints SD dials the managed control-plane IP, which is absent from the serving cert's SANs,
+// so without server_name every scrape fails TLS and no apiserver metrics reach CloudWatch.
+func validateAKSApiserverTLSServerName(t *testing.T, agentMap map[string]unstructured.Unstructured) {
+	scraper := otelConfigOf(t, agentMap, "cloudwatch-agent-cluster-scraper")
+	if scraper == "" {
+		return
+	}
+	assert.True(t, strings.Contains(scraper, "server_name: kubernetes.default.svc"),
+		"cluster-scraper otelConfig should set server_name for the apiserver TLS scrape on AKS")
 }
 
 // validateAKSServiceAttributes checks the AKS-gated service.*/deployment.environment.name are on the

--- a/integration-tests/amazon-cloudwatch-observability/validations/minikube/scenarios/default_otel_test.go
+++ b/integration-tests/amazon-cloudwatch-observability/validations/minikube/scenarios/default_otel_test.go
@@ -1,0 +1,148 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package scenarios
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/aws-observability/helm-charts/integration-tests/amazon-cloudwatch-observability/util"
+	"github.com/aws-observability/helm-charts/integration-tests/amazon-cloudwatch-observability/validations/minikube"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// TestDefaultOtel validates the config: "default:otel" value, which merges an OTLP receiver onto
+// the default CW Agent config. Asserts on the rendered CR's JSON spec.config, like the other scenarios.
+func TestDefaultOtel(t *testing.T) {
+	k8sClient, err := util.NewK8sClient()
+	require.NoError(t, err, "failed to create k8s client")
+
+	ns, err := k8sClient.GetNamespace(minikube.Namespace)
+	assert.NoError(t, err)
+	assert.Equal(t, minikube.Namespace, ns.Name)
+
+	exists, err := k8sClient.ValidateDeploymentExists(minikube.Namespace, "amazon-cloudwatch-observability-controller-manager")
+	assert.NoError(t, err)
+	assert.True(t, exists, "operator deployment should exist")
+
+	dynamicClient, err := k8sClient.GetDynamicClient()
+	require.NoError(t, err, "failed to get dynamic client")
+
+	gvr := schema.GroupVersionResource{
+		Group:    "cloudwatch.aws.amazon.com",
+		Version:  "v1alpha1",
+		Resource: "amazoncloudwatchagents",
+	}
+	agentList, err := dynamicClient.Resource(gvr).Namespace(minikube.Namespace).List(
+		context.Background(), metav1.ListOptions{},
+	)
+	require.NoError(t, err, "failed to list AmazonCloudWatchAgent CRs")
+
+	agentMap := make(map[string]unstructured.Unstructured)
+	for _, agent := range agentList.Items {
+		agentMap[agent.GetName()] = agent
+	}
+
+	t.Run("NodeAgentHasOtlpReceiver", func(t *testing.T) {
+		validateNodeAgentOtlpReceiver(t, agentMap)
+	})
+	t.Run("NodeAgentDefaultConfigSurvives", func(t *testing.T) {
+		validateNodeAgentDefaultConfigSurvives(t, agentMap)
+	})
+	t.Run("ClusterScraperHasNoOtlpReceiver", func(t *testing.T) {
+		validateClusterScraperNoOtlpReceiver(t, agentMap)
+	})
+
+	t.Log("default:otel config scenario validation passed")
+}
+
+// configJSONOf parses a CR's spec.config (a JSON string) into a map, failing the test on any issue.
+func configJSONOf(t *testing.T, agentMap map[string]unstructured.Unstructured, name string) map[string]interface{} {
+	t.Helper()
+	agent, exists := agentMap[name]
+	if !assert.True(t, exists, "%s CR should exist", name) {
+		return nil
+	}
+	spec, ok := agent.Object["spec"].(map[string]interface{})
+	if !assert.True(t, ok, "%s spec should be a map", name) {
+		return nil
+	}
+	configStr, ok := spec["config"].(string)
+	if !assert.True(t, ok, "%s config should be a string", name) {
+		return nil
+	}
+	var config map[string]interface{}
+	if !assert.NoError(t, json.Unmarshal([]byte(configStr), &config), "%s config should be valid JSON", name) {
+		return nil
+	}
+	return config
+}
+
+// otlpCollectBlockOf returns opentelemetry.collect.otlp from a parsed config, or nil if absent.
+func otlpCollectBlockOf(config map[string]interface{}) map[string]interface{} {
+	otel, ok := config["opentelemetry"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	collect, ok := otel["collect"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	otlp, _ := collect["otlp"].(map[string]interface{})
+	return otlp
+}
+
+// validateNodeAgentOtlpReceiver checks the node agent's "default:otel" config carries the OTLP receiver.
+func validateNodeAgentOtlpReceiver(t *testing.T, agentMap map[string]unstructured.Unstructured) {
+	config := configJSONOf(t, agentMap, "cloudwatch-agent")
+	if config == nil {
+		return
+	}
+	otlp := otlpCollectBlockOf(config)
+	if !assert.NotNil(t, otlp, "node agent config should have opentelemetry.collect.otlp for default:otel") {
+		return
+	}
+	// Endpoints are pinned to 0.0.0.0 so the receiver accepts traffic from other pods (the agent
+	// default binds loopback only).
+	assert.Equal(t, "0.0.0.0:4317", otlp["grpc_endpoint"], "otlp grpc_endpoint should be 0.0.0.0:4317")
+	assert.Equal(t, "0.0.0.0:4318", otlp["http_endpoint"], "otlp http_endpoint should be 0.0.0.0:4318")
+	assert.Equal(t, true, otlp["span_metrics_enabled"], "otlp span_metrics_enabled should be true")
+}
+
+// validateNodeAgentDefaultConfigSurvives checks the OTLP receiver was MERGED onto the default config,
+// not substituted for it: the default Container Insights block (logs.metrics_collected.kubernetes)
+// must remain alongside it.
+func validateNodeAgentDefaultConfigSurvives(t *testing.T, agentMap map[string]unstructured.Unstructured) {
+	config := configJSONOf(t, agentMap, "cloudwatch-agent")
+	if config == nil {
+		return
+	}
+	logs, ok := config["logs"].(map[string]interface{})
+	if !assert.True(t, ok, "node agent config should retain the default logs section") {
+		return
+	}
+	metricsCollected, ok := logs["metrics_collected"].(map[string]interface{})
+	if !assert.True(t, ok, "node agent config should retain logs.metrics_collected") {
+		return
+	}
+	_, hasKubernetes := metricsCollected["kubernetes"]
+	assert.True(t, hasKubernetes,
+		"default Container Insights (logs.metrics_collected.kubernetes) should survive the OTLP merge")
+}
+
+// validateClusterScraperNoOtlpReceiver checks the cluster-scraper (config: "default", not
+// "default:otel") does NOT get the OTLP receiver; it describes other workloads, not local ingest.
+func validateClusterScraperNoOtlpReceiver(t *testing.T, agentMap map[string]unstructured.Unstructured) {
+	config := configJSONOf(t, agentMap, "cloudwatch-agent-cluster-scraper")
+	if config == nil {
+		return
+	}
+	assert.Nil(t, otlpCollectBlockOf(config),
+		"cluster-scraper config should NOT have an OTLP receiver (config is plain default)")
+}


### PR DESCRIPTION
### Description of changes
#### default:otel
Adds a new reserved agent configuration value `default:otel`, which matches the platform specific default configurations added to the agent (https://github.com/aws/amazon-cloudwatch-agent/pull/2212). This configures the agent with an OTLP receiver that sends to the CloudWatch OTLP endpoints allowing other pods to send telemetry to CloudWatch.
```yaml
agents:
  - name: cloudwatch-agent
    config: "default:otel"
```

A new `build-config-default-otel` helper merges in an `opentelemetry.collect.otlp` block into the result of the `build-default-config` helper. Updates the Application Signals and DCGM exporter checks to treat `default:otel` similarly as `default`.

#### Fix API server TLS config for AKS
Adds `server_name: kubernetes.default.svc` to the `tls_config` of the `cluster-scraper`'s apiserver scrape config. This is gated on `k8sMode: AKS`. 

The scrape uses `role: endpoints` for its service discovery, which targets the API server using its endpoint IP. On AKS, the endpoint IP is not present in the API server's certificate (only DNS names and the ClusterIP are), so TLS verification fails and no API server metrics are collected. `server_name` makes verification use a supported DNS while still connecting to the discovered IP.

> [!NOTE]
> AKS exposes the API server behind a single load-balanced endpoint, so each scrape reaches one replica.
> https://learn.microsoft.com/en-us/azure/aks/control-plane-metrics-monitor#can-i-scrape-control-plane-metrics-by-using-self-hosted-prometheus
>> **Can I scrape control plane metrics by using self-hosted Prometheus?**
>> No. Currently, you can't scrape control plane metrics by using self-hosted Prometheus. Self-hosted Prometheus can scrape only a single instance, depending on the load balancer, so the metrics aren't reliable. Often, multiple replicas of the control plane metrics are visible only through the managed service for Prometheus.

### Testing

#### default:otel
Rendered the templates with and without `config: "default:otel"` to verify nothing changes for the default experience.

Added a minikube integration test scenario (`default-otel`) that validates the rendered `AmazonCloudWatchAgent` CRs:
- the node agent's configuration has the `otlp` section
- the default Container Insights block (`logs.metrics_collected.kubernetes`) is retained after the merge
- the cluster-scraper (`config: "default"`) does not get the `otlp` section

Deployed via helm install and verified that applications are able to send OTLP metrics, logs, and traces to the agent and telemetry lands in CloudWatch.

#### Fix API server TLS config for AKS
Extended minikube test for AKS OTel Container Insights for this change.

Deployed via helm install and can see `apiserver_request_total` after the scrape config fix.
<img width="2529" height="979" alt="image" src="https://github.com/user-attachments/assets/d83f33a4-dd16-4fa0-bf32-5f5ce9224169" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

