### PR TITLE
fix(neuron): keep per-core metrics on nodes running multiple Neuron r…

### DIFF
--- a/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-config.tpl
+++ b/charts/amazon-cloudwatch-observability/templates/linux/_otel-container-insights-config.tpl
@@ -624,19 +624,14 @@ processors:
       - k8s.pod.name
       - k8s.namespace.name
       - k8s.container.name
+      - runtime_tag
 
   transform/cw_k8s_ci_v0_neuron_promote:
     error_mode: ignore
     metric_statements:
-      - context: datapoint
+      - context: resource
         statements:
-          - set(resource.attributes["k8s.pod.name"], attributes["k8s.pod.name"]) where attributes["k8s.pod.name"] != nil
-          - set(resource.attributes["k8s.namespace.name"], attributes["k8s.namespace.name"]) where attributes["k8s.namespace.name"] != nil
-          - set(resource.attributes["k8s.container.name"], attributes["k8s.container.name"]) where attributes["k8s.container.name"] != nil
-          - set(resource.attributes["aws.neuron.runtime.tag"], attributes["runtime_tag"]) where attributes["runtime_tag"] != nil
-          - delete_key(attributes, "k8s.pod.name") where attributes["k8s.pod.name"] != nil
-          - delete_key(attributes, "k8s.namespace.name") where attributes["k8s.namespace.name"] != nil
-          - delete_key(attributes, "k8s.container.name") where attributes["k8s.container.name"] != nil
+          - set(attributes["aws.neuron.runtime.tag"], attributes["runtime_tag"]) where attributes["runtime_tag"] != nil
           - delete_key(attributes, "runtime_tag") where attributes["runtime_tag"] != nil
 
   transform/cw_k8s_ci_v0_neuron_hw_attrs:


### PR DESCRIPTION
## Description

On a node running more than one Neuron runtime, roughly half of every per-core Neuron
metric is replaced by `0` before export. A NeuronCore pinned at 75% reports idle.

`neuron-monitor` reports **every core from every runtime**: the runtime that owns a core
publishes the real value, and the others publish `0` for that same core. `runtime_tag` is
the only attribute separating those datapoints. Two things in this template destroy it:

1. `groupbyattrs/cw_k8s_ci_v0_neuron` does not group on `runtime_tag`, so every runtime on
   the node lands in a single `ResourceMetrics`.
2. `transform/cw_k8s_ci_v0_neuron_promote` runs in `context: datapoint` while writing
   `resource.attributes`. Resource attributes are per-`ResourceMetrics`, so the statement
   executes once per datapoint and the **last write wins** — then it deletes `runtime_tag`
   from the datapoint.

The two datapoints for a core now share one identity, whichever arrives last wins, and for
one core that is a legitimate-looking `0`.

**This fails silently.** The collision happens in-agent, so the exported surface shows too
*few* series rather than duplicated ones — cardinality is the signal, not duplication. A
2-core node emits 2 series where it should emit 4.

## Fix

```yaml
 groupbyattrs/cw_k8s_ci_v0_neuron:
   keys:
     - k8s.pod.name
     - k8s.namespace.name
     - k8s.container.name
+    - runtime_tag

 transform/cw_k8s_ci_v0_neuron_promote:
-  - context: datapoint
+  - context: resource
```

`runtime_tag` as a grouping key gives each runtime its own `ResourceMetrics`;
`context: resource` is the correct context for writing resource attributes.

The six `pod`/`namespace`/`container` statements are removed as **dead code, not a
behaviour change**: `groupbyattrs` *moves* its grouping keys onto the resource and deletes
the datapoint copies ([`processor.go` `deleteAttributes(requiredAttributes, attributes)`]),
so there was never anything left for them to promote. Net effect is 8 statements → 2.

## Testing

- `helm template` with `neuronMonitor.enabled=true` and `otelContainerInsights.enabled=true`:
  `runtime_tag` present in the grouping keys, promote renders in `resource` context with 2
  statements, and no processor referenced by `metrics/cw_k8s_ci_v0_neuron` is undefined.
- `helm lint` clean.
- `charts/amazon-cloudwatch-observability/tests/flag_matrix.sh` — all 8 cases pass.
- No chart test or golden file asserts the previous shape (checked).

## Relationship to aws/amazon-cloudwatch-agent#2263

The agent repo has an **independent copy** of this pipeline
(`translator/.../containerinsights/neuron.yaml`) with the identical defect. #2263 fixes
that copy and adds Go unit tests that run the real `groupbyattrs` + `transform` processors
over a synthetic 2-core × 2-runtime payload, including a negative control that pins the
collapse.

The two copies serve different paths: the agent's serves the **translator**
(config built from `cwagentconfig.json`), and this one serves the **EKS add-on** (the
operator's `AmazonCloudWatchAgent.spec.otelConfig`). Add-on-managed clusters take this
path only, so **#2263 alone does not fix them** — this change is required for the fix to
reach EKS. Ideally both land together.