### PR TITLE
Correlate DRA-allocated GPU/Neuron/EFA devices to pods in OTEL Container Insights

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/cloudwatch-agent-clusterrole.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/cloudwatch-agent-clusterrole.yaml
@@ -31,6 +31,9 @@ rules:
 - apiGroups: [ "" ]
   resources: [ "nodes/metrics" ]
   verbs: [ "get" ]
+- apiGroups: [ "resource.k8s.io" ]
+  resources: [ "resourceclaims", "resourceslices" ]
+  verbs: [ "get", "list", "watch" ]
 {{- end }}
 - apiGroups: [ "" ]
   resources: [ "configmaps" ]

--- a/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-config.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-config.tpl
@@ -566,11 +566,18 @@ processors:
           - set(attributes["namespace"], resource.attributes["namespace"]) where resource.attributes["namespace"] != nil
 
   {{- if .Values.dcgmExporter.enabled }}
+  # Group by both the native dcgm-exporter labels AND the OTEL
+  # semantic labels the awsdevicepodcorrelation processor sets. This moves whichever set is present onto the resource
+  # so DRA GPUs get resource-level pod identity + k8sattributes workload enrichment,
+  # matching the device-plugin path (and the efa/neuron pipelines).
   groupbyattrs/cw_k8s_ci_v0_dcgm:
     keys:
       - pod
       - namespace
       - container
+      - k8s.pod.name
+      - k8s.namespace.name
+      - k8s.container.name
 
   transform/cw_k8s_ci_v0_dcgm_promote:
     error_mode: ignore
@@ -648,6 +655,33 @@ processors:
         device_id_attribute: aws.efa.device
         resource_names:
           - vpc.amazonaws.com/efa
+    # DRA (Dynamic Resource Allocation) correlation paths. Keyed by DRA driver
+    # names; the processor watches ResourceClaims/Pods via the K8s API.
+    dra_device_types:
+      - name: efa-dra
+        device_id_attribute: aws.efa.device
+        driver_names:
+          - dra.net
+        # EFA DRA device name (pci-0000-00-1f-0) != metric label (rdmap0s31);
+        # source the key from the ResourceSlice attribute dra.net/rdmaDevice (Fix B).
+        dra_device_id_attribute: dra.net/rdmaDevice
+      - name: neuron-dra
+        device_id_attribute: neurondevice
+        driver_names:
+          - neuron.aws.com
+        dra_device_id_pattern: 'neuron-device-(\d+)'
+      - name: gpu-dra
+        device_id_attribute: gpu
+        driver_names:
+          - gpu.nvidia.com
+        dra_device_id_pattern: 'gpu-(\d+)'
+    node_name: ${env:K8S_NODE_NAME}
+
+  groupbyattrs/cw_k8s_ci_v0_efa:
+    keys:
+      - k8s.pod.name
+      - k8s.namespace.name
+      - k8s.container.name
 
   transform/cw_k8s_ci_v0_efa_promote:
     error_mode: ignore
@@ -890,7 +924,7 @@ service:
     {{- if .Values.dcgmExporter.enabled }}
     metrics/cw_k8s_ci_v0_dcgm:
       receivers: [prometheus/cw_k8s_ci_v0_dcgm]
-      processors: [filter/cw_k8s_ci_v0_scrape_metadata, transform/cw_k8s_ci_v0_set_unit, metricstarttime/cw_k8s_ci_v0, transform/cw_k8s_ci_v0_set_cluster_name, groupbyattrs/cw_k8s_ci_v0_dcgm, transform/cw_k8s_ci_v0_dcgm_promote, k8sattributes/cw_k8s_ci_v0_pod, transform/cw_k8s_ci_v0_set_node_name, transform/cw_k8s_ci_v0_promote_node_name, k8sattributes/cw_k8s_ci_v0_node, resourcedetection/cw_k8s_ci_v0, transform/cw_k8s_ci_v0_set_scope_dcgm, transform/cw_k8s_ci_v0_clear_schema_url, transform/cw_k8s_ci_v0_set_cloud_resource_id, transform/cw_k8s_ci_v0_set_workload, awsattributelimit/cw_k8s_ci_v0, batch/cw_k8s_ci_v0_metrics_dest]
+      processors: [filter/cw_k8s_ci_v0_scrape_metadata, transform/cw_k8s_ci_v0_set_unit, metricstarttime/cw_k8s_ci_v0, transform/cw_k8s_ci_v0_set_cluster_name, awsdevicepodcorrelation/cw_k8s_ci_v0, groupbyattrs/cw_k8s_ci_v0_dcgm, transform/cw_k8s_ci_v0_dcgm_promote, k8sattributes/cw_k8s_ci_v0_pod, transform/cw_k8s_ci_v0_set_node_name, transform/cw_k8s_ci_v0_promote_node_name, k8sattributes/cw_k8s_ci_v0_node, resourcedetection/cw_k8s_ci_v0, transform/cw_k8s_ci_v0_set_scope_dcgm, transform/cw_k8s_ci_v0_clear_schema_url, transform/cw_k8s_ci_v0_set_cloud_resource_id, transform/cw_k8s_ci_v0_set_workload, awsattributelimit/cw_k8s_ci_v0, batch/cw_k8s_ci_v0_metrics_dest]
       exporters:
         - otlphttp/cw_k8s_ci_v0_metrics_dest
     {{- end }}
