### PR TITLE
feat: selfTelemetry endpoint + watchReplicaset toggles

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
@@ -128,7 +128,12 @@ Logic:
 {{/* Container Insights: add logs.metrics_collected.kubernetes */}}
 {{- if and $ctx.Values.containerInsights.enabled (eq $ctx.Values.containerInsights.targetAgent $agentName) -}}
   {{- $needsLogs = true -}}
-  {{- $_ := set $metricsCollected "kubernetes" (dict "enhanced_container_insights" true) -}}
+  {{- $kubernetes := dict "enhanced_container_insights" true -}}
+  {{/* watch_replicaset is on by default in the agent; only emit it when opting out so default renders stay byte-identical */}}
+  {{- if not $ctx.Values.containerInsights.watchReplicaset -}}
+    {{- $_ := set $kubernetes "watch_replicaset" false -}}
+  {{- end -}}
+  {{- $_ := set $metricsCollected "kubernetes" $kubernetes -}}
 {{- end -}}
 {{- if $needsLogs -}}
   {{- $_ := set $config "logs" (dict "metrics_collected" $metricsCollected) -}}

--- a/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
@@ -248,13 +248,35 @@ Helper function to modify cloudwatch-agent config
 {{- end }}
 
 {{/*
+Resolve the self telemetry port for an agent, empty when the agent has no entry. selfTelemetry.ports
+therefore decides which agents serve the endpoint, which keeps agents that were never given a port,
+such as the Windows daemonsets, out of it.
+*/}}
+{{- define "cloudwatch-agent.self-telemetry-port" -}}
+{{- $ports := (.context.Values.selfTelemetry).ports | default dict -}}
+{{- if .agentName -}}
+{{- index $ports .agentName | default "" -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Helper function to modify customer supplied agent config if ContainerInsights or ApplicationSignals is enabled
 */}}
 {{- define "cloudwatch-agent.modify-config" -}}
-{{- if and (hasKey .Config "logs") (or (and (hasKey .Config.logs "metrics_collected") (hasKey .Config.logs.metrics_collected "application_signals")) (and (hasKey .Config.logs "metrics_collected") (hasKey .Config.logs.metrics_collected "kubernetes"))) }}
-{{- include "cloudwatch-agent.config-modifier" . }}
+{{- $configCopy := deepCopy .Config }}
+{{- $selfTelemetry := .Values.selfTelemetry | default dict }}
+{{- $selfTelemetryPort := include "cloudwatch-agent.self-telemetry-port" (dict "agentName" .agentName "context" .) }}
+{{- if and $selfTelemetry.enabled $selfTelemetryPort }}
+{{- if not (hasKey $configCopy "agent") }}
+{{- $_ := set $configCopy "agent" dict }}
+{{- end }}
+{{- $_ := set $configCopy.agent "self_telemetry" (dict "enabled" true "port" ($selfTelemetryPort | int)) }}
+{{- end }}
+{{- $ctx := merge (dict "Config" $configCopy) . }}
+{{- if and (hasKey $configCopy "logs") (or (and (hasKey $configCopy.logs "metrics_collected") (hasKey $configCopy.logs.metrics_collected "application_signals")) (and (hasKey $configCopy.logs "metrics_collected") (hasKey $configCopy.logs.metrics_collected "kubernetes"))) }}
+{{- include "cloudwatch-agent.config-modifier" $ctx }}
 {{- else }}
-{{- default "" .Config | toJson | quote }}
+{{- default "" $configCopy | toJson | quote }}
 {{- end }}
 {{- end }}
 

--- a/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
@@ -199,6 +199,26 @@ Logic:
 {{- if not (kindIs "bool" .Values.otelContainerInsights.logs.enabled) }}
 {{- fail "otelContainerInsights.logs.enabled must be a boolean (true/false)" }}
 {{- end }}
+{{- if not (kindIs "bool" .Values.containerInsights.watchReplicaset) }}
+{{- fail "containerInsights.watchReplicaset must be a boolean (true/false)" }}
+{{- end }}
+{{- if not (kindIs "bool" .Values.otelContainerInsights.watchReplicaset) }}
+{{- fail "otelContainerInsights.watchReplicaset must be a boolean (true/false)" }}
+{{- end }}
+{{- $selfTelemetry := .Values.selfTelemetry | default dict }}
+{{- if and (hasKey $selfTelemetry "enabled") (not (kindIs "bool" $selfTelemetry.enabled)) }}
+{{- fail "selfTelemetry.enabled must be a boolean (true/false)" }}
+{{- end }}
+{{- /* Agents share the node's hostNetwork port space, so two agents on the same self-telemetry
+       port makes one fail to start. Reject duplicate port assignments up front. */ -}}
+{{- $seenPorts := dict }}
+{{- range $agent, $port := ($selfTelemetry.ports | default dict) }}
+{{- $portKey := $port | toString }}
+{{- if hasKey $seenPorts $portKey }}
+{{- fail (printf "selfTelemetry.ports assigns port %v to both %s and %s; each agent needs a unique port" $port (index $seenPorts $portKey) $agent) }}
+{{- end }}
+{{- $_ := set $seenPorts $portKey $agent }}
+{{- end }}
 {{- end -}}
 
 {{- define "cloudwatch-agent.build-default-otel-config" -}}
