### PR TITLE
Add GKE as a supported k8sMode

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/gcp-critical-pods-resourcequota.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/gcp-critical-pods-resourcequota.yaml
@@ -1,18 +1,18 @@
 {{- if eq .Values.k8sMode "GKE" }}
 {{- /*
-GKE only admits pods that use the reserved system-node-critical / system-cluster-critical PriorityClasses in a
-namespace that has a ResourceQuota matching those classes. The agent runs at system-node-critical, so without
-this quota its pods are rejected at admission on GKE. GKE-only. EKS and AKS do not gate priority classes this way.
+On GKE, a pod that uses the system-node-critical or system-cluster-critical PriorityClass is only admitted in a
+namespace that has a ResourceQuota with a scopeSelector that matches that class. The agent and fluent-bit run
+at system-node-critical by default.
 Ref: https://kubernetes.io/docs/concepts/policy/resource-quotas/#limit-priority-class-consumption-by-default
 */ -}}
 apiVersion: v1
 kind: ResourceQuota
 metadata:
+  labels:
+    {{- include "amazon-cloudwatch-observability.labels" . | nindent 4}}
   name: gcp-critical-pods
   namespace: {{ .Release.Namespace }}
 spec:
-  hard:
-    pods: "1G"
   scopeSelector:
     matchExpressions:
       - operator: In

--- a/charts/amazon-cloudwatch-observability/templates/gcp-critical-pods-resourcequota.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/gcp-critical-pods-resourcequota.yaml
@@ -1,0 +1,23 @@
+{{- if eq .Values.k8sMode "GKE" }}
+{{- /*
+GKE only admits pods that use the reserved system-node-critical / system-cluster-critical PriorityClasses in a
+namespace that has a ResourceQuota matching those classes. The agent runs at system-node-critical, so without
+this quota its pods are rejected at admission on GKE. GKE-only. EKS and AKS do not gate priority classes this way.
+Ref: https://kubernetes.io/docs/concepts/policy/resource-quotas/#limit-priority-class-consumption-by-default
+*/ -}}
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: gcp-critical-pods
+  namespace: {{ .Release.Namespace }}
+spec:
+  hard:
+    pods: "1G"
+  scopeSelector:
+    matchExpressions:
+      - operator: In
+        scopeName: PriorityClass
+        values:
+          - system-node-critical
+          - system-cluster-critical
+{{- end }}

--- a/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-cluster-scraper-config.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-cluster-scraper-config.tpl
@@ -17,9 +17,9 @@ receivers:
           tls_config:
             ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
             insecure_skip_verify: false
-            {{- if eq .Values.k8sMode "AKS" }}
-            # Endpoints SD dials the apiserver by IP. On AKS the managed control-plane endpoint IP is
-            # not in the serving cert's SANs (only DNS names + the ClusterIP are), so verify against a
+            {{- if or (eq .Values.k8sMode "AKS") (eq .Values.k8sMode "GKE") }}
+            # Endpoints SD dials the apiserver by IP. On AKS and GKE the managed control-plane endpoint IP
+            # is not in the serving cert's SANs (only DNS names + the ClusterIP are), so verify against a
             # DNS SAN instead. On EKS the endpoint IPs are in the SANs, so this is not needed there.
             server_name: kubernetes.default.svc
             {{- end }}
@@ -256,6 +256,18 @@ processors:
         cloud.region: { enabled: true }
         host.id: { enabled: false }
         host.name: { enabled: false }
+    {{- else if eq .Values.k8sMode "GKE" }}
+    detectors: [gcp]
+    gcp:
+      resource_attributes:
+        cloud.account.id: { enabled: true }
+        cloud.availability_zone: { enabled: true }
+        cloud.platform: { enabled: true }
+        cloud.provider: { enabled: true }
+        cloud.region: { enabled: true }
+        host.id: { enabled: false }
+        host.name: { enabled: false }
+        k8s.cluster.name: { enabled: false }
     {{- else }}
     detectors: [eks, ec2]
     ec2:
