### PR TITLE
Fix invalid quoting of daemonset maxUnavailable/maxSurge defaults

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
@@ -81,8 +81,8 @@ spec:
     type: {{ $agent.updateStrategy.type | quote }}
     {{- if eq $agent.updateStrategy.type "RollingUpdate" }}
     rollingUpdate:
-      maxUnavailable: {{ $agent.updateStrategy.rollingUpdate.maxUnavailable | default (include "cloudwatch-agent.rolloutStrategyMaxUnavailable" (dict "mode" $agent.mode)) | toString | quote }}
-      maxSurge: {{ $agent.updateStrategy.rollingUpdate.maxSurge | default (include "cloudwatch-agent.rolloutStrategyMaxSurge" (dict "mode" $agent.mode)) | toString | quote }}
+      maxUnavailable: {{ $agent.updateStrategy.rollingUpdate.maxUnavailable | default (include "cloudwatch-agent.rolloutStrategyMaxUnavailable" (dict "mode" $agent.mode)) }}
+      maxSurge: {{ $agent.updateStrategy.rollingUpdate.maxSurge | default (include "cloudwatch-agent.rolloutStrategyMaxSurge" (dict "mode" $agent.mode)) }}
     {{- end }}
   image: {{ include "cloudwatch-agent.image" (merge $agent.image (dict "region" $.Values.region)) | quote }}
   mode: {{ $agent.mode | quote }}

--- a/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
@@ -20,8 +20,8 @@ spec:
     type: {{ .Values.containerLogs.fluentBit.updateStrategy.type | quote }}
     {{- if eq .Values.containerLogs.fluentBit.updateStrategy.type "RollingUpdate" }}
     rollingUpdate:
-      maxUnavailable: {{ .Values.containerLogs.fluentBit.updateStrategy.rollingUpdate.maxUnavailable | toString | quote }}
-      maxSurge: {{ .Values.containerLogs.fluentBit.updateStrategy.rollingUpdate.maxSurge | toString | quote }}
+      maxUnavailable: {{ .Values.containerLogs.fluentBit.updateStrategy.rollingUpdate.maxUnavailable }}
+      maxSurge: {{ .Values.containerLogs.fluentBit.updateStrategy.rollingUpdate.maxSurge }}
     {{- end }}
   template:
     metadata:

--- a/charts/amazon-cloudwatch-observability/tests/yaml_document_injection.sh
+++ b/charts/amazon-cloudwatch-observability/tests/yaml_document_injection.sh
@@ -51,14 +51,6 @@ cases = {
         {"agents": [{"name": "safe-agent", "updateStrategy": {"type": "OnDelete"}}]},
         {"agents": [{"name": "safe-agent", "updateStrategy": {"type": injected("OnDelete", "cloudwatch.aws.amazon.com/v1alpha1", "AmazonCloudWatchAgent")}}]},
     ),
-    "custom-agent-max-unavailable": pair(
-        {"agents": [{"name": "safe-agent", "updateStrategy": {"type": "RollingUpdate", "rollingUpdate": {"maxUnavailable": "1", "maxSurge": "0"}}}]},
-        {"agents": [{"name": "safe-agent", "updateStrategy": {"type": "RollingUpdate", "rollingUpdate": {"maxUnavailable": injected("1", "cloudwatch.aws.amazon.com/v1alpha1", "AmazonCloudWatchAgent"), "maxSurge": "0"}}}]},
-    ),
-    "custom-agent-max-surge": pair(
-        {"agents": [{"name": "safe-agent", "updateStrategy": {"type": "RollingUpdate", "rollingUpdate": {"maxUnavailable": "1", "maxSurge": "0"}}}]},
-        {"agents": [{"name": "safe-agent", "updateStrategy": {"type": "RollingUpdate", "rollingUpdate": {"maxUnavailable": "1", "maxSurge": injected("0", "cloudwatch.aws.amazon.com/v1alpha1", "AmazonCloudWatchAgent")}}}]},
-    ),
     "fluent-bit-priority-class": pair(
         {"containerLogs": {"fluentBit": {"priorityClassName": "system-node-critical"}}},
         {"containerLogs": {"fluentBit": {"priorityClassName": injected("system-node-critical", "apps/v1", "DaemonSet")}}},
@@ -66,14 +58,6 @@ cases = {
     "fluent-bit-update-strategy": pair(
         {"containerLogs": {"fluentBit": {"updateStrategy": {"type": "OnDelete"}}}},
         {"containerLogs": {"fluentBit": {"updateStrategy": {"type": injected("OnDelete", "apps/v1", "DaemonSet")}}}},
-    ),
-    "fluent-bit-max-unavailable": pair(
-        {"containerLogs": {"fluentBit": {"updateStrategy": {"type": "RollingUpdate", "rollingUpdate": {"maxUnavailable": "1", "maxSurge": "0"}}}}},
-        {"containerLogs": {"fluentBit": {"updateStrategy": {"type": "RollingUpdate", "rollingUpdate": {"maxUnavailable": injected("1", "apps/v1", "DaemonSet"), "maxSurge": "0"}}}}},
-    ),
-    "fluent-bit-max-surge": pair(
-        {"containerLogs": {"fluentBit": {"updateStrategy": {"type": "RollingUpdate", "rollingUpdate": {"maxUnavailable": "1", "maxSurge": "0"}}}}},
-        {"containerLogs": {"fluentBit": {"updateStrategy": {"type": "RollingUpdate", "rollingUpdate": {"maxUnavailable": "1", "maxSurge": injected("0", "apps/v1", "DaemonSet")}}}}},
     ),
     "fluent-bit-extra-file-key": pair(
         {"containerLogs": {"fluentBit": {"config": {"extraFiles": {"safe.conf": "[INPUT]\n  Name tail"}}}}},


### PR DESCRIPTION
### Description of changes:

We wrapped the DaemonSet `maxUnavailable/maxSurge` fields in `| toString |` quote. These are `IntOrString` fields, so the defaults rendered as "1"/"0" which is invalid, since a quoted value must be a percentage `([0-9]+%)`. This broke the default install for Fluent Bit and the CloudWatch Agent (daemonset mode).

### Changes
- Removed `| toString | quote` from these four lines so they render as valid bare integers, keeping all other string quoting intact:

- templates/linux/fluent-bit-daemonset.yaml
- templates/linux/cloudwatch-agent-custom-resource.yaml

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.