@@ -224,8 +244,12 @@ Helper function to modify cloudwatch-agent config
 
 {{- $agent := pluck "agent" $configCopy | first }}
 {{- if or (empty $agent) (empty $agent.region) }}
-{{- $agentRegion := dict "region" .Values.region }}
-{{- $agent := set $configCopy "agent" $agentRegion }}
+{{- if not (hasKey $configCopy "agent") }}
+{{- $_ := set $configCopy "agent" dict }}
+{{- end }}
+{{- /* Set region on the existing agent map; replacing the whole map would drop other agent
+       keys such as the injected self_telemetry. */ -}}
+{{- $_ := set $configCopy.agent "region" .Values.region }}
 {{- end }}
 
 {{- if .Values.useDualstackEndpoint }}
@@ -260,7 +284,17 @@ such as the Windows daemonsets, out of it.
 {{- define "cloudwatch-agent.self-telemetry-port" -}}
 {{- $ports := (.context.Values.selfTelemetry).ports | default dict -}}
 {{- if .agentName -}}
-{{- index $ports .agentName | default "" -}}
+{{- $port := index $ports .agentName | default "" -}}
+{{- if $port -}}
+{{- if not (regexMatch "^[0-9]+$" ($port | toString)) -}}
+{{- fail (printf "selfTelemetry.ports.%s must be a numeric TCP port, got %q" .agentName ($port | toString)) -}}
+{{- end -}}
+{{- $p := $port | int -}}
+{{- if or (lt $p 1) (gt $p 65535) -}}
+{{- fail (printf "selfTelemetry.ports.%s must be within 1-65535, got %d" .agentName $p) -}}
+{{- end -}}
+{{- end -}}
+{{- $port -}}
 {{- end -}}
 {{- end }}
 
@@ -268,6 +302,7 @@ such as the Windows daemonsets, out of it.
 Helper function to modify customer supplied agent config if ContainerInsights or ApplicationSignals is enabled
 */}}
 {{- define "cloudwatch-agent.modify-config" -}}
+{{- include "cloudwatch-agent.validate-flags" . -}}
 {{- $configCopy := deepCopy .Config }}
 {{- $selfTelemetry := .Values.selfTelemetry | default dict }}
 {{- $selfTelemetryPort := include "cloudwatch-agent.self-telemetry-port" (dict "agentName" .agentName "context" .) }}

--- a/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-cluster-scraper-config.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-cluster-scraper-config.tpl
@@ -608,12 +608,14 @@ exporters:
       authenticator: sigv4auth/cw_k8s_ci_v0_cwotel
 
 service:
-  {{- if not .Values.selfTelemetry.enabled }}
+  {{- $selfTelemetry := .Values.selfTelemetry | default dict }}
+  {{- $selfTelemetryPort := include "cloudwatch-agent.self-telemetry-port" (dict "agentName" .Values.otelContainerInsights.clusterScraperAgent "context" .) }}
+  {{- if not (and $selfTelemetry.enabled $selfTelemetryPort) }}
   # Pin internal self-telemetry off. Without this the collector falls back to its
   # built-in default (metrics level Normal + a Prometheus reader on localhost:8888),
   # which collides with the co-scheduled node DaemonSet agent on the node's :8888.
-  # When selfTelemetry is enabled it owns service.telemetry (with a non-8888 port), so this
-  # pin is omitted to avoid a merge race over the same key.
+  # Only omitted when THIS agent has a resolved self-telemetry port (so it actually owns
+  # service.telemetry on a non-8888 port); the global flag alone is not enough.
   telemetry:
     metrics:
       level: none

--- a/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-cluster-scraper-config.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-cluster-scraper-config.tpl
@@ -457,7 +457,9 @@ processors:
       metadata:
         - k8s.pod.uid
         - k8s.node.name
+{{- if .Values.otelContainerInsights.watchReplicaset }}
         - k8s.deployment.name
+{{- end }}
         - k8s.statefulset.name
         - k8s.daemonset.name
         - k8s.replicaset.name

