### PR TITLE
Disable webhook admissions enforcer in AKS

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -4,6 +4,12 @@ kind: MutatingWebhookConfiguration
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: {{ printf "%s/%s-serving-cert" .Release.Namespace (include "amazon-cloudwatch-observability.name" .) }}
+    {{- if eq .Values.k8sMode "AKS" }}
+    # Opt out of the AKS admissionsenforcer, which otherwise injects its own namespaceSelector into
+    # each webhook and takes server-side-apply ownership of the field, causing helm upgrade to
+    # conflict. See https://learn.microsoft.com/en-us/azure/aks/faq (admissions enforcer).
+    admissions.enforcer/disabled: "true"
+    {{- end }}
   labels:
     {{- include "amazon-cloudwatch-observability.labels" . | nindent 4}}
   name: {{ template "amazon-cloudwatch-observability.name" . }}-mutating-webhook-configuration
@@ -156,6 +162,12 @@ kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: {{ printf "%s/%s-serving-cert" .Release.Namespace (include "amazon-cloudwatch-observability.name" .) }}
+    {{- if eq .Values.k8sMode "AKS" }}
+    # Opt out of the AKS admissionsenforcer, which otherwise injects its own namespaceSelector into
+    # each webhook and takes server-side-apply ownership of the field, causing helm upgrade to
+    # conflict. See https://learn.microsoft.com/en-us/azure/aks/faq (admissions enforcer).
+    admissions.enforcer/disabled: "true"
+    {{- end }}
   labels:
     {{- include "amazon-cloudwatch-observability.labels" . | nindent 4}}
   name: {{ template "amazon-cloudwatch-observability.name" . }}-validating-webhook-configuration

--- a/charts/amazon-cloudwatch-observability/templates/admission-webhooks/operator-webhook.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/admission-webhooks/operator-webhook.yaml
@@ -15,6 +15,13 @@ data:
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
+  {{- if eq .Values.k8sMode "AKS" }}
+  annotations:
+    # Opt out of the AKS admissionsenforcer, which otherwise injects its own namespaceSelector into
+    # each webhook and takes server-side-apply ownership of the field, causing helm upgrade to
+    # conflict. See https://learn.microsoft.com/en-us/azure/aks/faq (admissions enforcer).
+    admissions.enforcer/disabled: "true"
+  {{- end }}
   labels:
     {{- include "amazon-cloudwatch-observability.labels" . | nindent 4}}
   name: {{ template "amazon-cloudwatch-observability.name" . }}-mutating-webhook-configuration
@@ -170,6 +177,13 @@ webhooks:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
+  {{- if eq .Values.k8sMode "AKS" }}
+  annotations:
+    # Opt out of the AKS admissionsenforcer, which otherwise injects its own namespaceSelector into
+    # each webhook and takes server-side-apply ownership of the field, causing helm upgrade to
+    # conflict. See https://learn.microsoft.com/en-us/azure/aks/faq (admissions enforcer).
+    admissions.enforcer/disabled: "true"
+  {{- end }}
   labels:
     {{- include "amazon-cloudwatch-observability.labels" . | nindent 4}}
   name: {{ template "amazon-cloudwatch-observability.name" . }}-validating-webhook-configuration

--- a/integration-tests/amazon-cloudwatch-observability/validations/minikube/scenarios/aks_otel_container_insights_test.go
+++ b/integration-tests/amazon-cloudwatch-observability/validations/minikube/scenarios/aks_otel_container_insights_test.go
@@ -73,6 +73,9 @@ func TestAKSOtelContainerInsights(t *testing.T) {
 	t.Run("OTELConfigRouting", func(t *testing.T) {
 		validateOTELConfigRoutingAKS(t, agentMap)
 	})
+	t.Run("WebhookEnforcerDisabled", func(t *testing.T) {
+		validateAKSWebhookEnforcerDisabled(t, k8sClient)
+	})
 
 	t.Log("AKS OTEL Container Insights scenario validation passed")
 }
