### PR TITLE
fix: render IntOrString rollingUpdate values unquoted for integers

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/_helpers.tpl
@@ -311,6 +311,23 @@ Validates metricResolution is in "<N>s" format.
 {{- end -}}
 {{- end -}}
 
+{{/*
+Render a Kubernetes IntOrString value (for example rollingUpdate.maxUnavailable).
+The API accepts either a bare integer or a percentage string, so a plain number
+must not be quoted: "1" is rejected with 'a valid percent string must be a
+numeric string followed by an ending %'. Emit digits bare and quote anything
+else, which keeps percentages valid while still preventing a configured value
+from breaking out of its YAML scalar.
+*/}}
+{{- define "cloudwatch-agent.intOrStringValue" -}}
+{{- $value := . | toString -}}
+{{- if regexMatch "^[0-9]+$" $value -}}
+{{- $value -}}
+{{- else -}}
+{{- $value | quote -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "cloudwatch-agent.updateStrategy" -}}
 {{- if eq .mode "deployment" -}}
 deploymentUpdateStrategy

--- a/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/cloudwatch-agent-custom-resource.yaml
@@ -81,8 +81,8 @@ spec:
     type: {{ $agent.updateStrategy.type | quote }}
     {{- if eq $agent.updateStrategy.type "RollingUpdate" }}
     rollingUpdate:
-      maxUnavailable: {{ $agent.updateStrategy.rollingUpdate.maxUnavailable | default (include "cloudwatch-agent.rolloutStrategyMaxUnavailable" (dict "mode" $agent.mode)) | toString | quote }}
-      maxSurge: {{ $agent.updateStrategy.rollingUpdate.maxSurge | default (include "cloudwatch-agent.rolloutStrategyMaxSurge" (dict "mode" $agent.mode)) | toString | quote }}
+      maxUnavailable: {{ include "cloudwatch-agent.intOrStringValue" ($agent.updateStrategy.rollingUpdate.maxUnavailable | default (include "cloudwatch-agent.rolloutStrategyMaxUnavailable" (dict "mode" $agent.mode))) }}
+      maxSurge: {{ include "cloudwatch-agent.intOrStringValue" ($agent.updateStrategy.rollingUpdate.maxSurge | default (include "cloudwatch-agent.rolloutStrategyMaxSurge" (dict "mode" $agent.mode))) }}
     {{- end }}
   image: {{ include "cloudwatch-agent.image" (merge $agent.image (dict "region" $.Values.region)) | quote }}
   mode: {{ $agent.mode | quote }}

--- a/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
+++ b/charts/amazon-cloudwatch-observability/templates/linux/fluent-bit-daemonset.yaml
@@ -20,8 +20,8 @@ spec:
     type: {{ .Values.containerLogs.fluentBit.updateStrategy.type | quote }}
     {{- if eq .Values.containerLogs.fluentBit.updateStrategy.type "RollingUpdate" }}
     rollingUpdate:
-      maxUnavailable: {{ .Values.containerLogs.fluentBit.updateStrategy.rollingUpdate.maxUnavailable | toString | quote }}
-      maxSurge: {{ .Values.containerLogs.fluentBit.updateStrategy.rollingUpdate.maxSurge | toString | quote }}
+      maxUnavailable: {{ include "cloudwatch-agent.intOrStringValue" .Values.containerLogs.fluentBit.updateStrategy.rollingUpdate.maxUnavailable }}
+      maxSurge: {{ include "cloudwatch-agent.intOrStringValue" .Values.containerLogs.fluentBit.updateStrategy.rollingUpdate.maxSurge }}
     {{- end }}
   template:
     metadata:


### PR DESCRIPTION
## Issue

The fluent-bit DaemonSet is rejected by the Kubernetes API, so `helm install`
reports a failed release and any Terraform/CI that installs the chart exits 1:

```
DaemonSet.apps "fluent-bit" is invalid:
[spec.updateStrategy.rollingUpdate.maxUnavailable: Invalid value: "1": a valid
percent string must be a numeric string followed by an ending '%',
spec.updateStrategy.rollingUpdate.maxSurge: Invalid value: "0": ...]
```

`maxUnavailable` and `maxSurge` are IntOrString fields: the API accepts a bare
integer or a percentage string, so a quoted plain number is neither. #357 added
`| toString | quote` to both, which turns the chart defaults (1 and 0) into "1"
and "0".

This was visible before merge — the `Minikube (feature-targeted-user-config-override)`
check on #357 failed with this exact error:
https://github.com/aws-observability/helm-charts/actions/runs/32889814702/job/97941815243

## Fix

Add a `cloudwatch-agent.intOrStringValue` helper that emits digits bare and quotes
anything else, and use it for both fields in the fluent-bit DaemonSet and the
CloudWatch Agent custom resource. Percentages such as `25%` stay quoted and valid,
and a configured value still cannot break out of its YAML scalar, so the hardening
from #357 is preserved.

The custom resource is included because it received the same quoting and has the
same defect; it is not currently rejected only because the operator's CRD
validation is looser than the DaemonSet API's.

## Testing

All the workflows on this PR should be passing before merging this as a proof of the fix.