@@ -335,6 +347,18 @@ processors:
         cloud.region: { enabled: true }
         host.id: { enabled: false }
         host.name: { enabled: false }
+    {{- else if eq .Values.k8sMode "GKE" }}
+    detectors: [gcp]
+    gcp:
+      resource_attributes:
+        cloud.account.id: { enabled: true }
+        cloud.availability_zone: { enabled: true }
+        cloud.platform: { enabled: true }
+        cloud.provider: { enabled: true }
+        cloud.region: { enabled: true }
+        host.id: { enabled: false }
+        host.name: { enabled: false }
+        k8s.cluster.name: { enabled: false }
     {{- else }}
     detectors: [eks, ec2]
     ec2:
@@ -527,6 +551,18 @@ processors:
         cloud.region: { enabled: true }
         host.id: { enabled: false }
         host.name: { enabled: false }
+    {{- else if eq .Values.k8sMode "GKE" }}
+    detectors: [gcp]
+    gcp:
+      resource_attributes:
+        cloud.account.id: { enabled: true }
+        cloud.availability_zone: { enabled: true }
+        cloud.platform: { enabled: true }
+        cloud.provider: { enabled: true }
+        cloud.region: { enabled: true }
+        host.id: { enabled: false }
+        host.name: { enabled: false }
+        k8s.cluster.name: { enabled: false }
     {{- else }}
     detectors: [eks, ec2]
     ec2:
@@ -587,6 +623,12 @@ processors:
           - set(resource.attributes["cloud.resource_id"], Concat(["/subscriptions/", resource.attributes["cloud.account.id"], "/resourceGroups/", resource.attributes["_tmp.azure.resourcegroup.name"], "/providers/Microsoft.ContainerService/managedClusters/", resource.attributes["k8s.cluster.name"]], ""))
             where resource.attributes["cloud.account.id"] != nil and resource.attributes["_tmp.azure.resourcegroup.name"] != nil and resource.attributes["k8s.cluster.name"] != nil
           - delete_key(resource.attributes, "_tmp.azure.resourcegroup.name")
+          {{- else if eq .Values.k8sMode "GKE" }}
+          {{/* GKE full resource name: zones/<zone> (zonal) or locations/<region> (regional). */}}
+          - set(resource.attributes["cloud.resource_id"], Concat(["//container.googleapis.com/projects/", resource.attributes["cloud.account.id"], "/zones/", resource.attributes["cloud.availability_zone"], "/clusters/", resource.attributes["k8s.cluster.name"]], ""))
+            where resource.attributes["cloud.account.id"] != nil and resource.attributes["cloud.availability_zone"] != nil and resource.attributes["k8s.cluster.name"] != nil
+          - set(resource.attributes["cloud.resource_id"], Concat(["//container.googleapis.com/projects/", resource.attributes["cloud.account.id"], "/locations/", resource.attributes["cloud.region"], "/clusters/", resource.attributes["k8s.cluster.name"]], ""))
+            where resource.attributes["cloud.resource_id"] == nil and resource.attributes["cloud.account.id"] != nil and resource.attributes["cloud.region"] != nil and resource.attributes["k8s.cluster.name"] != nil
           {{- else }}
           - set(resource.attributes["cloud.resource_id"], Concat(["arn:aws:eks:", resource.attributes["cloud.region"], ":", resource.attributes["cloud.account.id"], ":cluster/", resource.attributes["k8s.cluster.name"]], ""))
             where resource.attributes["cloud.region"] != nil and resource.attributes["cloud.account.id"] != nil and resource.attributes["k8s.cluster.name"] != nil

--- a/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-config.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-config.tpl
@@ -393,6 +393,18 @@ processors:
         cloud.region: { enabled: true }
         host.id: { enabled: true }
         host.name: { enabled: true }
