### PR TITLE
Add verify-all gate job in integration test workflow

### DIFF
--- a/.github/workflows/amazon-cloudwatch-observability-integration-test.yaml
+++ b/.github/workflows/amazon-cloudwatch-observability-integration-test.yaml
@@ -298,3 +298,40 @@ jobs:
           command: |
             cd integration-tests/amazon-cloudwatch-observability/terraform/eks/windows
             terraform destroy --auto-approve
+
+  verify-all:
+    name: Verify All Integration Test Jobs
+    needs: [ Build, Minikube-IntegrationTests, EKS-IntegrationTest, EKS-IntegrationTest-Win2022,
+             EKS-IntegrationTest-Win2019 ]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check Job Status
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          failed_jobs=()
+          successful_jobs=()
+
+          # Every needed job must report success. Any other result (failure, cancelled, or
+          # skipped) blocks the merge, so a cancelled or partial run can never appear green.
+          for job in $(echo "$NEEDS_JSON" | jq -r 'keys[]'); do
+            result=$(echo "$NEEDS_JSON" | jq -r ".[\"$job\"].result")
+
+            if [[ "$result" == "success" ]]; then
+              successful_jobs+=("$job")
+            else
+              failed_jobs+=("$job ($result)")
+            fi
+          done
+
+          echo "Successfully validated jobs:"
+          printf '%s\n' "${successful_jobs[@]}"
+
+          if [ ${#failed_jobs[@]} -ne 0 ]; then
+            echo -e "\nJobs that did not succeed:"
+            printf '%s\n' "${failed_jobs[@]}"
+            exit 1
+          fi
+
+          echo -e "\nAll required jobs completed successfully!"


### PR DESCRIPTION
## Description of issue
A recent PR merged even though none of the integration tests passed.

## Description of changes
Adds a `verify-all` job to the `amazon-cloudwatch-observability-integration-test` workflow similar to the existing one in the `amazon-cloudwatch-agent` repo's `PR-test` workflow (https://github.com/aws/amazon-cloudwatch-agent/blob/0b21e7ae80925d46f07f1e9fcad7b18d03e51685/.github/workflows/PR-test.yml#L400-L436). The main difference is that for this job, we treat skipped or cancelled tests as failures as well.

Once this change is merged, we will need to set up a required status check in this repo.

### Testing
https://github.com/aws-observability/helm-charts/actions/runs/33437204643/job/99650499635

```
Successfully validated jobs:
Build

Jobs that did not succeed:
EKS-IntegrationTest (skipped)
EKS-IntegrationTest-Win2019 (skipped)
EKS-IntegrationTest-Win2022 (skipped)
Minikube-IntegrationTests (failure)
Error: Process completed with exit code 1.
```
---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

