### PR TITLE
fix(container-insights): drop misleading zero cAdvisor metrics for VM-isolated pods

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-config.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-config.tpl
@@ -537,6 +537,7 @@ processors:
         - attributes["container"] == "" and attributes["pod"] == nil
         - attributes["container"] == nil and attributes["pod"] == ""
         - attributes["container"] == nil and attributes["pod"] == nil
+        - IsMatch(attributes["id"], "^/kubepods\\.slice/kubepods-pod[^/]+\\.slice$")
 
   filter/cw_k8s_ci_v0_cadvisor_pod:
     error_mode: ignore


### PR DESCRIPTION
## Problem

For **VM-isolated pods** (pods whose workload runs inside a micro-VM), OTel Container Insights reports pod CPU, memory, and network as **`0`** instead of nothing.

Why: the workload runs *inside the VM*, so on the host there's only an empty pod-slice cgroup — no real container to measure. cAdvisor scrapes that empty slice and reads `0` for everything. On a dashboard this looks like a **healthy, idle pod**, which is worse than a blank — it looks correct but isn't.

## Fix

One filter clause in `filter/cw_k8s_ci_v0_cadvisor_empty` (`templates/linux/_otel-container-insights-config.tpl`):

```yaml
- IsMatch(attributes["id"], "^/kubepods\\.slice/kubepods-pod[^/]+\\.slice$")
```

This drops the empty pod-slice datapoint before it's exported.

**Why the existing clauses miss it:** they check the `container`/`pod` *labels* for empty. A VM-isolated pod has a valid `pod` label, so it slips through. The new clause instead matches the **cgroup id shape**, which is unique to these pods:

- Normal pod: `…/kubepods-<qos>.slice/kubepods-<qos>-pod<uid>.slice/cri-containerd-<id>.scope`
- VM-isolated pod: `/kubepods.slice/kubepods-pod<uid>.slice`  ← bare, no QoS segment, no container scope

The regex is anchored (`^…$`), so it can **only** match the bare shape — a normal pod's id can never match.

## Metrics dropped

The clause drops the pod's whole empty pod-slice datapoint. On a live VM-isolated pod that was **43 cAdvisor series**.

**34 series that read `0`** — the misleading zeros (all CPU / memory / network / pressure usage):

```
container_cpu_cfs_burst_periods_total
container_cpu_cfs_burst_seconds_total
container_cpu_cfs_throttled_periods_total
container_cpu_cfs_throttled_seconds_total
container_cpu_load_average_10s
container_cpu_load_d_average_10s
container_cpu_system_seconds_total
container_cpu_user_seconds_total
container_file_descriptors
container_memory_cache
container_memory_failcnt
container_memory_failures_total
container_memory_kernel_usage
container_memory_mapped_file
container_memory_max_usage_bytes
container_memory_rss
container_memory_swap
container_memory_total_active_file_bytes
container_memory_total_inactive_file_bytes
container_memory_usage_bytes
container_memory_working_set_bytes
container_oom_events_total
container_pressure_cpu_stalled_seconds_total
container_pressure_cpu_waiting_seconds_total
container_pressure_io_stalled_seconds_total
container_pressure_io_waiting_seconds_total
container_pressure_memory_stalled_seconds_total
container_pressure_memory_waiting_seconds_total
container_processes
container_sockets
container_spec_memory_reservation_limit_bytes
container_spec_memory_swap_limit_bytes
container_tasks_state
container_threads
```

**9 series that were non-zero** — but these are the empty slice's *config/metadata*, not usage (VM CPU/memory limits, cgroup weight, timestamps, health flag, thread ceiling). They describe the VM wrapper, not the workload, and there's nothing to pair them with once usage is gone, so they go too:

```
container_cpu_cfs_periods_total       (= 2)
container_health_state                (= -1)
container_last_seen
container_spec_cpu_period             (= 100000)
container_spec_cpu_quota              (= 200000)
container_spec_cpu_shares             (= 2046)
container_spec_memory_limit_bytes     (≈ 1.5 GB)
container_start_time_seconds
container_threads_max                 (= 1048576)
```

## Verified safe (live cluster)

Tested on a real EKS cluster with a VM-isolated pod next to normal pods on the same node and same agent:

- **VM-isolated pod:** the false zeros are gone. Its real health signals (`pod_status_*`, from kube-state-metrics) are untouched.
- **Normal pods:** completely unaffected — full metric set with real values. **Zero false drops.**
- **No `pod_*` CI metric is lost.** The `pod_cpu_utilization` / `pod_cpu_limit`-style metrics come from the separate Classic pipeline, which this change doesn't touch.

## Not in scope

This removes the false zeros. It does **not** yet surface the pod's *real* in-VM usage — that data lives inside the VM and reaches the node via the kubelet Summary API, which is a separate, larger change.