+    {{- else if eq .Values.k8sMode "GKE" }}
+    detectors: [gcp]
+    gcp:
+      resource_attributes:
+        cloud.account.id: { enabled: true }
+        cloud.availability_zone: { enabled: true }
+        cloud.platform: { enabled: true }
+        cloud.provider: { enabled: true }
+        cloud.region: { enabled: true }
+        host.id: { enabled: true }
+        host.name: { enabled: true }
+        k8s.cluster.name: { enabled: false }
     {{- else }}
     detectors: [eks, ec2]
     ec2:
@@ -494,6 +506,12 @@ processors:
           - set(resource.attributes["cloud.resource_id"], Concat(["/subscriptions/", resource.attributes["cloud.account.id"], "/resourceGroups/", resource.attributes["_tmp.azure.resourcegroup.name"], "/providers/Microsoft.ContainerService/managedClusters/", resource.attributes["k8s.cluster.name"]], ""))
             where resource.attributes["cloud.account.id"] != nil and resource.attributes["_tmp.azure.resourcegroup.name"] != nil and resource.attributes["k8s.cluster.name"] != nil
           - delete_key(resource.attributes, "_tmp.azure.resourcegroup.name")
+          {{- else if eq .Values.k8sMode "GKE" }}
+          {{/* GKE full resource name: zones/<zone> (zonal) or locations/<region> (regional). */}}
+          - set(resource.attributes["cloud.resource_id"], Concat(["//container.googleapis.com/projects/", resource.attributes["cloud.account.id"], "/zones/", resource.attributes["cloud.availability_zone"], "/clusters/", resource.attributes["k8s.cluster.name"]], ""))
+            where resource.attributes["cloud.account.id"] != nil and resource.attributes["cloud.availability_zone"] != nil and resource.attributes["k8s.cluster.name"] != nil
+          - set(resource.attributes["cloud.resource_id"], Concat(["//container.googleapis.com/projects/", resource.attributes["cloud.account.id"], "/locations/", resource.attributes["cloud.region"], "/clusters/", resource.attributes["k8s.cluster.name"]], ""))
+            where resource.attributes["cloud.resource_id"] == nil and resource.attributes["cloud.account.id"] != nil and resource.attributes["cloud.region"] != nil and resource.attributes["k8s.cluster.name"] != nil
           {{- else }}
           - set(resource.attributes["cloud.resource_id"], Concat(["arn:aws:eks:", resource.attributes["cloud.region"], ":", resource.attributes["cloud.account.id"], ":cluster/", resource.attributes["k8s.cluster.name"]], ""))
             where resource.attributes["cloud.region"] != nil and resource.attributes["cloud.account.id"] != nil and resource.attributes["k8s.cluster.name"] != nil
@@ -518,7 +536,7 @@ processors:
           - set(resource.attributes["k8s.workload.type"], "CronJob") where resource.attributes["k8s.cronjob.name"] != nil and resource.attributes["k8s.workload.type"] == nil
           - set(resource.attributes["k8s.workload.name"], resource.attributes["k8s.replicaset.name"]) where resource.attributes["k8s.workload.name"] == nil and resource.attributes["k8s.replicaset.name"] != nil
           - set(resource.attributes["k8s.workload.type"], "ReplicaSet") where resource.attributes["k8s.replicaset.name"] != nil and resource.attributes["k8s.workload.type"] == nil
-          {{- if eq .Values.k8sMode "AKS" }}
+          {{- if or (eq .Values.k8sMode "AKS") (eq .Values.k8sMode "GKE") }}
           - set(resource.attributes["service.name"], resource.attributes["k8s.workload.name"]) where resource.attributes["service.name"] == nil and resource.attributes["k8s.workload.name"] != nil
           - set(resource.attributes["service.namespace"], resource.attributes["k8s.namespace.name"]) where resource.attributes["service.namespace"] == nil and resource.attributes["k8s.namespace.name"] != nil
           - set(resource.attributes["deployment.environment.name"], Concat([resource.attributes["cloud.platform"], Concat([resource.attributes["k8s.cluster.name"], resource.attributes["k8s.namespace.name"]], "/")], ":")) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["cloud.platform"] != nil and resource.attributes["k8s.cluster.name"] != nil and resource.attributes["k8s.namespace.name"] != nil