--- a/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-cluster-scraper-config.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-cluster-scraper-config.tpl
@@ -606,12 +606,16 @@ exporters:
       authenticator: sigv4auth/cw_k8s_ci_v0_cwotel
 
 service:
+  {{- if not .Values.selfTelemetry.enabled }}
   # Pin internal self-telemetry off. Without this the collector falls back to its
   # built-in default (metrics level Normal + a Prometheus reader on localhost:8888),
   # which collides with the co-scheduled node DaemonSet agent on the node's :8888.
+  # When selfTelemetry is enabled it owns service.telemetry (with a non-8888 port), so this
+  # pin is omitted to avoid a merge race over the same key.
   telemetry:
     metrics:
       level: none
+  {{- end }}
   extensions:
     - sigv4auth/cw_k8s_ci_v0_cwotel
     - nodemetadatacache/cw_k8s_ci_v0

--- a/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-config.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-config.tpl
@@ -829,12 +829,14 @@ exporters:
 {{- end }}
 
 service:
-  {{- if not .Values.selfTelemetry.enabled }}
+  {{- $selfTelemetry := .Values.selfTelemetry | default dict }}
+  {{- $selfTelemetryPort := include "cloudwatch-agent.self-telemetry-port" (dict "agentName" .Values.otelContainerInsights.targetAgent "context" .) }}
+  {{- if not (and $selfTelemetry.enabled $selfTelemetryPort) }}
   # Pin internal self-telemetry off. Without this the collector falls back to its
   # built-in default (metrics level Normal + a Prometheus reader on localhost:8888),
   # which collides with the co-scheduled cluster-scraper on the node's :8888.
-  # When selfTelemetry is enabled it owns service.telemetry (with a non-8888 port), so this
-  # pin is omitted to avoid a merge race over the same key.
+  # Only omitted when THIS agent has a resolved self-telemetry port (so it actually owns
+  # service.telemetry on a non-8888 port); the global flag alone is not enough.
   telemetry:
     metrics:
       level: none

--- a/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-config.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-config.tpl
@@ -827,12 +827,16 @@ exporters:
 {{- end }}
 
 service:
+  {{- if not .Values.selfTelemetry.enabled }}
   # Pin internal self-telemetry off. Without this the collector falls back to its
   # built-in default (metrics level Normal + a Prometheus reader on localhost:8888),
   # which collides with the co-scheduled cluster-scraper on the node's :8888.
+  # When selfTelemetry is enabled it owns service.telemetry (with a non-8888 port), so this
+  # pin is omitted to avoid a merge race over the same key.
   telemetry:
     metrics:
       level: none
+  {{- end }}
   extensions:
     - sigv4auth/cw_k8s_ci_v0_metrics_dest
 {{- if .Values.otelContainerInsights.logs.enabled }}

--- a/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-config.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-config.tpl
@@ -441,7 +441,9 @@ processors:
       metadata:
         - k8s.pod.uid
         - k8s.node.name
+{{- if .Values.otelContainerInsights.watchReplicaset }}
         - k8s.deployment.name
+{{- end }}
         - k8s.statefulset.name
         - k8s.daemonset.name
         - k8s.replicaset.name

--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
@@ -102,11 +102,11 @@ spec:
   {{- end }}
   hostNetwork: {{ $agent.hostNetwork }}
   {{- if eq ($agent.config | toString) "default:otel" }}
-  config: {{ include "cloudwatch-agent.modify-config" (merge (dict "Config" (include "cloudwatch-agent.build-config-default-otel" (dict "agentName" $agent.name "context" $) | fromJson)) $ ) }}
+  config: {{ include "cloudwatch-agent.modify-config" (merge (dict "Config" (include "cloudwatch-agent.build-config-default-otel" (dict "agentName" $agent.name "context" $) | fromJson) "agentName" $agent.name) $ ) }}
   {{- else if and $agent.config (ne ($agent.config | toString) "default") }}
-  config: {{ include "cloudwatch-agent.modify-config" (merge (dict "Config" $agent.config) $ ) }}
+  config: {{ include "cloudwatch-agent.modify-config" (merge (dict "Config" $agent.config "agentName" $agent.name) $ ) }}
   {{- else }}
-  config: {{ include "cloudwatch-agent.modify-config" (merge (dict "Config" (include "cloudwatch-agent.build-default-config" (dict "agentName" $agent.name "context" $) | fromJson)) $ ) }}
+  config: {{ include "cloudwatch-agent.modify-config" (merge (dict "Config" (include "cloudwatch-agent.build-default-config" (dict "agentName" $agent.name "context" $) | fromJson) "agentName" $agent.name) $ ) }}
   {{- end }}
   {{- $generatedOtelConfig := include "cloudwatch-agent.build-default-otel-config" (dict "agentName" $agent.name "context" $) -}}
   {{- if $agent.otelConfig }}

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -1132,6 +1132,10 @@ containerInsights:
   enabled: true
   ## The agent in the agents array that receives legacy Container Insights config.
   targetAgent: "cloudwatch-agent"