@@ -932,6 +966,7 @@ service:
         - transform/cw_k8s_ci_v0_set_scope_efa
         - transform/cw_k8s_ci_v0_set_cluster_name
         - awsdevicepodcorrelation/cw_k8s_ci_v0
+        - groupbyattrs/cw_k8s_ci_v0_efa
         - transform/cw_k8s_ci_v0_efa_promote
         - transform/cw_k8s_ci_v0_set_node_name
         - transform/cw_k8s_ci_v0_promote_node_name


### PR DESCRIPTION
## What

Adds device-to-pod correlation for devices allocated via Kubernetes Dynamic
Resource Allocation (DRA) to the OTEL Container Insights pipeline, so GPU,
Neuron, and EFA metrics are attributed to `k8s.pod.name` / `k8s.namespace.name`
/ `k8s.container.name` when a pod obtains its device through a
DRA driver instead of the classic device plugin.

Changes (all under `charts/amazon-cloudwatch-observability`):

- **`awsdevicepodcorrelation` processor** - add `dra_device_types` and
  `node_name`. The processor watches ResourceClaims/Pods via the K8s API:
  - `efa-dra` (driver `dra.net`) keys on the `dra.net/rdmaDevice` ResourceSlice
    attribute, because the DRA device name (`pci-0000-00-1f-0`) doesn't match the
    metric label (`rdmap0s31`).
  - `gpu-dra` (`gpu.nvidia.com`) and `neuron-dra` (`neuron.aws.com`) extract the
    device index from the DRA device name (`gpu-(\d+)`, `neuron-device-(\d+)`).
- **dcgm pipeline** - run the processor before groupbyattrs and add k8s.* group keys so DRA GPUs get resource-level pod identity + workload enrichment. There is intentionally no device-plugin gpu entry in device_types (dcgm-exporter self-correlates device-plugin GPUs), so on the device-plugin path the processor makes no GPU change; it only acts on GPUs via gpu-dra when a DRA claim exists. Mixed device-plugin/DRA GPU nodes resolve correctly - each datapoint carries only one identity set.
- **efa pipeline** - add a `groupbyattrs` split before pod-identity promotion,
  so a node with multiple EFA devices belonging to different pods doesn't
  collapse every device onto one pod (mirrors what the dcgm/neuron pipelines
  already do).
- **ClusterRole** - grant read (`get`/`list`/`watch`) on
  `resource.k8s.io` `resourceclaims`/`resourceslices`, scoped under
  `otelContainerInsights.enabled` (the only consumer of the DRA path).

## Why

Exporters that self-correlate GPUs/Neuron devices to pods (dcgm-exporter,
neuron-monitor) do so via the kubelet PodResources API keyed on device-plugin
device IDs. DRA-allocated devices are handled by DRA drivers and don't surface
there the same way, so those metrics lose pod attribution under DRA. This adds
the DRA-aware correlation the exporters can't do on their own.

## Blast radius

Everything except the RBAC rule is inside the OTEL Container Insights config,
rendered only when `otelContainerInsights.enabled=true`, and the dcgm/efa parts
are further gated by `dcgmExporter.enabled` / the EFA pipeline. The RBAC rule is
also gated to `otelContainerInsights.enabled`. The device-plugin paths are
unchanged: the processor is a no-op on device-plugin GPU, the added dcgm group
keys are absent there, and the EFA split is a no-op for the single-device case
(it only fixes the multi-device-multi-pod collapse).

## Testing

- `helm lint`.
- Chart flag-matrix render test (`tests/flag_matrix.sh`) - all 8
  enabled/logs/containerLogs combinations pass.
- End-to-end on EKS 1.34 with an agent image built from the matching
  `awsdevicepodcorrelation` processor change, across GPU (g6), Neuron (trn1),
  and EFA (c5n, `dra.net`), single- and multi-device. Verified via the
  CloudWatch metrics store (PromQL) that each distinct device correlates to its
  own pod (e.g. `gpu=2`/`gpu=3` and `rdmap16s25`/`rdmap16s26` map to different
  pods) and unclaimed devices carry no pod attributes.

## Dependency

The correlation logic lives in the `awsdevicepodcorrelation` processor in the
CloudWatch Agent (opentelemetry-collector-contrib fork). This chart change
activates and configures it; it takes effect once the agent image includes the
processor's DRA support.