@@ -707,7 +725,7 @@ processors:
           # Logs need service.name; metrics use k8s.workload.name directly, except on
           # AKS — see transform/cw_k8s_ci_v0_set_workload.
           - set(attributes["service.name"], attributes["k8s.workload.name"]) where attributes["service.name"] == nil and attributes["k8s.workload.name"] != nil
-          {{- if eq .Values.k8sMode "AKS" }}
+          {{- if or (eq .Values.k8sMode "AKS") (eq .Values.k8sMode "GKE") }}
           - set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where attributes["service.namespace"] == nil and attributes["k8s.namespace.name"] != nil
           - set(attributes["deployment.environment.name"], Concat([attributes["cloud.platform"], Concat([attributes["k8s.cluster.name"], attributes["k8s.namespace.name"]], "/")], ":")) where attributes["deployment.environment.name"] == nil and attributes["cloud.platform"] != nil and attributes["k8s.cluster.name"] != nil and attributes["k8s.namespace.name"] != nil
           {{- end }}
@@ -733,6 +751,12 @@ processors:
           - set(attributes["cloud.resource_id"], Concat(["/subscriptions/", attributes["cloud.account.id"], "/resourceGroups/", attributes["_tmp.azure.resourcegroup.name"], "/providers/Microsoft.ContainerService/managedClusters/", attributes["k8s.cluster.name"]], ""))
             where attributes["cloud.account.id"] != nil and attributes["_tmp.azure.resourcegroup.name"] != nil and attributes["k8s.cluster.name"] != nil
           - delete_key(attributes, "_tmp.azure.resourcegroup.name")
+          {{- else if eq .Values.k8sMode "GKE" }}
+          {{/* GKE full resource name: zones/<zone> (zonal) or locations/<region> (regional). */}}
+          - set(attributes["cloud.resource_id"], Concat(["//container.googleapis.com/projects/", attributes["cloud.account.id"], "/zones/", attributes["cloud.availability_zone"], "/clusters/", attributes["k8s.cluster.name"]], ""))
+            where attributes["cloud.account.id"] != nil and attributes["cloud.availability_zone"] != nil and attributes["k8s.cluster.name"] != nil
+          - set(attributes["cloud.resource_id"], Concat(["//container.googleapis.com/projects/", attributes["cloud.account.id"], "/locations/", attributes["cloud.region"], "/clusters/", attributes["k8s.cluster.name"]], ""))
+            where attributes["cloud.resource_id"] == nil and attributes["cloud.account.id"] != nil and attributes["cloud.region"] != nil and attributes["k8s.cluster.name"] != nil
           {{- else }}
           - set(attributes["cloud.resource_id"], Concat(["arn:aws:eks:", attributes["cloud.region"], ":", attributes["cloud.account.id"], ":cluster/", attributes["k8s.cluster.name"]], ""))
             where attributes["cloud.region"] != nil and attributes["cloud.account.id"] != nil and attributes["k8s.cluster.name"] != nil

--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
@@ -64,7 +64,10 @@ data:
 {{- $region := .Values.region | required ".Values.region is required." -}}
 {{- $isROSA := eq $.Values.k8sMode "ROSA" -}}
 {{- $isAKS := eq $.Values.k8sMode "AKS" -}}
-{{- if $isAKS }}{{- $_ := $.Values.roleArn | required ".Values.roleArn is required when k8sMode is AKS." -}}{{- end }}
+{{- $isGKE := eq $.Values.k8sMode "GKE" -}}
+{{- /* AKS and GKE both reach AWS via a projected Kubernetes service-account token (web-identity federation). */ -}}
+{{- $isWorkloadIdentity := or $isAKS $isGKE -}}
+{{- if $isWorkloadIdentity }}{{- $_ := $.Values.roleArn | required ".Values.roleArn is required when k8sMode is AKS or GKE." -}}{{- end }}
 {{- range .Values.agents }}
 {{- $agent := mergeOverwrite (deepCopy $.Values.agent) . }}
 {{/* Skip cluster-scraper agent when otelContainerInsights is disabled */}}