+  ## Watch ReplicaSets cluster-wide to attribute pods to their Deployment (sets
+  ## k8s.deployment.name). Set to false to stop the cluster-wide ReplicaSet informer;
+  ## pods keep k8s.replicaset.name (from ownerRef, no informer). Default true.
+  watchReplicaset: true
 
 ## Controls the Application Signals pipeline (application performance monitoring via traces and metrics).
 applicationSignals:
@@ -1159,6 +1163,11 @@ applicationSignals:
 ##
 otelContainerInsights:
   enabled: false
+  ## Watch ReplicaSets to attribute pods to their Deployment via the k8sattributes
+  ## processor (adds k8s.deployment.name to the extract). Set to false to drop
+  ## k8s.deployment.name, which stops the k8sattributes ReplicaSet informer on every
+  ## agent running this pipeline; k8s.replicaset.name is unaffected. Default true.
+  watchReplicaset: true
   ## OTEL-native CI log pipelines (application, host).
   ## Only takes effect when otelContainerInsights.enabled is true.
   logs:

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -1195,3 +1195,36 @@ otelContainerInsights:
       enabled: true
       ## Namespace where KEDA is deployed.
       namespace: "keda"
+
+## ══════════════════════════════════════════════════════════════════════════════
+## Self Telemetry
+## ══════════════════════════════════════════════════════════════════════════════
+##
+## Serves the agent's own metrics on a loopback prometheus endpoint: the
+## collector's otelcol_* metrics plus the discovery and scrape state of every
+## prometheus receiver, including the Telegraf prometheus plugin. This is how a
+## scrape pool that discovered nothing becomes visible, via
+## prometheus_target_scrape_pool_targets reaching zero.
+##
+## The endpoint is bound to 127.0.0.1 and there is no bind address option, so
+## enabling it never publishes anything off the node and adds no Service port.
+## Nothing is emitted to CloudWatch on its own.
+##
+## To get these metrics anywhere, point the agent's own prometheus scrape config
+## at the endpoint on the same node - the agent scrapes itself. See
+## https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-PrometheusEC2.html
+## and set agents[].config.logs.metrics_collected.prometheus with a scrape job
+## targeting 127.0.0.1:<port>.
+##
+selfTelemetry:
+  enabled: false
+  ## The agents that serve the endpoint, and the loopback port each one binds. An
+  ## agent with no entry here does not serve it at all.
+  ##
+  ## Agents run with hostNetwork, so they share the node's port space and cannot
+  ## share a port: a port already in use makes the agent fail to start rather
+  ## than degrade. These defaults also sit below the 32768-60999 ephemeral range,
+  ## so the kernel cannot hand the port to an outbound connection first.
+  ports:
+    cloudwatch-agent: 28888
+    cloudwatch-agent-cluster-scraper: 28889


### PR DESCRIPTION
## What
- **`selfTelemetry.enabled`** (default `false`) + per-agent **`selfTelemetry.ports`**: injects `agent.self_telemetry` so each selected agent serves its own prometheus metrics on a loopback port.
- **`watchReplicaset`** toggle (default `true`), per pipeline:
  - `containerInsights.watchReplicaset` (ECI) → emits `watch_replicaset: false` into the generated agent config when off.
  - `otelContainerInsights.watchReplicaset` (OCI) → drops `k8s.deployment.name` from the k8sattributes extract (node + cluster-scraper) when off, stopping the ReplicaSet informer.

At their defaults, rendered manifests are unchanged.

## Testing
`helm lint` clean. `helm template` regression: with both toggles at defaults, rendered output is byte-identical to the base. Full matrix verified on a live EKS cluster — ECI-only / OCI-only / ECI+OCI × watchReplicaset{on,off} × selfTelemetry{on,off}: agent config correctness, pod health, loopback endpoint serving/closed as configured, and Container Insights metrics in CloudWatch.

## Merge order (3-repo stack) — this PR is #3
1. contrib — https://github.com/amazon-contributing/opentelemetry-collector-contrib/pull/623
2. agent — https://github.com/aws/amazon-cloudwatch-agent/pull/2246
3. chart (this PR) — https://github.com/aws-observability/helm-charts/pull/354

These toggles require an agent build that includes the agent PR, so this chart PR merges last.