@@ -196,4 +199,40 @@ func validateAKSHostAttributes(t *testing.T, agentMap map[string]unstructured.Un
 
 	assertEnabled("node agent", otelConfigOf(t, agentMap, "cloudwatch-agent"), true)
 	assertEnabled("cluster-scraper", otelConfigOf(t, agentMap, "cloudwatch-agent-cluster-scraper"), false)
+}
+
+// validateAKSWebhookEnforcerDisabled checks the webhook configurations carry the
+// admissions.enforcer/disabled annotation on AKS. Without it, the AKS admissionsenforcer rewrites each
+// webhook's namespaceSelector and takes server-side-apply ownership of the field, which makes the next
+// helm upgrade fail with an apply conflict.
+func validateAKSWebhookEnforcerDisabled(t *testing.T, k8sClient *util.K8sClient) {
+	const enforcerDisabled = "admissions.enforcer/disabled"
+
+	mwc, err := k8sClient.ListMutatingWebhookConfigurations()
+	require.NoError(t, err, "failed to list MutatingWebhookConfigurations")
+	assertEnforcerDisabled := func(name string, annotations map[string]string) {
+		assert.Equal(t, "true", annotations[enforcerDisabled],
+			"%s should set %s on AKS", name, enforcerDisabled)
+	}
+
+	foundMutating := false
+	for _, wh := range mwc.Items {
+		if wh.Name == minikube.WebhookName {
+			foundMutating = true
+			assertEnforcerDisabled(wh.Name, wh.Annotations)
+		}
+	}
+	assert.True(t, foundMutating, "mutating webhook configuration %s should exist", minikube.WebhookName)
+
+	vwc, err := k8sClient.ListValidatingWebhookConfigurations()
+	require.NoError(t, err, "failed to list ValidatingWebhookConfigurations")
+	validatingName := "amazon-cloudwatch-observability-validating-webhook-configuration"
+	foundValidating := false
+	for _, wh := range vwc.Items {
+		if wh.Name == validatingName {
+			foundValidating = true
+			assertEnforcerDisabled(wh.Name, wh.Annotations)
+		}
+	}
+	assert.True(t, foundValidating, "validating webhook configuration %s should exist", validatingName)
 }


### PR DESCRIPTION
### Description of changes
On AKS, helm upgrade of an existing install fails with a server-side apply conflict on the webhook configurations' namespaceSelector field.

```
Error: UPGRADE FAILED: conflict occurred while applying object /amazon-cloudwatch-observability-mutating-webhook-configuration
admissionregistration.k8s.io/v1, Kind=MutatingWebhookConfiguration: Apply failed with 5 conflicts:
conflicts with "admissionsenforcer" using admissionregistration.k8s.io/v1:
- .webhooks[name="mamazoncloudwatchagent.kb.io"].namespaceSelector
- .webhooks[name="minstrumentation.kb.io"].namespaceSelector
- .webhooks[name="mnamespace.kb.io"].namespaceSelector
- .webhooks[name="mpod.kb.io"].namespaceSelector
- .webhooks[name="mworkload.kb.io"].namespaceSelector
&& conflict occurred while applying object /amazon-cloudwatch-observability-validating-webhook-configuration
admissionregistration.k8s.io/v1, Kind=ValidatingWebhookConfiguration: Apply failed with 4 conflicts:
conflicts with "admissionsenforcer" using admissionregistration.k8s.io/v1:
- .webhooks[name="vamazoncloudwatchagentcreateupdate.kb.io"].namespaceSelector
- .webhooks[name="vamazoncloudwatchagentdelete.kb.io"].namespaceSelector
- .webhooks[name="vinstrumentationcreateupdate.kb.io"].namespaceSelector
- .webhooks[name="vinstrumentationdelete.kb.io"].namespaceSelector
```

This is due to the AKS admissionsenforcer admissions controller. On any user created webhook configuration, it rewrites the webhook's namespaceSelector
```
namespaceSelector:
  matchExpressions:
  - key: control-plane
    operator: NotIn
    values: ["true"]
  - key: kubernetes.azure.com/managedby
    operator: NotIn
    values: ["aks"]
```
which causes the conflicts since the chart applies the `namespaceSelector: {}` on an upgrade.

The admissionsenforcer can be disabled for mutating webhooks by adding a label or annotation.
https://learn.microsoft.com/en-us/azure/aks/faq#can-admission-controller-webhooks-affect-kube-system-and-internal-aks-namespaces-
> **Can admission controller webhooks affect kube-system and internal AKS namespaces?**
>
> To protect the stability of the system and prevent custom admission controllers from affecting internal services in the kube-system namespace, AKS has an admissions enforcer, which automatically excludes kube-system and AKS internal namespaces. This service ensures that the custom admission controllers don't affect the services that run in kube-system.
> If you have a critical use case for deploying something on kube-system (not recommended) in support of your custom admission webhook, you can add the following label or annotation so that the admissions enforcer ignores it:
>
>    Label: "admissions.enforcer/disabled": "true"
>    Annotation: "admissions.enforcer/disabled": true

This PR adds the annotation to the MutatingWebhookConfiguration and ValidatingWebhookConfiguration metadata, which is gated on `k8sMode: AKS`.

### Testing
- Updated the minikube AKS Otel CI test to check for the disable annotation.
- Verified helm upgrade on a test AKS cluster.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