@@ -190,7 +193,7 @@ spec:
     name: kubelet-ca
     readOnly: true
     {{ end }}
-    {{ if $isAKS }}
+    {{ if $isWorkloadIdentity }}
   - mountPath: /var/run/secrets/aws
     name: aws-iam-token
     readOnly: true
@@ -265,7 +268,7 @@ spec:
     hostPath:
       path: /etc/kubernetes/kubelet-ca.crt
   {{end }}
-  {{ if $isAKS }}
+  {{ if $isWorkloadIdentity }}
   - name: aws-iam-token
     projected:
       sources:
@@ -298,6 +301,12 @@ spec:
   {{ if $isAKS }}
   - name: RUN_IN_AKS
     value: "True"
+  {{ end }}
+  {{ if $isGKE }}
+  - name: RUN_IN_GKE
+    value: "True"
+  {{ end }}
+  {{ if $isWorkloadIdentity }}
   - name: AWS_WEB_IDENTITY_TOKEN_FILE
     value: /var/run/secrets/aws/token
   - name: AWS_ROLE_ARN

--- a/charts/amazon-cloudwatch-observability/values.yaml
+++ b/charts/amazon-cloudwatch-observability/values.yaml
@@ -18,8 +18,8 @@ adcEndpointOverrides:
   eusc-de-east-1: amazonaws.eu
 ## Provide the Region (this is a required parameter)
 region:
-k8sMode: EKS # can be EKS | ROSA | K8S | AKS
-## IAM role ARN for AKS workload-identity federation (required when k8sMode is AKS)
+k8sMode: EKS # can be EKS | ROSA | K8S | AKS | GKE
+## IAM role ARN for AKS/GKE workload-identity federation (required when k8sMode is AKS or GKE)
 roleArn:
 ## Enable dualstack endpoints for IPv6 support (default: false)
 useDualstackEndpoint: false


### PR DESCRIPTION
### Description of changes

Adds GKE (Google Kubernetes Engine) as a supported k8sMode in a similar way to the existing AKS support. GKE uses the same projected service-account token model as AKS.

Updates the OTel Container Insights to have GKE branches which set:
- `resourcedetection`: attaches `gcp` resource attributes
- `set_cloud_resource_id`: in the metrics and logs for the node and cluster-scraper to set the GKE cluster's Full Resource Name. See https://github.com/aws/amazon-cloudwatch-agent/pull/2258 for details (same setup in both).
- `deployment.environment.name`: evaluates to `{{cloud.platform}}:{{k8s.cluster.name}}/{{k8s.namespace.name}}` just like AKS
- API server endpoints setup matches AKS with `kubernetes.default.svc` workaround.

Includes a new `gcp-critical-pods` ResourceQuota just for GKE. GKE only admits pods that use the reserved `system-node-critical`/`system-cluster-critical` PriorityClasses in a namespace that has a ResourceQuota matching those classes.

https://developers.deepgram.com/docs/gcp-k8s#configure-namespace-resource-quotas-for-gke
> When deploying workloads in a non-default namespace (such as `dg-self-hosted`), GKE does not automatically provision quotas for the `system-node-critical` and `system-cluster-critical` priority classes in that namespace.

> Create a ResourceQuota in your Deepgram namespace to enable these priorities

