### PR TITLE
Pin OTel Container Insights self-telemetry to level: none

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-cluster-scraper-config.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-cluster-scraper-config.tpl
@@ -395,6 +395,12 @@ exporters:
       authenticator: sigv4auth/cw_k8s_ci_v0_cwotel
 
 service:
+  # Pin internal self-telemetry off. Without this the collector falls back to its
+  # built-in default (metrics level Normal + a Prometheus reader on localhost:8888),
+  # which collides with the co-scheduled node DaemonSet agent on the node's :8888.
+  telemetry:
+    metrics:
+      level: none
   extensions:
     - sigv4auth/cw_k8s_ci_v0_cwotel
     - nodemetadatacache/cw_k8s_ci_v0

--- a/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-config.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-config.tpl
@@ -827,6 +827,12 @@ exporters:
 {{- end }}
 
 service:
+  # Pin internal self-telemetry off. Without this the collector falls back to its
+  # built-in default (metrics level Normal + a Prometheus reader on localhost:8888),
+  # which collides with the co-scheduled cluster-scraper on the node's :8888.
+  telemetry:
+    metrics:
+      level: none
   extensions:
     - sigv4auth/cw_k8s_ci_v0_metrics_dest
 {{- if .Values.otelContainerInsights.logs.enabled }}


### PR DESCRIPTION
## What
Explicitly set `service.telemetry.metrics.level: none` in both OTel Container Insights config templates (node DaemonSet + cluster-scraper).

## Why
The generated OCI otelConfig had no `service.telemetry` section, so the collector fell back to its built-in default (`level: Normal` + a Prometheus self-telemetry reader on `localhost:8888`). On a `hostNetwork` node the DaemonSet agent binds `:8888`; when the cluster-scraper co-schedules onto the same node it contends for the same port and the DaemonSet pod crash-loops with `bind: address already in use`.

Pinning `level: none` stops the collector from ever opening the self-telemetry listener, so the collision cannot occur regardless of pod placement.

## Testing done
Validated before/after on a live EKS cluster (v6.4.0, OCI enabled, 3 nodes so the scraper co-schedules with a DaemonSet pod):
- **Before (stock chart):** DS otelConfig has no `service.telemetry`; co-scheduled DaemonSet pod CrashLoopBackOff — `listen tcp 127.0.0.1:8888: bind: address already in use`.
- **After (this change):** both agents render `service.telemetry.metrics.level: none`; the same DaemonSet pod starts cleanly ("Everything is ready"), no bind error, 0 new restarts over a sustained hold.
- `helm lint` clean; `helm template` confirms EKS non-OCI, Windows CI, and ROSA/K8S renders are unchanged.