> [!NOTE]
> Google's documentation unfortunately doesn't explicitly call out the behavior just that:
> https://docs.cloud.google.com/kubernetes-engine/quotas#resource_quotas
>> For clusters with under 100 nodes, GKE applies [Kubernetes resource quota](https://kubernetes.io/docs/concepts/policy/resource-quotas/) to every namespace
>
> Kubernetes documentation discusses the mechanisms of limiting priority class consumption by default, but nothing beyond that
> https://kubernetes.io/docs/concepts/policy/resource-quotas/#limiting-priorityclass-consumption-by-default
>> With this mechanism, operators are able to restrict usage of certain high priority classes to a limited number of namespaces and not every namespace will be able to consume these priority classes by default.

GKE configures and ships a `gcp-critical-pods` quota in its own managed namespaces.
```
NAMESPACE                           NAME                                      REQUEST       LIMIT   AGE
gke-managed-cim                     gcp-critical-pods                         pods: 1/1G            2d4h
gke-managed-networking-dra-driver   gke-managed-networking-dra-driver-quota   pods: 0/1G            2d4h
gke-managed-system                  gcp-critical-pods                         pods: 0/1G            2d4h
kube-system                         gcp-critical-pods                         pods: 22/1G           2d4h
```

The node agent, cluster-scraper agent, and fluent-bit all run as `system-node-critical` by default, so without the quota, the DaemonSets/Deployments fail to create the pods with `Error creating: insufficient quota to match these scopes: [{PriorityClass In [system-node-critical system-cluster-critical]}]`.

### Testing
With registered IAM OIDC Identity Provider and IAM role with trust policy set to:
```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Principal": {
                "Federated": "arn:aws:iam::<ACCOUNT_ID>:oidc-provider/container.googleapis.com/v1/projects/<PROJECT_ID>/locations/us-east1-b/clusters/cwagent-otel-gke"
            },
            "Action": "sts:AssumeRoleWithWebIdentity",
            "Condition": {
                "StringEquals": {
                    "container.googleapis.com/v1/projects/<PROJECT_ID>/locations/us-east1-b/clusters/cwagent-otel-gke:sub": "system:serviceaccount:amazon-cloudwatch:cloudwatch-agent",
                    "container.googleapis.com/v1/projects/<PROJECT_ID>/locations/us-east1-b/clusters/cwagent-otel-gke:aud": "sts.amazonaws.com"
                }
            }
        }
    ]
}
```

Deployed to a GKE cluster and verified that the Helm chart works E2E.
```
helm upgrade --install amazon-cloudwatch-observability aws-observability/amazon-cloudwatch-observability \
  --namespace amazon-cloudwatch --create-namespace \
  --set k8sMode=GKE \
  --set roleArn=arn:aws:iam::<ACCOUNT_ID>:role/cwagent-gke-federation-test \
  --set region=us-east-1 \
  --set clusterName=cwagent-otel-gke \
  --set containerInsights.enabled=false \
  --set containerLogs.enabled=false \
  --set otelContainerInsights.enabled=true \
  --set otelContainerInsights.logs.enabled=true \
  --set-string 'agents[0].name=cloudwatch-agent' \
  --set-string 'agents[0].config=default:otel' \
  --set-string 'agents[1].name=cloudwatch-agent-cluster-scraper' \
  --set-string 'agents[1].mode=deployment' \
  --set-string 'agents[1].config=default' \
  --set agent.image.repositoryDomainMap.public=<ARTIFACT_REGISTRY_REPO> \
  --set agent.image.tag=<TAG>
```

> [!NOTE]
> Container insights application logs work as expected, but host logs are not collected on GKE. The host-log pipeline tails `/var/log/messages`, `/var/log/dmesg`, and `/var/log/secure`, but on the cluster's Container-Optimized OS nodes `/var/log/messages` and `/var/log/secure` don't exist and `/var/log/dmesg` is a directory (COS keeps system logs in the systemd journal, `/var/log/journal`). So the filelog receiver matches no files and the `/aws/otel/containerinsights/<cluster>/host` log group is never created. Application logs (from `/var/log/containers`) and metrics are unaffected.

<img width="2525" height="963" alt="image" src="https://github.com/user-attachments/assets/cf4bb9b1-c122-4752-924a-3cfe32161e91" />

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

